### PR TITLE
drop cppzmq dependency from mingw build since it is completely unused

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,7 +895,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "(Clang|AppleClang)" AND ARCH_WIDTH EQUAL "32" AN
   endif()
 endif()
 
-find_path(ZMQ_INCLUDE_PATH zmq.hpp)
+find_path(ZMQ_INCLUDE_PATH zmq.h)
 find_library(ZMQ_LIB zmq)
 find_library(PGM_LIBRARY pgm)
 find_library(NORM_LIBRARY norm)
@@ -904,7 +904,7 @@ find_library(PROTOLIB_LIBRARY protolib)
 find_library(SODIUM_LIBRARY sodium)
 
 if(NOT ZMQ_INCLUDE_PATH)
-  message(FATAL_ERROR "Could not find required header zmq.hpp")
+  message(FATAL_ERROR "Could not find required header zmq.h")
 endif()
 if(NOT ZMQ_LIB)
   message(FATAL_ERROR "Could not find required libzmq")

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ pacman -Syu
 You'll need below dependencies to build nerva.  Run command for your target Windows version. 
 Windows 64-bit:
 ```bash
-pacman -S mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-unbound mingw-w64-x86_64-cppzmq git
+pacman -S mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-unbound git
 ```
 
 Windows 32-bit: 
 ```bash
-pacman -S mingw-w64-i686-toolchain make mingw-w64-i686-cmake mingw-w64-i686-boost mingw-w64-i686-openssl mingw-w64-i686-zeromq mingw-w64-i686-libsodium mingw-w64-i686-hidapi mingw-w64-i686-unbound mingw-w64-i686-cppzmq git
+pacman -S mingw-w64-i686-toolchain make mingw-w64-i686-cmake mingw-w64-i686-boost mingw-w64-i686-openssl mingw-w64-i686-zeromq mingw-w64-i686-libsodium mingw-w64-i686-hidapi mingw-w64-i686-unbound git
 ```
 
 ### Clone NERVA repository 


### PR DESCRIPTION
This PR addresses an issues of requiring `mingw-w64-x86_64-cppzmq` package to be installed in mingw64 environment even it is not referenced at all from any code.