### PR TITLE
p2p: record failed peers to prevent infinite loop

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -381,7 +381,7 @@ namespace nodetool
     bool try_ping(basic_node_data& node_data, p2p_connection_context& context, const t_callback &cb);
     bool try_get_support_flags(const p2p_connection_context& context, std::function<void(p2p_connection_context&, const uint32_t&)> f);
     bool make_expected_connections_count(network_zone& zone, PeerType peer_type, size_t expected_connections);
-    void cache_connect_fail_info(const epee::net_utils::network_address& addr);
+    void record_addr_failed(const epee::net_utils::network_address& addr);
     bool is_addr_recently_failed(const epee::net_utils::network_address& addr);
     bool is_priority_node(const epee::net_utils::network_address& na);
     bool connect_to_seed();


### PR DESCRIPTION
This PR addresses an issue that a failed peer is being attempted in a short window significantly effects the ability for peoples to connect to the network. With this change, we will only retry the peer after an hour after its last failure giving more chance for node to attempt the entire list.

Credit:
The implementation does came from monero current source code