### PR TITLE
Startup speed improvements

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -51,8 +51,6 @@ static const char *DEFAULT_DNS_PUBLIC_ADDR[] =
   "76.76.19.19",      // Alternate DNS
 };
 
-static int IS_FIRST_RUN;
-
 static boost::mutex instance_lock;
 
 namespace
@@ -257,12 +255,6 @@ DNSResolver::DNSResolver() : m_data(new DNSResolverData())
   for (size_t i = 0; i < sizeof(DEFAULT_DNS_PUBLIC_ADDR) / sizeof(DEFAULT_DNS_PUBLIC_ADDR[0]); ++i)
     dns_public_addr.push_back(DEFAULT_DNS_PUBLIC_ADDR[i]);
   LOG_PRINT_L0("Using public DNS server(s): " << boost::join(dns_public_addr, ", ") << " (TCP)");
-
-  if(IS_FIRST_RUN < 2)
-  {
-    MGUSER_GREEN("Connecting to NERVA network. Please wait...");
-    IS_FIRST_RUN += 1;
-  }
 
   // init libunbound context
   m_data->m_ub_context = ub_ctx_create();

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -265,14 +265,14 @@ namespace cryptonote
     m_blockchain_storage.set_enforce_dns_checkpoints(enforce_dns);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::update_checkpoints()
+  bool core::update_checkpoints(const bool skip_dns /* = false */)
   {
     if (m_nettype != MAINNET || m_disable_dns_checkpoints) return true;
 
     if (m_checkpoints_updating.test_and_set()) return true;
 
     bool res = true;
-    if (time(NULL) - m_last_dns_checkpoints_update >= 3600)
+    if (!skip_dns && time(NULL) - m_last_dns_checkpoints_update >= 3600)
     {
       res = m_blockchain_storage.update_checkpoints(m_checkpoints_path, true);
       m_last_dns_checkpoints_update = time(NULL);
@@ -686,7 +686,8 @@ namespace cryptonote
 
     // load json & DNS checkpoints, and verify them
     // with respect to what blocks we already have
-    CHECK_AND_ASSERT_MES(update_checkpoints(), false, "One or more checkpoints loaded from json or dns conflicted with existing checkpoints.");
+    const bool skip_dns_checkpoints = !command_line::get_arg(vm, arg_dns_checkpoints);
+    CHECK_AND_ASSERT_MES(update_checkpoints(skip_dns_checkpoints), false, "One or more checkpoints loaded from json or dns conflicted with existing checkpoints.");
 
    // DNS versions checking
     if (check_updates_string == "disabled")
@@ -1680,9 +1681,6 @@ namespace cryptonote
         << main_message << ENDL
         << "Use the \"help\" command to see the list of available commands." << ENDL
         << "Use \"help <command>\" to see a command's documentation." << ENDL);
-
-      if (!dns_config::is_dnssec_ok())
-        MGUSER_MAGENTA("There appears to be a DNSSEC validation error." << ENDL << "This node cannot reliably download seed node lists or update notifications." << ENDL);
 
       m_starter_message_showed = true;
     }

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -689,7 +689,7 @@ namespace cryptonote
       *
       * @note see Blockchain::update_checkpoints()
       */
-     bool update_checkpoints();
+     bool update_checkpoints(const bool skip_dns = false);
 
      /**
       * @brief tells the daemon to wind down operations and stop running

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -497,6 +497,10 @@ namespace cryptonote
       MLOG_PEER_STATE("requesting chain");
     }
 
+    // load json & DNS checkpoints every 10min/hour respectively,
+    // and verify them with respect to what blocks we already have
+    CHECK_AND_ASSERT_MES(m_core.update_checkpoints(), 1, "One or more checkpoints loaded from json or dns conflicted with existing checkpoints.");
+
     return 1;
   }
   //------------------------------------------------------------------------------------------------------------------------
@@ -773,7 +777,11 @@ namespace cryptonote
           MLOG_P2P_MESSAGE("-->>NOTIFY_REQUEST_CHAIN: m_block_ids.size()=" << r.block_ids.size() );
           post_notify<NOTIFY_REQUEST_CHAIN>(r, context);
           MLOG_PEER_STATE("requesting chain");
-        }            
+        }
+
+        // load json & DNS checkpoints every 10min/hour respectively,
+        // and verify them with respect to what blocks we already have
+        CHECK_AND_ASSERT_MES(m_core.update_checkpoints(), 1, "One or more checkpoints loaded from json or dns conflicted with existing checkpoints.");
       }
     } 
     else
@@ -2482,4 +2490,3 @@ skip:
     m_core.stop();
   }
 } // namespace
-

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -47,7 +47,6 @@
 #include "daemon/command_line_args.h"
 #include "version.h"
 #include "common/xnv_https.h"
-#include "common/dns_config.h"
 
 #ifdef STACK_TRACE
 #include "common/stack_trace.h"
@@ -361,8 +360,6 @@ int main(int argc, char const * argv[])
 
     if (!tools::check_aesni())
       return 1;
-
-    dns_config::init(testnet);
 
     if (noanalytics)
       MGINFO("Analytics disabled.");

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -166,7 +166,8 @@ namespace nodetool
           m_proxy_address(),
           m_current_number_of_out_peers(0),
           m_current_number_of_in_peers(0),
-          m_can_pingback(false)
+          m_can_pingback(false),
+          m_seed_nodes_initialized(false)
       {
         set_config_defaults();
       }
@@ -185,7 +186,8 @@ namespace nodetool
           m_proxy_address(),
           m_current_number_of_out_peers(0),
           m_current_number_of_in_peers(0),
-          m_can_pingback(false)
+          m_can_pingback(false),
+          m_seed_nodes_initialized(false)
       {
         set_config_defaults();
       }
@@ -204,6 +206,7 @@ namespace nodetool
       std::atomic<unsigned int> m_current_number_of_out_peers;
       std::atomic<unsigned int> m_current_number_of_in_peers;
       bool m_can_pingback;
+      bool m_seed_nodes_initialized;
 
     private:
       void set_config_defaults() noexcept


### PR DESCRIPTION
Apply startup speed improvements based on Monero #8587.
Delay dns_config initialization until it tires to connect to seed. 
Remove IS_FIRST_RUN check as it's no longer needed.