### PR TITLE
Change strspan to accept generic type instead of string

### DIFF
--- a/contrib/epee/include/span.h
+++ b/contrib/epee/include/span.h
@@ -166,10 +166,11 @@ namespace epee
   }
 
   //! make a span from a std::string
-  template<typename T>
-  span<const T> strspan(const std::string &s) noexcept
+  template<typename T, typename U>
+  span<const T> strspan(const U&s) noexcept
   {
-    static_assert(std::is_same<T, char>() || std::is_same<T, unsigned char>() || std::is_same<T, int8_t>() || std::is_same<T, uint8_t>(), "Unexpected type");
+    static_assert(std::is_same<typename U::value_type, char>(), "unexpected source type");
+    static_assert(std::is_same<T, char>() || std::is_same<T, unsigned char>() || std::is_same<T, int8_t>() || std::is_same<T, uint8_t>(), "Unexpected destination type");
     return {reinterpret_cast<const T*>(s.data()), s.size()};
   }
 }


### PR DESCRIPTION
This avoids "implicit instantiation of undefined template" compile error on some mac machines.
Change from Monero #7661