### PR TITLE
Add --no-dns start-up argument

### DIFF
--- a/src/common/dns_config.cpp
+++ b/src/common/dns_config.cpp
@@ -10,9 +10,9 @@ namespace dns_config
     std::vector<std::string> m_txt_seed_nodes;
     std::vector<std::string> m_update;
     std::vector<std::string> m_download;
-        std::vector<std::string> m_analytics;
+    std::vector<std::string> m_analytics;
     bool m_dnssec_ok;
-    tools::DNSResolver dr = tools::DNSResolver::create();
+    bool m_is_dns_disabled = false;
 
     void init(const bool testnet)
     {
@@ -25,6 +25,12 @@ namespace dns_config
 
         bool dns_avail = false, dns_valid = false;
         std::vector<std::string> result;
+
+        if(is_dns_disabled())
+        {
+            LOG_PRINT_L0("DNS disabled. Returning from init...");
+            return;
+        }
 
         tools::DNSResolver dr = tools::DNSResolver::create();
 
@@ -75,4 +81,7 @@ namespace dns_config
     bool has_seed_node_records() { return m_seed_nodes.size() > 0; }
     bool has_analytics_records() { return m_analytics.size() > 0; }
     bool is_dnssec_ok() { return m_dnssec_ok; }
+
+    void disable_dns(bool disable) { m_is_dns_disabled = disable; }
+    bool is_dns_disabled() { return m_is_dns_disabled; }    
 }

--- a/src/common/dns_config.h
+++ b/src/common/dns_config.h
@@ -60,6 +60,9 @@ namespace dns_config
     bool has_analytics_records();    
     bool is_dnssec_ok();
 
+    void disable_dns(bool disable);
+    bool is_dns_disabled();
+
     struct dns_config_t
     {
         std::vector<std::string> const SEED_NODES;

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -34,6 +34,7 @@
 #include "include_base_utils.h"
 #include "common/threadpool.h"
 #include "crypto/crypto.h"
+#include "dns_config.h"
 #include <boost/thread/mutex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -244,6 +245,13 @@ static void add_anchors(ub_ctx *ctx)
 DNSResolver::DNSResolver() : m_data(new DNSResolverData())
 {
   std::vector<std::string> dns_public_addr;
+
+  if(dns_config::is_dns_disabled())
+  {
+    LOG_PRINT_L0("DNS disabled. Returning from DNSResolver...");
+    return;
+  }
+
   char* DNS_PUBLIC = getenv("DNS_PUBLIC");
   if (DNS_PUBLIC)
   {
@@ -285,6 +293,12 @@ std::vector<std::string> DNSResolver::get_record(const std::string& url, int rec
   std::vector<std::string> addresses;
   dnssec_available = false;
   dnssec_valid = false;
+
+  if(dns_config::is_dns_disabled())
+  {
+    LOG_PRINT_L0("DNS disabled. Returning from get_records...");
+    return addresses;
+  }
 
   LOG_PRINT_L3("get_record URL: " << url <<  " record_type: " << record_type);
 

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -139,6 +139,12 @@ namespace daemon_args
   , false
   };
 
+  const command_line::arg_descriptor<bool> arg_nodns = {
+    "no-dns"
+  , "Do not use DNS to get seed nodes, update links or anything else from the web"
+  , false
+  };
+
 }  // namespace daemon_args
 
 #endif // DAEMON_COMMAND_LINE_ARGS_H

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -47,6 +47,7 @@
 #include "daemon/command_line_args.h"
 #include "version.h"
 #include "common/xnv_https.h"
+#include "common/dns_config.h"
 
 #ifdef STACK_TRACE
 #include "common/stack_trace.h"
@@ -135,6 +136,7 @@ int main(int argc, char const * argv[])
 
       // Settings
       command_line::add_arg(core_settings, daemon_args::arg_noanalytics);
+      command_line::add_arg(core_settings, daemon_args::arg_nodns);
       command_line::add_arg(core_settings, daemon_args::arg_log_file);
       command_line::add_arg(core_settings, daemon_args::arg_log_level);
       command_line::add_arg(core_settings, daemon_args::arg_max_log_file_size);
@@ -220,6 +222,7 @@ int main(int argc, char const * argv[])
     const bool testnet = command_line::get_arg(vm, cryptonote::arg_testnet_on);
     const bool stagenet = command_line::get_arg(vm, cryptonote::arg_stagenet_on);
     const bool noanalytics = command_line::get_arg(vm, daemon_args::arg_noanalytics);
+    const bool nodns = command_line::get_arg(vm, daemon_args::arg_nodns);
 
     if (testnet && stagenet)
     {
@@ -367,6 +370,12 @@ int main(int argc, char const * argv[])
       MGINFO("Analytics enabled.");
 
     analytics::enable(!noanalytics);
+
+    if (nodns)
+    {
+      MGINFO("DNS disabled.");
+      dns_config::disable_dns(nodns);
+    }
 
     blacklist::read_blacklist_from_url();
     if (blacklist::get_ip_list().size() > 0)


### PR DESCRIPTION
With this argument, the node will not retrieve TXT records and will not connect to anything that uses DNS.
No seed nodes, checking for updates or checkpoints.