### PR TITLE
ci: limit push trigger to master to prevent duplicate CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ name: ci/gh-actions/build
 
 on:
     push:
+        branches:
+            - master
         paths-ignore:
             - 'docs/**'
             - '**/README.md'

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -31,6 +31,8 @@ name: ci/gh-actions/depends
 
 on:
     push:
+        branches:
+            - master
         paths-ignore:
             - 'docs/**'
             - '**/README.md'


### PR DESCRIPTION
## Summary
- Restricts the `push` trigger in `build.yml` and `depends.yml` to the `master` branch only
- Prevents duplicate CI runs when a branch has an open PR (previously both `on: push` and `on: pull_request` would fire)

## Test plan
- [x] Verify PRs only trigger one set of checks (from `pull_request`)
- [x] Verify pushes to `master` still trigger CI