### PR TITLE
ci: auto-set make job count based on runner resources

### DIFF
--- a/.github/actions/set-make-job-count/action.yml
+++ b/.github/actions/set-make-job-count/action.yml
@@ -1,0 +1,22 @@
+name: 'set-make-job-count'
+description: 'Set the MAKE_JOB_COUNT environment variable to a value suitable for the host runner'
+runs:
+  using: "composite"
+  steps:
+    # Each job runner requires 2.25 GiB (i.e. 1024 * 9/4 MiB) memory and
+    # a dedicated logical CPU core
+    - name: set-jobs-macOS
+      if: runner.os == 'macOS'
+      run: |
+        echo MAKE_JOB_COUNT=$(expr $(printf '%s\n%s' $(( $(sysctl -n hw.memsize) * 4 / (1073741824 * 9) )) $(sysctl -n hw.logicalcpu) | sort -n | head -n1) '|' 1) >> $GITHUB_ENV
+      shell: bash
+    - name: set-jobs-windows
+      if: runner.os == 'Windows'
+      run: |
+        echo MAKE_JOB_COUNT=$(expr $(printf '%s\n%s' $(( $(grep MemTotal: /proc/meminfo | cut -d: -f2 | cut -dk -f1) * 4 / (1048576 * 9) )) $(nproc) | sort -n | head -n1) '|' 1) >> $GITHUB_ENV
+      shell: msys2 {0}
+    - name: set-jobs-linux
+      if: runner.os == 'Linux'
+      run: |
+        echo MAKE_JOB_COUNT=$(expr $(printf '%s\n%s' $(( $(grep MemTotal: /proc/meminfo | cut -d: -f2 | cut -dk -f1) * 4 / (1048576 * 9) )) $(nproc) | sort -n | head -n1) '|' 1) >> $GITHUB_ENV
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,11 @@ jobs:
                 run: sudo apt update
             -   name: Install dependencies
                 run: sudo apt install -y build-essential cmake ccache pkg-config libboost-all-dev libssl-dev libzmq3-dev libpgm-dev libunbound-dev libsodium-dev git
+            -   uses: ./.github/actions/set-make-job-count
             -   name: Build
                 run: |
                     ${{env.CCACHE_SETTINGS}}
-                    make -j3
+                    make -j${{env.MAKE_JOB_COUNT}}
 
     build-windows:
         runs-on: windows-latest
@@ -109,10 +110,11 @@ jobs:
                     gpg --homedir /etc/pacman.d/gnupg --verify mingw-w64-x86_64-icu-75.1-2-any.pkg.tar.zst.sig
                     gpg --homedir /etc/pacman.d/gnupg --verify mingw-w64-x86_64-boost-1.86.0-7-any.pkg.tar.zst.sig
                     pacman --noconfirm -U mingw-w64-x86_64-icu-75.1-2-any.pkg.tar.zst mingw-w64-x86_64-boost-1.86.0-7-any.pkg.tar.zst
+            -   uses: ./.github/actions/set-make-job-count
             -   name: Build
                 run: |
                     ${{env.CCACHE_SETTINGS}}
-                    make release-static-win64 -j2
+                    make release-static-win64 -j${{env.MAKE_JOB_COUNT}}
 
     build-macos:
         runs-on: macos-latest
@@ -131,10 +133,11 @@ jobs:
                 run: |
                     HOMEBREW_NO_AUTO_UPDATE=1 brew install boost@1.85 hidapi zmq libpgm miniupnpc ldns expat libunwind-headers protobuf@21 ccache
                     brew link protobuf@21 boost@1.85
+            -   uses: ./.github/actions/set-make-job-count
             -   name: Build
                 run: |
                     ${{env.CCACHE_SETTINGS}}
-                    make -j3
+                    make -j${{env.MAKE_JOB_COUNT}}
 
     libwallet-ubuntu:
         runs-on: ubuntu-latest
@@ -157,8 +160,9 @@ jobs:
                 run: sudo apt update
             -   name: Install dependencies
                 run: sudo apt install -y build-essential cmake ccache pkg-config libboost-all-dev libssl-dev libzmq3-dev libpgm-dev libunbound-dev libsodium-dev git
+            -   uses: ./.github/actions/set-make-job-count
             -   name: Build
                 run: |
                     ${{env.CCACHE_SETTINGS}}
                     cmake .
-                    make wallet_api -j3
+                    make wallet_api -j${{env.MAKE_JOB_COUNT}}

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -126,10 +126,11 @@ jobs:
                 run: |
                     update-alternatives --set ${{ matrix.toolchain.host }}-g++ $(which ${{ matrix.toolchain.host }}-g++-posix)
                     update-alternatives --set ${{ matrix.toolchain.host }}-gcc $(which ${{ matrix.toolchain.host }}-gcc-posix)
+            -   uses: ./.github/actions/set-make-job-count
             -   name: Build
                 run: |
                     ${{env.CCACHE_SETTINGS}}
-                    make depends target=${{ matrix.toolchain.host }} -j2
+                    make depends target=${{ matrix.toolchain.host }} -j${{env.MAKE_JOB_COUNT}}
             -   uses: actions/upload-artifact@v4
                 with:
                     name: ${{ matrix.toolchain.name }}


### PR DESCRIPTION
## Summary
Port of monero-project/monero#9690.

- Add a composite action (`.github/actions/set-make-job-count`) that dynamically determines an appropriate number of make jobs for the GitHub runner, based on available CPU cores and RAM
- Each job requires a dedicated core and 2.25 GiB of RAM — the action takes the minimum of both constraints (with a floor of 1)
- Replace all hardcoded `-j2`/`-j3` values in build and depends workflows with `-j${{env.MAKE_JOB_COUNT}}`
- Supports Linux, macOS, and Windows (MSYS2) runners

## Test plan
- [x] Verify all build jobs pick up the correct job count
- [x] Verify build times improve compared to previous hardcoded values
- [x] Confirm no OOM or resource issues on any platform