### PR TITLE
feat: add --dns-server CLI option for custom DNS resolvers

### DIFF
--- a/src/common/dns_config.cpp
+++ b/src/common/dns_config.cpp
@@ -44,6 +44,7 @@ namespace dns_config
     std::vector<std::string> m_analytics;
     bool m_dnssec_ok;
     bool m_is_dns_disabled = false;
+    std::vector<std::string> m_custom_dns_servers;
 
     void init(const bool testnet)
     {
@@ -114,5 +115,8 @@ namespace dns_config
     bool is_dnssec_ok() { return m_dnssec_ok; }
 
     void disable_dns(bool disable) { m_is_dns_disabled = disable; }
-    bool is_dns_disabled() { return m_is_dns_disabled; }    
+    bool is_dns_disabled() { return m_is_dns_disabled; }
+
+    void set_dns_servers(const std::vector<std::string>& servers) { m_custom_dns_servers = servers; }
+    std::vector<std::string> get_dns_servers() { return m_custom_dns_servers; }
 }

--- a/src/common/dns_config.h
+++ b/src/common/dns_config.h
@@ -92,6 +92,9 @@ namespace dns_config
     void disable_dns(bool disable);
     bool is_dns_disabled();
 
+    void set_dns_servers(const std::vector<std::string>& servers);
+    std::vector<std::string> get_dns_servers();
+
     struct dns_config_t
     {
         std::vector<std::string> const SEED_NODES;

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -253,16 +253,27 @@ DNSResolver::DNSResolver() : m_data(new DNSResolverData())
     return;
   }
 
-  char* DNS_PUBLIC = getenv("DNS_PUBLIC");
-  if (DNS_PUBLIC)
+  // Check for user-specified DNS servers (--dns-server CLI option)
+  std::vector<std::string> custom_servers = dns_config::get_dns_servers();
+  if (!custom_servers.empty())
   {
-    dns_public_addr = tools::dns_utils::parse_dns_public(std::string(DNS_PUBLIC));
-    if (dns_public_addr.empty())
-      MERROR("Failed to parse DNS_PUBLIC");
+    dns_public_addr = custom_servers;
   }
+  else
+  {
+    // Check DNS_PUBLIC environment variable
+    char* DNS_PUBLIC = getenv("DNS_PUBLIC");
+    if (DNS_PUBLIC)
+    {
+      dns_public_addr = tools::dns_utils::parse_dns_public(std::string(DNS_PUBLIC));
+      if (dns_public_addr.empty())
+        MERROR("Failed to parse DNS_PUBLIC");
+    }
 
-  for (size_t i = 0; i < sizeof(DEFAULT_DNS_PUBLIC_ADDR) / sizeof(DEFAULT_DNS_PUBLIC_ADDR[0]); ++i)
-    dns_public_addr.push_back(DEFAULT_DNS_PUBLIC_ADDR[i]);
+    // Append default DNS servers as fallback
+    for (size_t i = 0; i < sizeof(DEFAULT_DNS_PUBLIC_ADDR) / sizeof(DEFAULT_DNS_PUBLIC_ADDR[0]); ++i)
+      dns_public_addr.push_back(DEFAULT_DNS_PUBLIC_ADDR[i]);
+  }
   LOG_PRINT_L0("Using public DNS server(s): " << boost::join(dns_public_addr, ", ") << " (TCP)");
 
   // init libunbound context

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -145,6 +145,11 @@ namespace daemon_args
   , false
   };
 
+  const command_line::arg_descriptor<std::vector<std::string>> arg_dns_server = {
+    "dns-server"
+  , "Use specified DNS server(s) instead of the defaults (e.g. --dns-server=9.9.9.9 --dns-server=149.112.112.112)"
+  };
+
 }  // namespace daemon_args
 
 #endif // DAEMON_COMMAND_LINE_ARGS_H

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -137,6 +137,7 @@ int main(int argc, char const * argv[])
       // Settings
       command_line::add_arg(core_settings, daemon_args::arg_noanalytics);
       command_line::add_arg(core_settings, daemon_args::arg_nodns);
+      command_line::add_arg(core_settings, daemon_args::arg_dns_server);
       command_line::add_arg(core_settings, daemon_args::arg_log_file);
       command_line::add_arg(core_settings, daemon_args::arg_log_level);
       command_line::add_arg(core_settings, daemon_args::arg_max_log_file_size);
@@ -375,6 +376,15 @@ int main(int argc, char const * argv[])
     {
       MGINFO("DNS disabled.");
       dns_config::disable_dns(nodns);
+    }
+
+    if (!vm["dns-server"].defaulted())
+    {
+      const auto dns_servers = command_line::get_arg(vm, daemon_args::arg_dns_server);
+      if (!dns_servers.empty())
+      {
+        dns_config::set_dns_servers(dns_servers);
+      }
     }
 
     blacklist::read_blacklist_from_url();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -54,6 +54,7 @@ using namespace epee;
 #include "multisig/multisig.h"
 #include "common/boost_serialization_helper.h"
 #include "common/command_line.h"
+#include "common/dns_config.h"
 #include "common/threadpool.h"
 #include "int-util.h"
 #include "profile_tools.h"
@@ -277,6 +278,7 @@ struct options {
   const command_line::arg_descriptor<std::string> hw_device_derivation_path = {"hw-device-deriv-path", tools::wallet2::tr("HW device wallet derivation path (e.g., SLIP-10)"), ""};
   const command_line::arg_descriptor<std::string> tx_notify = { "tx-notify" , "Run a program for each new incoming transaction, '%s' will be replaced by the transaction hash" , "" };
   const command_line::arg_descriptor<bool> no_dns = {"no-dns", tools::wallet2::tr("Do not use DNS"), false};
+  const command_line::arg_descriptor<std::vector<std::string>> dns_server = {"dns-server", tools::wallet2::tr("Use specified DNS server(s) instead of the defaults")};
   const command_line::arg_descriptor<bool> offline = {"offline", tools::wallet2::tr("Do not connect to a daemon, nor use DNS"), false};
   const command_line::arg_descriptor<std::string> extra_entropy = {"extra-entropy", tools::wallet2::tr("File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, which typically means more than 256 bits of data)")};
 };
@@ -478,6 +480,13 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
 
   if (command_line::get_arg(vm, opts.no_dns))
     wallet->enable_dns(false);
+
+  if (!vm["dns-server"].defaulted())
+  {
+    const auto dns_servers = command_line::get_arg(vm, opts.dns_server);
+    if (!dns_servers.empty())
+      dns_config::set_dns_servers(dns_servers);
+  }
 
   if (command_line::get_arg(vm, opts.offline))
     wallet->set_offline();
@@ -1188,6 +1197,7 @@ void wallet2::init_options(boost::program_options::options_description& desc_par
   command_line::add_arg(desc_params, opts.hw_device_derivation_path);
   command_line::add_arg(desc_params, opts.tx_notify);
   command_line::add_arg(desc_params, opts.no_dns);
+  command_line::add_arg(desc_params, opts.dns_server);
   command_line::add_arg(desc_params, opts.offline);
   command_line::add_arg(desc_params, opts.extra_entropy);
 }


### PR DESCRIPTION
## Summary
- Add `--dns-server` flag to both daemon and wallet CLI
- Allows users to specify custom DNS server(s) instead of the hardcoded defaults (Cloudflare, Google, OpenDNS, Alternate DNS)
- When set, only the user-specified servers are used — the defaults and `DNS_PUBLIC` env var are bypassed
- DNSSEC validation is preserved since we still use libunbound

### Scope
This flag affects **explicit DNS lookups via libunbound** only — e.g., seed node resolution on the daemon side and OpenAlias resolution in the wallet. It does **not** affect transport-layer DNS (i.e., `--daemon-address` hostname resolution), which goes through the OS resolver via Boost ASIO and cannot be overridden this way.

### Usage
```
nervad --dns-server=9.9.9.9 --dns-server=149.112.112.112
nerva-wallet-cli --dns-server=9.9.9.9
```

Closes #38

## Test plan
- [x] Verify `nervad --dns-server=9.9.9.9` resolves seed nodes using the specified server
- [x] Verify `nervad` without the flag still uses the default DNS servers
- [x] Verify `nerva-wallet-cli --dns-server=9.9.9.9` affects OpenAlias resolution
- [x] Verify `--no-dns` still takes precedence and disables DNS entirely