### PR TITLE
ci: post artifact download links as PR comment

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -68,33 +68,43 @@ jobs:
                     -   name: "ARM v7"
                         host: "arm-linux-gnueabihf"
                         packages: "python3 gperf g++-arm-linux-gnueabihf"
+                        artifact-name: "nerva-linux-armv7"
                     -   name: "ARM v8"
                         host: "aarch64-linux-gnu"
                         packages: "python3 gperf g++-aarch64-linux-gnu"
+                        artifact-name: "nerva-linux-armv8"
                     -   name: "i686 Win"
                         host: "i686-w64-mingw32"
                         packages: "python3 g++-mingw-w64-i686"
+                        artifact-name: "nerva-windows-x32"
                     -   name: "i686 Linux"
                         host: "i686-pc-linux-gnu"
                         packages: "gperf cmake g++-multilib python3-zmq"
+                        artifact-name: "nerva-linux-i686"
                     -   name: "Win64"
                         host: "x86_64-w64-mingw32"
                         packages: "cmake python3 g++-mingw-w64-x86-64"
+                        artifact-name: "nerva-windows-x64"
                     -   name: "x86_64 Linux"
                         host: "x86_64-unknown-linux-gnu"
                         packages: "gperf cmake python3-zmq libdbus-1-dev libharfbuzz-dev"
+                        artifact-name: "nerva-linux-x86_64"
                     -   name: "Cross-Mac x86_64"
                         host: "x86_64-apple-darwin"
                         packages: "cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev python3-setuptools-git libtinfo5"
+                        artifact-name: "nerva-macos-x64"
                     -   name: "Cross-Mac aarch64"
                         host: "aarch64-apple-darwin"
                         packages: "cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev python3-setuptools-git libtinfo5"
+                        artifact-name: "nerva-macos-armv8"
                     -   name: "x86_64 Freebsd"
                         host: "x86_64-unknown-freebsd"
                         packages: "clang-8 gperf cmake python3-zmq libdbus-1-dev libharfbuzz-dev"
+                        artifact-name: "nerva-freebsd-x86_64"
                     -   name: "ARMv8 Android"
                         host: "aarch64-linux-android"
                         packages: "gperf cmake python3 unzip python-is-python3"
+                        artifact-name: "nerva-android-armv8"
         name: ${{ matrix.toolchain.name }}
         steps:
             -   name: Set apt conf
@@ -133,6 +143,92 @@ jobs:
                     make depends target=${{ matrix.toolchain.host }} -j${{env.MAKE_JOB_COUNT}}
             -   uses: actions/upload-artifact@v4
                 with:
-                    name: ${{ matrix.toolchain.name }}
+                    name: ${{ matrix.toolchain.artifact-name }}
                     path: |
                         build/${{ matrix.toolchain.host }}/release/bin/nerva*
+
+    # Post a PR comment with artifact download links after all matrix jobs complete.
+    # NOTE: The target list below is coupled to the matrix above — update both together.
+    post-artifact-links:
+        needs: build-cross
+        if: always() && github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            -   name: Post artifact links
+                uses: actions/github-script@v7
+                with:
+                    script: |
+                        const targets = [
+                            'nerva-linux-armv7',
+                            'nerva-linux-armv8',
+                            'nerva-windows-x32',
+                            'nerva-linux-i686',
+                            'nerva-windows-x64',
+                            'nerva-linux-x86_64',
+                            'nerva-macos-x64',
+                            'nerva-macos-armv8',
+                            'nerva-freebsd-x86_64',
+                            'nerva-android-armv8',
+                        ];
+
+                        const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            run_id: context.runId,
+                            per_page: 100,
+                        });
+
+                        const artifactMap = new Map(artifacts.map(a => [a.name, a]));
+                        let succeeded = 0;
+                        let failed = 0;
+
+                        const rows = targets.map(target => {
+                            const artifact = artifactMap.get(target);
+                            if (artifact) {
+                                succeeded++;
+                                const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${artifact.id}`;
+                                return `| ${target} | :white_check_mark: | [Download](${url}) |`;
+                            } else {
+                                failed++;
+                                return `| ${target} | :x: | Build failed |`;
+                            }
+                        });
+
+                        const body = [
+                            '<!-- nerva-artifact-links -->',
+                            '## Build Artifacts',
+                            '',
+                            '| Target | Status | Download |',
+                            '|--------|--------|----------|',
+                            ...rows,
+                            '',
+                            '---',
+                            `*${succeeded} succeeded, ${failed} failed* | [View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                        ].join('\n');
+
+                        const prNumber = context.payload.pull_request.number;
+                        const { data: comments } = await github.rest.issues.listComments({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            issue_number: prNumber,
+                            per_page: 100,
+                        });
+
+                        const existing = comments.find(c => c.body.includes('<!-- nerva-artifact-links -->'));
+                        if (existing) {
+                            await github.rest.issues.updateComment({
+                                owner: context.repo.owner,
+                                repo: context.repo.repo,
+                                comment_id: existing.id,
+                                body,
+                            });
+                        } else {
+                            await github.rest.issues.createComment({
+                                owner: context.repo.owner,
+                                repo: context.repo.repo,
+                                issue_number: prNumber,
+                                body,
+                            });
+                        }


### PR DESCRIPTION
## Summary

- Adds a `post-artifact-links` job to the depends workflow that posts a PR comment with a markdown table of build artifact download links
- Runs after all matrix jobs complete (including on partial failure), only on pull requests
- Uses a hidden HTML marker (`<!-- nerva-artifact-links -->`) to update the existing comment on re-push instead of posting duplicates
- Reports both successful builds (with download links) and failed targets
- Renames artifacts to use descriptive names matching the release convention (e.g. `nerva-linux-x86_64`, `nerva-windows-x64`)

Closes #52