### PR TITLE
ci: upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,10 +58,10 @@ jobs:
         env:
             CCACHE_TEMPDIR: /tmp/.ccache-temp
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
                 with:
                     submodules: recursive
-            -   uses: actions/cache@v4
+            -   uses: actions/cache@v5
                 with:
                     path: ~/.cache/ccache
                     key: ccache-${{ runner.os }}-build-${{ github.ref }}-${{ github.run_number }}
@@ -92,10 +92,10 @@ jobs:
             run:
                 shell: msys2 {0}
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
                 with:
                     submodules: recursive
-            -   uses: actions/cache@v4
+            -   uses: actions/cache@v5
                 with:
                     path: C:\ccache
                     key: ccache-${{ runner.os }}-build-${{ github.ref }}-${{ github.run_number }}
@@ -110,7 +110,7 @@ jobs:
                     install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-unbound git
             -   name: Cache pinned MSYS2 packages
                 id: cache-pinned-pkgs
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: C:\msys2-pkg-cache
                     key: msys2-pinned-pkgs-boost1.86.0-7-icu75.1-2
@@ -142,10 +142,10 @@ jobs:
         env:
             CCACHE_TEMPDIR: /tmp/.ccache-temp
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
                 with:
                     submodules: recursive
-            -   uses: actions/cache@v4
+            -   uses: actions/cache@v5
                 with:
                     path: /Users/runner/Library/Caches/ccache
                     key: ccache-${{ runner.os }}-build-${{ github.ref }}-${{ github.run_number }}
@@ -168,10 +168,10 @@ jobs:
         env:
             CCACHE_TEMPDIR: /tmp/.ccache-temp
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
                 with:
                     submodules: recursive
-            -   uses: actions/cache@v4
+            -   uses: actions/cache@v5
                 with:
                     path: ~/.cache/ccache
                     key: ccache-${{ runner.os }}-libwallet-${{ github.ref }}-${{ github.run_number }}

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -103,18 +103,18 @@ jobs:
                 run: apt update; apt -y install build-essential libtool cmake autotools-dev automake pkg-config bsdmainutils curl git ca-certificates ccache ${{ matrix.toolchain.packages }}
             -   name: Configure git
                 run: git config --global --add safe.directory '*'
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
                 with:
                     fetch-depth: 0
                     submodules: recursive
             -   name: Ccache
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: ~/.ccache
                     key: ccache-${{ matrix.toolchain.host }}-${{ github.sha }}
                     restore-keys: ccache-${{ matrix.toolchain.host }}-
             -   name: Depends cache
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: contrib/depends/built
                     key: depends-${{ matrix.toolchain.host }}-${{ hashFiles('contrib/depends/packages/*') }}
@@ -131,7 +131,7 @@ jobs:
                 run: |
                     ${{env.CCACHE_SETTINGS}}
                     make depends target=${{ matrix.toolchain.host }} -j${{env.MAKE_JOB_COUNT}}
-            -   uses: actions/upload-artifact@v4
+            -   uses: actions/upload-artifact@v7
                 with:
                     name: ${{ matrix.toolchain.name }}
                     path: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
     docker:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
                 with:
                     submodules: recursive
             -   name: Set up QEMU


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v4 to v6
- Upgrade `actions/cache` from v4 to v5
- Upgrade `actions/upload-artifact` from v4 to v7
- `msys2/setup-msys2` is already on latest major version (v2), no change needed

Picks up bug fixes, performance improvements, and avoids Node.js 20 deprecation warnings.

Closes #53

## Test plan
- [x] Verify all CI workflows (build, depends, docker) run successfully