### PR TITLE
fix: README copyright line break formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Check out the project [documentation][nerva-docs-link], create an [issue][nerva-
 
 [LICENSE](LICENSE)
 
-Copyright (c) 2018-2026 The Nerva Project.
+Copyright (c) 2018-2026 The Nerva Project.  
 Copyright (c) 2014-2026 The Monero Project.  
 Copyright (c) 2017-2018 The Masari Project.  
 Portions Copyright (c) 2012-2013 The Cryptonote developers. 


### PR DESCRIPTION
## Summary
- Add missing trailing spaces on the Nerva copyright line so it renders as a separate line in markdown

## Test plan
- [x] Visual inspection — all four copyright lines now render on separate lines