### PR TITLE
feat: default to 1 mining thread on Android for autodetect

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -452,8 +452,12 @@ namespace cryptonote
     if (threads_count == 0)
     {
       m_threads_autodetect.clear();
+#ifdef __ANDROID__
+      m_threads_total = 1;
+#else
       m_threads_autodetect.push_back({epee::misc_utils::get_ns_count(), m_total_hashes});
       m_threads_total = 1;
+#endif
     }
     m_starter_nonce = crypto::rand<uint32_t>();
     CRITICAL_REGION_LOCAL(m_threads_lock);
@@ -482,7 +486,13 @@ namespace cryptonote
     }
 
     if (threads_count == 0)
+    {
+#ifdef __ANDROID__
+      MGUSER_CYAN("Mining has started with 1 thread (mobile default). Set threads manually to use more, good luck!");
+#else
       MGUSER_CYAN("Mining has started, autodetecting optimal number of threads, good luck!" );
+#endif
+    }
     else
       MGUSER_CYAN("Mining has started with " << threads_count << " threads, good luck!" );
 


### PR DESCRIPTION
## Summary

- On Android, when autodetect is used (threads = 0), default to 1 CPU thread instead of running progressive thread detection
- Non-Android platforms retain existing autodetect behaviour
- Informs the user via log message that the mobile default is 1 thread and they can set more manually

## Why

Mobile devices have thermal and battery constraints that make full CPU utilization unsuitable as a default. The existing autodetect ramps threads up progressively which is fine on desktop but inappropriate for phones/tablets.

Closes #62