### PR TITLE
fix: bound wallet scan threadpool to half of available cores

### DIFF
--- a/src/common/threadpool.h
+++ b/src/common/threadpool.h
@@ -51,6 +51,9 @@ public:
   static threadpool *getNewForUnitTests(unsigned max_threads = 0) {
     return new threadpool(max_threads);
   }
+  static threadpool *getNew(unsigned max_threads = 0) {
+    return new threadpool(max_threads);
+  }
 
   // The waiter lets the caller know when all of its
   // tasks are completed.

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -416,7 +416,9 @@ namespace cryptonote
       }
     }
 
-    size_t max_blocks = COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT;
+    size_t max_blocks = (req.max_count > 0 && req.max_count < COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT)
+      ? (size_t)req.max_count
+      : COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT;
 
     std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > > bs;
     if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, bs, res.current_height, res.start_height, req.prune, !req.no_miner_tx, max_blocks))

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -143,12 +143,14 @@ namespace cryptonote
       uint64_t    start_height;
       bool        prune;
       bool        no_miner_tx;
+      uint64_t    max_count; // 0 = server default (COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT)
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(block_ids)
         KV_SERIALIZE(start_height)
         KV_SERIALIZE(prune)
         KV_SERIALIZE_OPT(no_miner_tx, false)
+        KV_SERIALIZE_OPT(max_count, (uint64_t)0)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2476,6 +2476,7 @@ void wallet2::pull_blocks(uint64_t start_height, uint64_t &blocks_start_height, 
   req.prune = true;
   req.start_height = start_height;
   req.no_miner_tx = m_refresh_type == RefreshNoCoinbase;
+  req.max_count = BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
   {
     const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex};
     bool r = net_utils::invoke_http_bin("/getblocks.bin", req, res, m_http_client, rpc_timeout);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1144,6 +1144,8 @@ wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended):
   m_rpc_version(0),
   m_export_format(ExportFormat::Binary)
 {
+  unsigned scan_threads = std::max(1u, boost::thread::hardware_concurrency() / 2);
+  m_scan_threadpool.reset(tools::threadpool::getNew(scan_threads));
 }
 
 wallet2::~wallet2()
@@ -1828,7 +1830,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 
     int num_vouts_received = 0;
     tx_pub_key = pub_key_field.pub_key;
-    tools::threadpool& tpool = tools::threadpool::getInstance();
+    tools::threadpool& tpool = *m_scan_threadpool;
     tools::threadpool::waiter waiter;
     const cryptonote::account_keys& keys = m_account.get_keys();
     crypto::key_derivation derivation;
@@ -1915,7 +1917,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
         }
       }
     }
-    else if (tx.vout.size() > 1 && tools::threadpool::getInstance().get_max_concurrency() > 1 && !is_out_data_ptr)
+    else if (tx.vout.size() > 1 && m_scan_threadpool->get_max_concurrency() > 1 && !is_out_data_ptr)
     {
       for (size_t i = 0; i < tx.vout.size(); ++i)
       {
@@ -2518,7 +2520,7 @@ void wallet2::process_parsed_blocks(uint64_t start_height, const std::vector<cry
   THROW_WALLET_EXCEPTION_IF(blocks.size() != parsed_blocks.size(), error::wallet_internal_error, "size mismatch");
   THROW_WALLET_EXCEPTION_IF(!m_blockchain.is_in_bounds(current_index), error::out_of_hashchain_bounds_error);
 
-  tools::threadpool& tpool = tools::threadpool::getInstance();
+  tools::threadpool& tpool = *m_scan_threadpool;
   tools::threadpool::waiter waiter;
 
   size_t num_txes = 0;
@@ -2696,7 +2698,7 @@ void wallet2::pull_and_parse_next_blocks(uint64_t start_height, uint64_t &blocks
     pull_blocks(start_height, blocks_start_height, short_chain_history, blocks, o_indices, current_height);
     THROW_WALLET_EXCEPTION_IF(blocks.size() != o_indices.size(), error::wallet_internal_error, "Mismatched sizes of blocks and o_indices");
 
-    tools::threadpool& tpool = tools::threadpool::getInstance();
+    tools::threadpool& tpool = *m_scan_threadpool;
     tools::threadpool::waiter waiter;
     parsed_blocks.resize(blocks.size());
     for (size_t i = 0; i < blocks.size(); ++i)
@@ -3162,7 +3164,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
   size_t try_count = 0;
   crypto::hash last_tx_hash_id = m_transfers.size() ? m_transfers.back().m_txid : null_hash;
   std::list<crypto::hash> short_chain_history;
-  tools::threadpool& tpool = tools::threadpool::getInstance();
+  tools::threadpool& tpool = *m_scan_threadpool;
   tools::threadpool::waiter waiter;
   uint64_t blocks_start_height;
   std::vector<cryptonote::block_complete_entry> blocks;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1142,14 +1142,22 @@ wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended):
   m_use_dns(true),
   m_offline(false),
   m_rpc_version(0),
-  m_export_format(ExportFormat::Binary)
+  m_export_format(ExportFormat::Binary),
+  m_scan_semaphore(std::max(1u, tools::get_max_concurrency() / 2))
 {
-  unsigned scan_threads = std::max(1u, boost::thread::hardware_concurrency() / 2);
-  m_scan_threadpool.reset(tools::threadpool::getNew(scan_threads));
 }
 
 wallet2::~wallet2()
 {
+}
+
+void wallet2::scan_submit(tools::threadpool &tpool, tools::threadpool::waiter *waiter, std::function<void()> f, bool leaf)
+{
+  tpool.submit(waiter, [this, f = std::move(f)]() {
+    m_scan_semaphore.acquire();
+    f();
+    m_scan_semaphore.release();
+  }, leaf);
 }
 
 bool wallet2::has_testnet_option(const boost::program_options::variables_map& vm)
@@ -1830,7 +1838,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 
     int num_vouts_received = 0;
     tx_pub_key = pub_key_field.pub_key;
-    tools::threadpool& tpool = *m_scan_threadpool;
+    tools::threadpool& tpool = tools::threadpool::getInstance();
     tools::threadpool::waiter waiter;
     const cryptonote::account_keys& keys = m_account.get_keys();
     crypto::key_derivation derivation;
@@ -1898,7 +1906,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
       {
         for (size_t i = 1; i < tx.vout.size(); ++i)
         {
-          tpool.submit(&waiter, boost::bind(&wallet2::check_acc_out_precomp_once, this, std::cref(tx.vout[i]), std::cref(derivation), std::cref(additional_derivations), i,
+          scan_submit(tpool, &waiter, boost::bind(&wallet2::check_acc_out_precomp_once, this, std::cref(tx.vout[i]), std::cref(derivation), std::cref(additional_derivations), i,
             std::cref(is_out_data_ptr), std::ref(tx_scan_info[i]), std::ref(output_found[i])), true);
         }
         waiter.wait(&tpool);
@@ -1917,11 +1925,11 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
         }
       }
     }
-    else if (tx.vout.size() > 1 && m_scan_threadpool->get_max_concurrency() > 1 && !is_out_data_ptr)
+    else if (tx.vout.size() > 1 && tools::threadpool::getInstance().get_max_concurrency() > 1 && !is_out_data_ptr)
     {
       for (size_t i = 0; i < tx.vout.size(); ++i)
       {
-        tpool.submit(&waiter, boost::bind(&wallet2::check_acc_out_precomp_once, this, std::cref(tx.vout[i]), std::cref(derivation), std::cref(additional_derivations), i,
+        scan_submit(tpool, &waiter, boost::bind(&wallet2::check_acc_out_precomp_once, this, std::cref(tx.vout[i]), std::cref(derivation), std::cref(additional_derivations), i,
             std::cref(is_out_data_ptr), std::ref(tx_scan_info[i]), std::ref(output_found[i])), true);
       }
       waiter.wait(&tpool);
@@ -2521,7 +2529,7 @@ void wallet2::process_parsed_blocks(uint64_t start_height, const std::vector<cry
   THROW_WALLET_EXCEPTION_IF(blocks.size() != parsed_blocks.size(), error::wallet_internal_error, "size mismatch");
   THROW_WALLET_EXCEPTION_IF(!m_blockchain.is_in_bounds(current_index), error::out_of_hashchain_bounds_error);
 
-  tools::threadpool& tpool = *m_scan_threadpool;
+  tools::threadpool& tpool = tools::threadpool::getInstance();
   tools::threadpool::waiter waiter;
 
   size_t num_txes = 0;
@@ -2540,11 +2548,11 @@ void wallet2::process_parsed_blocks(uint64_t start_height, const std::vector<cry
       continue;
     }
     if (m_refresh_type != RefreshNoCoinbase)
-      tpool.submit(&waiter, [&, i, txidx](){ cache_tx_data(parsed_blocks[i].block.miner_tx, get_transaction_hash(parsed_blocks[i].block.miner_tx), tx_cache_data[txidx]); });
+      scan_submit(tpool, &waiter, [&, i, txidx](){ cache_tx_data(parsed_blocks[i].block.miner_tx, get_transaction_hash(parsed_blocks[i].block.miner_tx), tx_cache_data[txidx]); });
     ++txidx;
     for (size_t idx = 0; idx < parsed_blocks[i].txes.size(); ++idx)
     {
-      tpool.submit(&waiter, [&, i, idx, txidx](){ cache_tx_data(parsed_blocks[i].txes[idx], parsed_blocks[i].block.tx_hashes[idx], tx_cache_data[txidx]); });
+      scan_submit(tpool, &waiter, [&, i, idx, txidx](){ cache_tx_data(parsed_blocks[i].txes[idx], parsed_blocks[i].block.tx_hashes[idx], tx_cache_data[txidx]); });
       ++txidx;
     }
   }
@@ -2570,7 +2578,7 @@ void wallet2::process_parsed_blocks(uint64_t start_height, const std::vector<cry
   {
     if (tx_cache_data[i].empty())
       continue;
-    tpool.submit(&waiter, [&hwdev, &gender, &tx_cache_data, i, is_hw_device]() {
+    scan_submit(tpool, &waiter, [&hwdev, &gender, &tx_cache_data, i, is_hw_device]() {
       auto &slot = tx_cache_data[i];
       boost::unique_lock<hw::device> hwdev_lock(hwdev, boost::defer_lock);
       if (is_hw_device)
@@ -2618,13 +2626,13 @@ void wallet2::process_parsed_blocks(uint64_t start_height, const std::vector<cry
     {
       THROW_WALLET_EXCEPTION_IF(txidx >= tx_cache_data.size(), error::wallet_internal_error, "txidx out of range");
       const size_t n_vouts = m_refresh_type == RefreshType::RefreshOptimizeCoinbase ? 1 : parsed_blocks[i].block.miner_tx.vout.size();
-      tpool.submit(&waiter, [&, i, n_vouts, txidx](){ geniod(parsed_blocks[i].block.miner_tx, n_vouts, txidx); }, true);
+      scan_submit(tpool, &waiter, [&, i, n_vouts, txidx](){ geniod(parsed_blocks[i].block.miner_tx, n_vouts, txidx); }, true);
     }
     ++txidx;
     for (size_t j = 0; j < parsed_blocks[i].txes.size(); ++j)
     {
       THROW_WALLET_EXCEPTION_IF(txidx >= tx_cache_data.size(), error::wallet_internal_error, "txidx out of range");
-      tpool.submit(&waiter, [&, i, j, txidx](){ geniod(parsed_blocks[i].txes[j], parsed_blocks[i].txes[j].vout.size(), txidx); }, true);
+      scan_submit(tpool, &waiter, [&, i, j, txidx](){ geniod(parsed_blocks[i].txes[j], parsed_blocks[i].txes[j].vout.size(), txidx); }, true);
       ++txidx;
     }
   }
@@ -2699,12 +2707,12 @@ void wallet2::pull_and_parse_next_blocks(uint64_t start_height, uint64_t &blocks
     pull_blocks(start_height, blocks_start_height, short_chain_history, blocks, o_indices, current_height);
     THROW_WALLET_EXCEPTION_IF(blocks.size() != o_indices.size(), error::wallet_internal_error, "Mismatched sizes of blocks and o_indices");
 
-    tools::threadpool& tpool = *m_scan_threadpool;
+    tools::threadpool& tpool = tools::threadpool::getInstance();
     tools::threadpool::waiter waiter;
     parsed_blocks.resize(blocks.size());
     for (size_t i = 0; i < blocks.size(); ++i)
     {
-      tpool.submit(&waiter, boost::bind(&wallet2::parse_block_round, this, std::cref(blocks[i].block),
+      scan_submit(tpool, &waiter, boost::bind(&wallet2::parse_block_round, this, std::cref(blocks[i].block),
         std::ref(parsed_blocks[i].block), std::ref(parsed_blocks[i].hash), std::ref(parsed_blocks[i].error)), true);
     }
     waiter.wait(&tpool);
@@ -2724,7 +2732,7 @@ void wallet2::pull_and_parse_next_blocks(uint64_t start_height, uint64_t &blocks
       parsed_blocks[i].txes.resize(blocks[i].txs.size());
       for (size_t j = 0; j < blocks[i].txs.size(); ++j)
       {
-        tpool.submit(&waiter, [&, i, j](){
+        scan_submit(tpool, &waiter, [&, i, j](){
           if (!parse_and_validate_tx_base_from_blob(blocks[i].txs[j].blob, parsed_blocks[i].txes[j]))
           {
             boost::unique_lock<boost::mutex> lock(error_lock);
@@ -3165,7 +3173,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
   size_t try_count = 0;
   crypto::hash last_tx_hash_id = m_transfers.size() ? m_transfers.back().m_txid : null_hash;
   std::list<crypto::hash> short_chain_history;
-  tools::threadpool& tpool = *m_scan_threadpool;
+  tools::threadpool& tpool = tools::threadpool::getInstance();
   tools::threadpool::waiter waiter;
   uint64_t blocks_start_height;
   std::vector<cryptonote::block_complete_entry> blocks;
@@ -3234,7 +3242,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
         break;
       }
       if (!last)
-        tpool.submit(&waiter, [&]{pull_and_parse_next_blocks(start_height, next_blocks_start_height, short_chain_history, blocks, parsed_blocks, next_blocks, next_parsed_blocks, last, error, exception);});
+        scan_submit(tpool, &waiter, [&]{pull_and_parse_next_blocks(start_height, next_blocks_start_height, short_chain_history, blocks, parsed_blocks, next_blocks, next_parsed_blocks, last, error, exception);});
 
       if (!first)
       {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1155,8 +1155,8 @@ void wallet2::scan_submit(tools::threadpool &tpool, tools::threadpool::waiter *w
 {
   tpool.submit(waiter, [this, f = std::move(f)]() {
     m_scan_semaphore.acquire();
+    auto release = epee::misc_utils::create_scope_leave_handler([this]{ m_scan_semaphore.release(); });
     f();
-    m_scan_semaphore.release();
   }, leaf);
 }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3242,7 +3242,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
         break;
       }
       if (!last)
-        scan_submit(tpool, &waiter, [&]{pull_and_parse_next_blocks(start_height, next_blocks_start_height, short_chain_history, blocks, parsed_blocks, next_blocks, next_parsed_blocks, last, error, exception);});
+        tpool.submit(&waiter, [&]{pull_and_parse_next_blocks(start_height, next_blocks_start_height, short_chain_history, blocks, parsed_blocks, next_blocks, next_parsed_blocks, last, error, exception);});
 
       if (!first)
       {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <memory>
+#include "common/threadpool.h"
 
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
@@ -1389,6 +1390,8 @@ private:
     std::unordered_map<crypto::public_key, crypto::key_image> m_cold_key_images;
 
     std::atomic<bool> m_run;
+
+    std::unique_ptr<tools::threadpool> m_scan_threadpool;
 
     boost::recursive_mutex m_daemon_rpc_mutex;
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1261,6 +1261,25 @@ private:
     void set_offline(bool offline = true);
 
   private:
+    struct scan_semaphore {
+      boost::mutex m_mutex;
+      boost::condition_variable m_cv;
+      unsigned m_count;
+      scan_semaphore(unsigned count) : m_count(count) {}
+      void acquire() {
+        boost::unique_lock<boost::mutex> lock(m_mutex);
+        m_cv.wait(lock, [this]{ return m_count > 0; });
+        --m_count;
+      }
+      void release() {
+        const boost::unique_lock<boost::mutex> lock(m_mutex);
+        ++m_count;
+        m_cv.notify_one();
+      }
+    };
+
+    void scan_submit(tools::threadpool &tpool, tools::threadpool::waiter *waiter, std::function<void()> f, bool leaf = false);
+
     /*!
      * \brief  Stores wallet information to wallet file.
      * \param  keys_file_name Name of wallet file
@@ -1391,7 +1410,7 @@ private:
 
     std::atomic<bool> m_run;
 
-    std::unique_ptr<tools::threadpool> m_scan_threadpool;
+    scan_semaphore m_scan_semaphore;
 
     boost::recursive_mutex m_daemon_rpc_mutex;
 

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -199,8 +199,7 @@ namespace wallet_args
     if (notice)
       Print(print) << notice << ENDL;
 
-    if (!command_line::is_arg_defaulted(vm, arg_max_concurrency))
-      tools::set_max_concurrency(command_line::get_arg(vm, arg_max_concurrency));
+    tools::set_max_concurrency(command_line::get_arg(vm, arg_max_concurrency));
 
     Print(print) << "NERVA '" << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ")";
 


### PR DESCRIPTION
## Summary

- Replaces the dedicated `m_scan_threadpool` with a counting semaphore (`m_scan_semaphore`) over the global `threadpool::getInstance()` — eliminates the N×1.5 total thread count that arose from having two separate pools
- Semaphore is initialised to `max(1, get_max_concurrency() / 2)` at wallet construction, after `wallet_args` has called `set_max_concurrency()` from `--max-concurrency`, so the flag is correctly respected
- CPU-intensive leaf tasks (output checking, block/tx parsing, cache and key derivation work) go through `scan_submit()`, which wraps each with a RAII scope guard around semaphore acquire/release — the guard ensures the slot is always returned even if the task throws
- `pull_and_parse_next_blocks` is submitted without the semaphore since it is an I/O-bound orchestrator that internally dispatches those leaf tasks; wrapping it would cause a slot-hold deadlock on single-core machines where tasks execute inline
- Caps each `getblocks.bin` response to `BLOCKS_SYNCHRONIZING_DEFAULT_COUNT` (100) blocks via the `max_count` request field, down from the server default of 1000 — reduces `m_daemon_rpc_mutex` hold time per batch
- Fixes the macOS `DEFAULT_MAX_CONCURRENCY=1` pthread workaround in `wallet_args.cpp` — the previous `is_arg_defaulted` guard meant the default was never applied unless the user explicitly passed `--max-concurrency`

## Relationship to #77

#77 (now merged) fixed RPC unresponsiveness by moving `refresh()` to a dedicated background thread. This PR is independent and addresses the remaining issues #77 did not cover: CPU saturation from uncapped scan parallelism, the 1000-block batch size on the wallet RPC endpoint, and the macOS concurrency default bug.