### PR TITLE
fix: data race, unconditional parse, and uint64 underflow in block tracking

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -173,6 +173,7 @@ namespace cryptonote
     // block_height,block_hash,peer_ip:peer_port,local_timestamp_block_received
     bool m_track_block_recvd_times;
     std::ofstream m_track_block_recvd_times_fstream;
+    boost::mutex m_track_block_recvd_times_mutex;
 
     boost::mutex m_buffer_mutex;
     double get_avg_block_size();

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -438,11 +438,13 @@ namespace cryptonote
   {
     crypto::hash hash;
     cryptonote::block b;
-    bool ret = cryptonote::parse_and_validate_block_from_blob(arg.b.block, b, &hash);
+    bool ret = false;
+    if (m_track_block_recvd_times || ELPP->vRegistry()->allowed(el::Level::Info, "net.p2p.msg"))
+      ret = cryptonote::parse_and_validate_block_from_blob(arg.b.block, b, &hash);
     MLOGIF_P2P_MESSAGE(hash; b; ;, ret, "Received NOTIFY_NEW_BLOCK " << hash << " (height " << arg.current_blockchain_height << ", " << arg.b.txs.size() << " txes)");
 
     time_t ts = time(NULL);
-    if (m_track_block_recvd_times)
+    if (m_track_block_recvd_times && arg.current_blockchain_height > 0)
     {
       boost::unique_lock<boost::mutex> lock(m_track_block_recvd_times_mutex);
       m_track_block_recvd_times_fstream << arg.current_blockchain_height-1 << "," << hash << "," << context.m_remote_address.str() << "," << ts << std::endl;
@@ -524,11 +526,13 @@ namespace cryptonote
   {
     crypto::hash hash;
     cryptonote::block b;
-    bool ret = cryptonote::parse_and_validate_block_from_blob(arg.b.block, b, &hash);
+    bool ret = false;
+    if (m_track_block_recvd_times || ELPP->vRegistry()->allowed(el::Level::Info, "net.p2p.msg"))
+      ret = cryptonote::parse_and_validate_block_from_blob(arg.b.block, b, &hash);
     MLOGIF_P2P_MESSAGE(hash; b; ;, ret, "Received NOTIFY_NEW_FLUFFY_BLOCK " << hash << " (height " << arg.current_blockchain_height << ", " << arg.b.txs.size() << " txes)");
 
     time_t ts = time(NULL);
-    if (m_track_block_recvd_times)
+    if (m_track_block_recvd_times && arg.current_blockchain_height > 0)
     {
       boost::unique_lock<boost::mutex> lock(m_track_block_recvd_times_mutex);
       m_track_block_recvd_times_fstream << arg.current_blockchain_height-1 << "," << hash << "," << context.m_remote_address.str() << "," << ts << std::endl;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -443,7 +443,10 @@ namespace cryptonote
 
     time_t ts = time(NULL);
     if (m_track_block_recvd_times)
+    {
+      boost::unique_lock<boost::mutex> lock(m_track_block_recvd_times_mutex);
       m_track_block_recvd_times_fstream << arg.current_blockchain_height-1 << "," << hash << "," << context.m_remote_address.str() << "," << ts << std::endl;
+    }
 
     if(context.m_state != cryptonote_connection_context::state_normal)
       return 1;
@@ -526,7 +529,10 @@ namespace cryptonote
 
     time_t ts = time(NULL);
     if (m_track_block_recvd_times)
+    {
+      boost::unique_lock<boost::mutex> lock(m_track_block_recvd_times_mutex);
       m_track_block_recvd_times_fstream << arg.current_blockchain_height-1 << "," << hash << "," << context.m_remote_address.str() << "," << ts << std::endl;
+    }
 
     if(context.m_state != cryptonote_connection_context::state_normal)
       return 1;


### PR DESCRIPTION
## Summary

Three issues introduced with the `--track-block-recvd-times` feature:

**1. Data race on `m_track_block_recvd_times_fstream` (high severity)**
`handle_notify_new_block` and `handle_notify_new_fluffy_block` are called from concurrent P2P connection threads. Writing to `std::ofstream` without synchronization is undefined behavior and can corrupt the CSV output or crash the daemon. Adds a dedicated `boost::mutex` locked around both write sites.

**2. Unconditional block parsing — performance regression (medium severity)**
`parse_and_validate_block_from_blob` was moved out of the `MLOGIF_P2P_MESSAGE` macro to provide the hash for tracking, but this caused it to run on every received block even when both tracking and P2P message logging are disabled. Since the block is re-parsed downstream in the core handler, this is redundant work. The parse is now gated on `m_track_block_recvd_times || net.p2p.msg log level active`, restoring the original behavior.

**3. `uint64_t` underflow in block height tracking (low severity)**
`arg.current_blockchain_height - 1` would wrap to `2^64 - 1` if a peer sends `current_blockchain_height = 0`. A guard (`> 0`) is added before the subtraction.