### PR TITLE
feat: add multi-arch Docker build support for amd64 and arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,5 +54,6 @@ jobs:
                 uses: docker/build-push-action@v6
                 with:
                     context: .
+                    platforms: linux/amd64,linux/arm64
                     push: true
                     tags: sn1f3rt/nerva:latest, sn1f3rt/nerva:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,11 @@ RUN set -ex && \
         arm64) BUILD_TARGET="aarch64-linux-gnu" ;; \
         *)     BUILD_TARGET="x86_64-linux-gnu" ;; \
     esac && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        for tool in gcc g++ ar ranlib strip nm; do \
+            ln -sf /usr/bin/$tool /usr/local/bin/aarch64-linux-gnu-$tool ; \
+        done ; \
+    fi && \
     git submodule init && git submodule update && \
     rm -rf build && \
     if [ -z "$NPROC" ] ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,19 @@ WORKDIR /src
 COPY . .
 
 ARG NPROC
+ARG TARGETARCH
 RUN set -ex && \
+    case "$TARGETARCH" in \
+        arm64) BUILD_TARGET="aarch64-linux-gnu" ;; \
+        *)     BUILD_TARGET="x86_64-linux-gnu" ;; \
+    esac && \
     git submodule init && git submodule update && \
     rm -rf build && \
     if [ -z "$NPROC" ] ; \
-    then make -j$(nproc) depends target=x86_64-linux-gnu ; \
-    else make -j$NPROC depends target=x86_64-linux-gnu ; \
-    fi
+    then make -j$(nproc) depends target=$BUILD_TARGET ; \
+    else make -j$NPROC depends target=$BUILD_TARGET ; \
+    fi && \
+    cp -r /src/build/${BUILD_TARGET}/release/bin /src/build/out
 
 # runtime stage
 FROM ubuntu:20.04
@@ -39,7 +45,7 @@ RUN set -ex && \
     apt-get --no-install-recommends --yes install ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt
-COPY --from=builder /src/build/x86_64-linux-gnu/release/bin /usr/local/bin/
+COPY --from=builder /src/build/out /usr/local/bin/
 
 # Create nerva user
 RUN adduser --system --group --disabled-password nerva && \


### PR DESCRIPTION
## Summary

- Adds `TARGETARCH` build arg to the `Dockerfile` to dynamically select the correct build target (`aarch64-linux-gnu` for arm64, `x86_64-linux-gnu` otherwise)
- Copies release binaries to a common `/src/build/out` path so the runtime stage can use a single consistent `COPY` source regardless of architecture
- Enables `linux/amd64` and `linux/arm64` platforms in the Docker CI workflow