### PR TITLE
fix: resolve PR number via head owner/branch for fork PRs

### DIFF
--- a/.github/workflows/post-artifact-links.yml
+++ b/.github/workflows/post-artifact-links.yml
@@ -104,9 +104,16 @@ jobs:
                             `*${succeeded} succeeded, ${failed} failed* | [View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})`,
                         ].join('\n');
 
-                        const prs = context.payload.workflow_run.pull_requests;
+                        const headOwner = context.payload.workflow_run.head_repository.owner.login;
+                        const headBranch = context.payload.workflow_run.head_branch;
+                        const { data: prs } = await github.rest.pulls.list({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            state: 'open',
+                            head: `${headOwner}:${headBranch}`,
+                        });
                         if (!prs || prs.length === 0) {
-                            core.warning('No associated pull requests found; skipping comment.');
+                            core.warning('No open pull request found for this branch; skipping comment.');
                             return;
                         }
                         const prNumber = prs[0].number;

--- a/.github/workflows/post-artifact-links.yml
+++ b/.github/workflows/post-artifact-links.yml
@@ -104,19 +104,25 @@ jobs:
                             `*${succeeded} succeeded, ${failed} failed* | [View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})`,
                         ].join('\n');
 
+                        if (!context.payload.workflow_run.head_repository) {
+                            core.warning('head_repository is null (fork deleted?); skipping comment.');
+                            return;
+                        }
                         const headOwner = context.payload.workflow_run.head_repository.owner.login;
                         const headBranch = context.payload.workflow_run.head_branch;
+                        const headSha = context.payload.workflow_run.head_sha;
                         const { data: prs } = await github.rest.pulls.list({
                             owner: context.repo.owner,
                             repo: context.repo.repo,
                             state: 'open',
                             head: `${headOwner}:${headBranch}`,
                         });
-                        if (!prs || prs.length === 0) {
-                            core.warning('No open pull request found for this branch; skipping comment.');
+                        const pr = prs.find(p => p.head.sha === headSha);
+                        if (!pr) {
+                            core.warning('No open pull request found for this commit; skipping comment.');
                             return;
                         }
-                        const prNumber = prs[0].number;
+                        const prNumber = pr.number;
 
                         const { data: comments } = await github.rest.issues.listComments({
                             owner: context.repo.owner,


### PR DESCRIPTION
## Summary

- `listPullRequestsAssociatedWithCommit` only works for commits on the default branch — for fork PR commits it returns nothing, causing the artifact comment to be silently skipped.
- Switch to `pulls.list` filtered by `head` (`owner:branch`), which correctly resolves open PRs from forks.

Fixes the remaining issue from #78.