### PR TITLE
fix: wallet correctness — pool spend detection and key image state

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1550,16 +1550,11 @@ void wallet2::set_unspent(size_t idx)
   td.m_spent_height = 0;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::is_spent(const transfer_details &td, bool strict) const
+bool wallet2::is_spent(const transfer_details &td, bool /*strict*/) const
 {
-  if (strict)
-  {
-    return td.m_spent && td.m_spent_height > 0;
-  }
-  else
-  {
-    return td.m_spent;
-  }
+  // Pool-spent outputs (m_spent_height==0) are still spent; the strict flag
+  // only controls whether unconfirmed change is added back in balance_per_subaddress.
+  return td.m_spent;
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::is_spent(size_t idx, bool strict) const

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2228,7 +2228,11 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
     else if (!m_unconfirmed_txs.count(txid))
     {
       // Add to unconfirmed txs if not already there (e.g. restoring wallet, or running the wallet in parallel to the sending wallet w/same seed)
-      add_unconfirmed_tx(txid, tx, tx_money_spent_in_ins, {}/*don't know dests*/, crypto::null_hash/*don't know payment_id*/, self_received, *subaddr_account, subaddr_indices);
+      crypto::hash payment_id = crypto::null_hash;
+      tx_extra_nonce extra_nonce;
+      if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+        get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id);
+      add_unconfirmed_tx(txid, tx, tx_money_spent_in_ins, {}/*don't know dests*/, payment_id, self_received, *subaddr_account, subaddr_indices);
       auto i = m_unconfirmed_txs.find(txid);
       THROW_WALLET_EXCEPTION_IF(i == m_unconfirmed_txs.end(), error::wallet_internal_error,
         "unconfirmed tx wasn't found: " + string_tools::pod_to_hex(txid));
@@ -2864,24 +2868,29 @@ void wallet2::update_pool_state(std::vector<std::tuple<cryptonote::transaction, 
     }
     else
     {
-      // The inputs are spent, they're in the pool! It's possible the tx was previously marked as failed, so we
-      // make sure to re-mark the outputs as spent.
-      for (size_t vini = 0; vini < pit->second.m_tx.vin.size(); ++vini)
+      // The tx is in the pool. If it was previously marked as failed, restore it to pending
+      // and re-mark its outputs as spent so balance and transfer display are consistent.
+      if (pit->second.m_state == wallet2::unconfirmed_transfer_details::failed)
       {
-        if (pit->second.m_tx.vin[vini].type() != typeid(txin_to_key))
-          continue;
-        const crypto::key_image &key_image = boost::get<txin_to_key>(pit->second.m_tx.vin[vini]).k_image;
-        const auto it_ki = m_key_images.find(key_image);
-        if (it_ki == m_key_images.end())
-          continue;
-        const std::size_t i = it_ki->second;
-        if (i >= m_transfers.size())
-          continue;
-        const transfer_details &td = m_transfers.at(i);
-        if (td.m_key_image != key_image || td.m_spent)
-          continue;
-        LOG_PRINT_L1("Resetting spent status for output " << vini << ": " << key_image << " (spent=true)");
-        set_spent(i, 0);
+        LOG_PRINT_L1("Pending txid " << pit->first << " reappeared in pool, restoring to pending");
+        pit->second.m_state = wallet2::unconfirmed_transfer_details::pending;
+        for (size_t vini = 0; vini < pit->second.m_tx.vin.size(); ++vini)
+        {
+          if (pit->second.m_tx.vin[vini].type() != typeid(txin_to_key))
+            continue;
+          const crypto::key_image &key_image = boost::get<txin_to_key>(pit->second.m_tx.vin[vini]).k_image;
+          const auto it_ki = m_key_images.find(key_image);
+          if (it_ki == m_key_images.end())
+            continue;
+          const std::size_t i = it_ki->second;
+          if (i >= m_transfers.size())
+            continue;
+          const transfer_details &td = m_transfers.at(i);
+          if (td.m_key_image != key_image || td.m_spent)
+            continue;
+          LOG_PRINT_L1("Resetting spent status for output " << vini << ": " << key_image << " (spent=true)");
+          set_spent(i, 0);
+        }
       }
     }
   }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -875,6 +875,11 @@ bool get_short_payment_id(crypto::hash8 &payment_id8, const tools::wallet2::pend
   return false;
 }
 
+uint64_t get_outgoing_amount(const cryptonote::transaction &tx, const uint64_t amount_spent)
+{
+  return tx.version == 1 ? get_outs_money_amount(tx) : (amount_spent - tx.rct_signatures.txnFee);
+}
+
 tools::wallet2::tx_construction_data get_construction_data_with_decrypted_short_payment_id(const tools::wallet2::pending_tx &ptx, hw::device &hwdev)
 {
   tools::wallet2::tx_construction_data construction_data = ptx.construction_data;
@@ -2161,10 +2166,10 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
         LOG_ERROR("spent funds are from different subaddress accounts; count of incoming/outgoing payments will be incorrect");
       subaddr_account = td.m_subaddr_index.major;
       subaddr_indices.insert(td.m_subaddr_index.minor);
+      LOG_PRINT_L0("Spent money: " << print_money(amount) << ", with tx: " << txid);
+      set_spent(it->second, height);
       if (!pool)
       {
-        LOG_PRINT_L0("Spent money: " << print_money(amount) << ", with tx: " << txid);
-        set_spent(it->second, height);
         if (0 != m_callback)
           m_callback->on_money_spent(height, txid, tx, amount, tx, td.m_subaddr_index);
       }
@@ -2201,21 +2206,33 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 
   uint64_t fee = miner_tx ? 0 : tx.rct_signatures.txnFee;
 
-  if (tx_money_spent_in_ins > 0 && !pool)
+  if (tx_money_spent_in_ins > 0)
   {
     uint64_t self_received = std::accumulate<decltype(tx_money_got_in_outs.begin()), uint64_t>(tx_money_got_in_outs.begin(), tx_money_got_in_outs.end(), 0,
       [&subaddr_account] (uint64_t acc, const std::pair<cryptonote::subaddress_index, uint64_t>& p)
       {
         return acc + (p.first.major == *subaddr_account ? p.second : 0);
       });
-    process_outgoing(txid, tx, height, ts, tx_money_spent_in_ins, self_received, *subaddr_account, subaddr_indices);
-    // if sending to yourself at the same subaddress account, set the outgoing payment amount to 0 so that it's less confusing
-    if (tx_money_spent_in_ins == self_received + fee)
+    if (!pool)
     {
-      auto i = m_confirmed_txs.find(txid);
-      THROW_WALLET_EXCEPTION_IF(i == m_confirmed_txs.end(), error::wallet_internal_error,
-        "confirmed tx wasn't found: " + string_tools::pod_to_hex(txid));
-      i->second.m_change = self_received;
+      process_outgoing(txid, tx, height, ts, tx_money_spent_in_ins, self_received, *subaddr_account, subaddr_indices);
+      // if sending to yourself at the same subaddress account, set the outgoing payment amount to 0 so that it's less confusing
+      if (tx_money_spent_in_ins == self_received + fee)
+      {
+        auto i = m_confirmed_txs.find(txid);
+        THROW_WALLET_EXCEPTION_IF(i == m_confirmed_txs.end(), error::wallet_internal_error,
+          "confirmed tx wasn't found: " + string_tools::pod_to_hex(txid));
+        i->second.m_change = self_received;
+      }
+    }
+    else if (!m_unconfirmed_txs.count(txid))
+    {
+      // Add to unconfirmed txs if not already there (e.g. restoring wallet, or running the wallet in parallel to the sending wallet w/same seed)
+      add_unconfirmed_tx(txid, tx, tx_money_spent_in_ins, {}/*don't know dests*/, crypto::null_hash/*don't know payment_id*/, self_received, *subaddr_account, subaddr_indices);
+      auto i = m_unconfirmed_txs.find(txid);
+      THROW_WALLET_EXCEPTION_IF(i == m_unconfirmed_txs.end(), error::wallet_internal_error,
+        "unconfirmed tx wasn't found: " + string_tools::pod_to_hex(txid));
+      i->second.m_amount_out = get_outgoing_amount(tx, tx_money_spent_in_ins);
     }
   }
 
@@ -2350,7 +2367,7 @@ void wallet2::process_outgoing(const crypto::hash &txid, const cryptonote::trans
     // wallet (eg, we're a cold wallet and the hot wallet sent it). For RCT transactions,
     // we only see 0 input amounts, so have to deduce amount out from other parameters.
     entry.first->second.m_amount_in = spent;
-    entry.first->second.m_amount_out = spent - tx.rct_signatures.txnFee;
+    entry.first->second.m_amount_out = get_outgoing_amount(tx, spent);
     entry.first->second.m_change = received;
 
     std::vector<tx_extra_field> tx_extra_fields;
@@ -3156,6 +3173,17 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
     // Lighwallet refresh done
     return;
   }
+
+  if (!m_first_refresh_done)
+  {
+    // We want to process the whole pool again, in case we identify received outputs in the chain we might have spent in the pool
+    m_scanned_pool_txs[0].clear();
+    m_scanned_pool_txs[1].clear();
+    // Clear unconfirmed (received) payments because the data is 100% recovered when scanning
+    m_unconfirmed_payments.clear();
+    // Don't clear unconfirmed (sent) txs because some data is not recover-able when scanning (dests)
+  }
+
   received_money = false;
   blocks_fetched = 0;
   uint64_t added_blocks = 0;
@@ -6041,9 +6069,9 @@ uint64_t wallet2::select_transfers(uint64_t needed_money, std::vector<size_t> un
   return found_money;
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::add_unconfirmed_tx(const cryptonote::transaction& tx, uint64_t amount_in, const std::vector<cryptonote::tx_destination_entry> &dests, const crypto::hash &payment_id, uint64_t change_amount, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices)
+void wallet2::add_unconfirmed_tx(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount_in, const std::vector<cryptonote::tx_destination_entry> &dests, const crypto::hash &payment_id, uint64_t change_amount, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices)
 {
-  unconfirmed_transfer_details& utd = m_unconfirmed_txs[cryptonote::get_transaction_hash(tx)];
+  unconfirmed_transfer_details& utd = m_unconfirmed_txs[txid];
   utd.m_amount_in = amount_in;
   utd.m_amount_out = 0;
   for (const auto &d: dests)
@@ -6153,7 +6181,7 @@ void wallet2::commit_tx(pending_tx& ptx)
     for(size_t idx: ptx.selected_transfers)
       amount_in += m_transfers[idx].amount();
   }
-  add_unconfirmed_tx(ptx.tx, amount_in, dests, payment_id, ptx.change_dts.amount, ptx.construction_data.subaddr_account, ptx.construction_data.subaddr_indices);
+  add_unconfirmed_tx(txid, ptx.tx, amount_in, dests, payment_id, ptx.change_dts.amount, ptx.construction_data.subaddr_account, ptx.construction_data.subaddr_indices);
   if (store_tx_info() && ptx.tx_key != crypto::null_skey)
   {
     m_tx_keys.insert(std::make_pair(txid, ptx.tx_key));

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2844,21 +2844,44 @@ void wallet2::update_pool_state(std::vector<std::tuple<cryptonote::transaction, 
         remove_rings(pit->second.m_tx);
         for (size_t vini = 0; vini < pit->second.m_tx.vin.size(); ++vini)
         {
-          if (pit->second.m_tx.vin[vini].type() == typeid(txin_to_key))
-          {
-            txin_to_key &tx_in_to_key = boost::get<txin_to_key>(pit->second.m_tx.vin[vini]);
-            for (size_t i = 0; i < m_transfers.size(); ++i)
-            {
-              const transfer_details &td = m_transfers[i];
-              if (td.m_key_image == tx_in_to_key.k_image)
-              {
-                 LOG_PRINT_L1("Resetting spent status for output " << vini << ": " << td.m_key_image);
-                 set_unspent(i);
-                 break;
-              }
-            }
-          }
+          if (pit->second.m_tx.vin[vini].type() != typeid(txin_to_key))
+            continue;
+          const crypto::key_image &key_image = boost::get<txin_to_key>(pit->second.m_tx.vin[vini]).k_image;
+          const auto it_ki = m_key_images.find(key_image);
+          if (it_ki == m_key_images.end())
+            continue;
+          const std::size_t i = it_ki->second;
+          if (i >= m_transfers.size())
+            continue;
+          if (m_transfers.at(i).m_key_image != key_image)
+            continue;
+          if (!m_transfers.at(i).m_spent)
+            continue;
+          LOG_PRINT_L1("Resetting spent status for output " << vini << ": " << key_image);
+          set_unspent(i);
         }
+      }
+    }
+    else
+    {
+      // The inputs are spent, they're in the pool! It's possible the tx was previously marked as failed, so we
+      // make sure to re-mark the outputs as spent.
+      for (size_t vini = 0; vini < pit->second.m_tx.vin.size(); ++vini)
+      {
+        if (pit->second.m_tx.vin[vini].type() != typeid(txin_to_key))
+          continue;
+        const crypto::key_image &key_image = boost::get<txin_to_key>(pit->second.m_tx.vin[vini]).k_image;
+        const auto it_ki = m_key_images.find(key_image);
+        if (it_ki == m_key_images.end())
+          continue;
+        const std::size_t i = it_ki->second;
+        if (i >= m_transfers.size())
+          continue;
+        const transfer_details &td = m_transfers.at(i);
+        if (td.m_key_image != key_image || td.m_spent)
+          continue;
+        LOG_PRINT_L1("Resetting spent status for output " << vini << ": " << key_image << " (spent=true)");
+        set_spent(i, 0);
       }
     }
   }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1290,7 +1290,7 @@ private:
     bool prepare_file_names(const std::string& file_path);
     void process_unconfirmed(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height);
     void process_outgoing(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height, uint64_t ts, uint64_t spent, uint64_t received, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices);
-    void add_unconfirmed_tx(const cryptonote::transaction& tx, uint64_t amount_in, const std::vector<cryptonote::tx_destination_entry> &dests, const crypto::hash &payment_id, uint64_t change_amount, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices);
+    void add_unconfirmed_tx(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount_in, const std::vector<cryptonote::tx_destination_entry> &dests, const crypto::hash &payment_id, uint64_t change_amount, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices);
     void generate_genesis(cryptonote::block& b) const;
     void check_genesis(const crypto::hash& genesis_hash) const; //throws
     bool generate_chacha_key_from_secret_keys(crypto::chacha_key &key) const;


### PR DESCRIPTION
## Summary

- **Pool spend detection during scanning** — When refreshing, the wallet
  now detects outgoing transactions in the mempool even when the wallet
  didn't originate them (e.g. after restoring from seed or running a
  parallel wallet with the same seed). Outputs are marked spent
  immediately when a matching key image is found in a pool transaction,
  and the tx is added to the unconfirmed list. First refresh also clears
  the pool scan cache so restored wallets get a complete view of pending
  spends.

- **Key image spent status correctness** — When a pending transaction
  re-appears in the pool after previously being marked failed, its
  outputs are now correctly re-marked as spent. The output unspent reset
  on tx failure was also refactored to use `m_key_images` O(1) lookup
  instead of an O(n) linear scan, with an idempotency guard to skip
  outputs already in the correct state.

## Test plan

- [ ] Send a transaction via wallet A; refresh a parallel wallet B
  (same seed, different file) while tx is in pool — verify it appears
  in `show_transfers pending` on wallet B
- [ ] Confirm balance reflects pool spend immediately after refresh,
  not only after block confirmation
- [ ] Verify normal send/receive flow unaffected