### PR TITLE
fix: disable docker/metadata-action auto-latest to prevent RC tags being marked as latest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,8 @@ jobs:
                 uses: docker/metadata-action@v5
                 with:
                     images: sn1f3rt/nerva
+                    flavor: |
+                        latest=false
                     tags: |
                         type=ref,event=tag
                         type=raw,value=latest,enable=${{ !contains(github.ref_name, 'rc') && !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') }}


### PR DESCRIPTION
## Summary

- `docker/metadata-action@v5` defaults to `flavor: latest=auto`, which independently applies the `latest` tag using its own semver analysis — bypassing the `enable=false` logic already in the workflow
- Nerva's 4-part version format (`v0.2.1.0-rc1`) causes `semver.coerce` to strip the 4th segment **and** the prerelease suffix, producing `0.2.1` with no prerelease marker; the action then treats the RC as a stable release and applies `latest`
- Fix: add `flavor: latest=false` so `type=raw,value=latest,enable=...` is the sole controller of when `latest` is applied (that logic was already correct)

## Root cause (why PR #75 didn't fully fix it)

PR #75 added the conditional `enable=` logic on the `type=raw` tag, but left `docker/metadata-action`'s default `latest=auto` flavor active. That default path applies `latest` independently of the `type=raw` entry, and it misfires on 4-part semver versions.