### PR TITLE
fix: prevent crash in build_block_cache on Windows (LMDB write txn reuse)

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2385,7 +2385,7 @@ block_header BlockchainLMDB::get_block_header(const crypto::hash& h) const
 void check_error(int err)
 {
   if (err)
-    fprintf(stderr, "get_v3_data failed, error %d %s\n", err, mdb_strerror(err));
+    throw0(DB_ERROR(lmdb_error("LMDB cursor error in PoW cache: ", err).c_str()));
 }
 
 void BlockchainLMDB::build_block_cache(uint64_t height)
@@ -2397,32 +2397,32 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
 
   m_block_cache.reserve(height);
 
-  // During batch sync, blocks are written inside a batch write transaction that
-  // is not committed until the batch ends. A fresh read-only transaction can
-  // only see committed data, so it would fail to read blocks that have been
-  // added in the current batch but not yet committed. Reuse m_write_txn when
-  // one is active so we can see those uncommitted blocks. This matches the
-  // TXN_BLOCK_PREFIX pattern used elsewhere in this file.
+  // Always use a fresh read-only transaction. get_block_sync_size() caps the
+  // batch at BLOCKS_SYNCHRONIZING_SAFE_BATCH_COUNT (256), matching the
+  // stable_height offset of height-256 used by all CNA PoW variants, so
+  // stable_height blocks are always committed and visible to a read txn.
+  // Using the write txn here caused EINVAL from mdb_cursor_open on Windows
+  // (write txn is not valid for read-cursor operations in all LMDB states).
   MDB_txn *txn;
-  MDB_cursor *cur;
-  bool own_txn = false;
-  if (m_batch_active || m_write_txn)
+  if (auto r = lmdb_txn_begin(m_env, NULL, MDB_RDONLY, &txn, 0))
+    throw0(DB_ERROR(lmdb_error("Failed to create a transaction for the db: ", r).c_str()));
+
+  MDB_cursor *cur = nullptr;
+  if (auto r = mdb_cursor_open(txn, m_block_info, &cur))
   {
-    txn = m_write_txn->m_txn;
-  }
-  else
-  {
-    if (auto r = lmdb_txn_begin(m_env, NULL, MDB_RDONLY, &txn, 0))
-      throw0(DB_ERROR(lmdb_error("Failed to create a transaction for the db: ", r).c_str()));
-    own_txn = true;
+    mdb_txn_abort(txn);
+    throw0(DB_ERROR(lmdb_error("Failed to open block_info cursor for block cache: ", r).c_str()));
   }
 
-  int err = mdb_cursor_open(txn, m_block_info, &cur); check_error(err);
-
-  for(uint64_t index = m_block_cache.size(); index < height; ++index)
+  for (uint64_t index = m_block_cache.size(); index < height; ++index)
   {
     MDB_val_set(query, index);
-    err = mdb_cursor_get(cur, (MDB_val*)&zerokval, &query, MDB_GET_BOTH); check_error(err);
+    if (auto r = mdb_cursor_get(cur, (MDB_val*)&zerokval, &query, MDB_GET_BOTH))
+    {
+      mdb_cursor_close(cur);
+      mdb_txn_abort(txn);
+      throw0(DB_ERROR(lmdb_error("Failed to read block_info record for block cache: ", r).c_str()));
+    }
     const mdb_block_info *bi = (const mdb_block_info*)query.mv_data;
     block_cache_data entry;
     entry.hash      = bi->bi_hash;
@@ -2433,9 +2433,7 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
   }
 
   mdb_cursor_close(cur);
-  if (own_txn)
-    mdb_txn_abort(txn);
-
+  mdb_txn_abort(txn);
   m_block_cache_height.store(height, std::memory_order_release);
   CRITICAL_REGION_END();
 }


### PR DESCRIPTION
## Problem

nervad crashes after running for some time on Windows when fully synced
and mining. The crash is preceded by a single stderr line:

    get_v3_data failed, error 22 Invalid argument

and then an immediate access violation.

**Root cause:** `build_block_cache` was reusing the active batch write
transaction (`m_write_txn`) when `m_batch_active` was set. On Windows
with `MDB_WRITEMAP`, `mdb_cursor_open` returns `EINVAL` (22) when given
that write txn in certain states. The previous `check_error` only printed
to stderr and returned, leaving the cursor pointer uninitialised. The
subsequent `mdb_cursor_get` call dereferenced the garbage pointer, causing
an access violation and crash.

## Fix

- `build_block_cache` now always opens a fresh read-only transaction
  instead of reusing the write txn.
- `check_error` now throws `DB_ERROR` instead of printing to stderr, so
  any future LMDB failures surface as catchable exceptions rather than
  silent continuation with an invalid cursor.

The write txn reuse was never necessary: `get_block_sync_size()` caps
batch size at `BLOCKS_SYNCHRONIZING_SAFE_BATCH_COUNT` (256), which
matches the `stable_height = height-256` offset used by all CNA PoW
variants. The blocks needed by `build_block_cache` are therefore always
in a prior committed batch and visible to a read-only transaction.

## Testing

Confirmed on Windows 11 with nervad v0.2.2.0-rc1 (7746fa8b). Previously
crashed multiple times per day; ran for over 20 hours continuously with
this fix applied and zero LMDB errors in the log.