### PR TITLE
fix(ci): install unbound on macOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
                         ccache-${{ runner.os }}-build-
             -   name: Install dependencies
                 run: |
-                    HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi zmq libpgm miniupnpc ldns expat libunwind-headers protobuf@21 ccache
+                    HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi zmq libpgm miniupnpc ldns expat unbound libunwind-headers protobuf@21 ccache
                     brew link protobuf@21 boost
             -   uses: ./.github/actions/set-make-job-count
             -   name: Build


### PR DESCRIPTION
## Problem

`build-macos` (the native Homebrew CI job) started failing at CMake configure with:

```
CMake Error in src/daemon/CMakeLists.txt:
  Found relative path while evaluating include directories of "daemon":
    "UNBOUND_INCLUDE_DIR-NOTFOUND"
CMake Generate step failed.
```

## Root cause

The macOS job installs deps via Homebrew but **never installed `unbound`** (Linux installs `libunbound-dev`, Windows installs `mingw-w64-x86_64-unbound`). It used to resolve anyway because the older `macos-latest` runner image made unbound discoverable to `find_package(Unbound)`.

After a `macos-latest` image update (it last passed on master 2026-05-24), `find_package(Unbound)` no longer finds it. The bundled-submodule fallback in `external/CMakeLists.txt` then sets `UNBOUND_INCLUDE`, but the top-level `CMakeLists.txt` does `include_directories(${UNBOUND_INCLUDE_DIR})` — a different, now-`NOTFOUND` variable — so the generate step aborts.

This is environmental and affects every PR and master, not any specific change.

## Fix

Add `unbound` to the macOS brew install list, matching the other platforms. One word; `find_package(Unbound)` then takes the working path.

## Scope
- Only `.github/workflows/build.yml` (macOS dependency list).
- The `depends.yml` Cross-Mac builds were unaffected (the depends toolchain supplies unbound).