### PR TITLE
ci: warm master caches on a schedule, raise depends ccache size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ on:
         paths-ignore:
             - 'docs/**'
             - '**/README.md'
+    schedule:
+        -   cron: '0 6 * * 1,4'
     workflow_dispatch:
 
 env:

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -40,6 +40,8 @@ on:
         paths-ignore:
             - 'docs/**'
             - '**/README.md'
+    schedule:
+        -   cron: '0 6 * * 1,4'
     workflow_dispatch:
 
 env:
@@ -50,7 +52,7 @@ env:
         Acquire::ftp::Timeout "120";
         EOF
     CCACHE_SETTINGS: |
-        ccache --max-size=150M
+        ccache --max-size=500M
         ccache --set-config=compression=true
 
 jobs:
@@ -142,6 +144,7 @@ jobs:
                     ${{env.CCACHE_SETTINGS}}
                     make depends target=${{ matrix.toolchain.host }} -j${{env.MAKE_JOB_COUNT}}
             -   uses: actions/upload-artifact@v7
+                if: github.event_name != 'schedule'
                 with:
                     name: ${{ matrix.toolchain.artifact-name }}
                     path: |


### PR DESCRIPTION
## Why

GitHub Actions caches have a **7-day no-access eviction TTL**, and caches are scoped per-branch: a PR can inherit the **base branch (master)** caches but **not** sibling PRs'. So the intended flow is *master build populates caches → every PR inherits them on first run*.

That broke recently: the last master push to run these workflows was ~2 weeks ago; everything since was README/release-only, which both workflows `path-ignore`. Master's caches lapsed (no `refs/heads/master` caches currently exist), so **every new PR starts cold** and rebuilds the full `contrib/depends` toolchain from source (~15-25 min), with the identical depends tree re-stored under each PR's own scope.

## Changes

- **Scheduled cache warmer** — add a twice-weekly `schedule` (Mon & Thu 06:00 UTC) to `build.yml` and `depends.yml`. Scheduled runs only trigger on the default branch, so they refresh the master-scoped `depends/built` + ccache caches before the TTL, keeping new PRs warm even during doc-only quiet periods.
- **Skip artifact upload on scheduled runs** (`if: github.event_name != 'schedule'`) — the warmer only needs to populate caches, not publish binaries.
- **`depends.yml` ccache cap `150M` → `500M`** to match `build.yml`. Note: this is headroom/consistency, not a speedup — actual ccache usage is ~35 MB, well under either cap, so the size cap was never the bottleneck. The warmer is the actual fix for slow PR builds.

## Notes
- Once a substantive PR merges to master (e.g. #93), it also repopulates the caches immediately; the schedule keeps them fresh thereafter.
- No new workflow files — reuses the existing build logic to avoid duplication.