### PR TITLE
feat: --mining-threads-adaptive to re-autodetect when hashrate drops

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -81,6 +81,10 @@
 #define AUTODETECT_WINDOW 10 // seconds
 #define AUTODETECT_GAIN_THRESHOLD 1.02f  // 2%
 
+#define ADAPTIVE_DROP_THRESHOLD 0.85f      // re-detect if H/s falls below 85% of baseline
+#define ADAPTIVE_DWELL_SAMPLES 2           // require this many consecutive low samples
+#define ADAPTIVE_COOLDOWN_MS (30 * 60 * 1000ull)  // wait 30 min between re-detections
+
 using namespace epee;
 
 #include "miner.h"
@@ -94,6 +98,7 @@ namespace cryptonote
     const command_line::arg_descriptor<std::string> arg_start_mining =    {"start-mining", "Specify wallet address to mining for", "", true};
     const command_line::arg_descriptor<uint16_t>    arg_donate_mining =    {"donate-level", "Specify a percentage of blocks to mine to the development wallet", miner::MINING_DEFAULT_DONATION_LEVEL, true};
     const command_line::arg_descriptor<uint32_t>      arg_mining_threads =  {"mining-threads", "Specify mining threads count", 0, true};
+    const command_line::arg_descriptor<bool>          arg_mining_threads_adaptive = {"mining-threads-adaptive", "Re-run --mining-threads 0 autodetect if hashrate drops (needs --mining-threads 0)", false, true};
     const command_line::arg_descriptor<bool>        arg_bg_mining_enable =  {"bg-mining-enable", "enable background mining", true, true};
     const command_line::arg_descriptor<bool>        arg_bg_mining_ignore_battery =  {"bg-mining-ignore-battery", "if true, assumes plugged in when unable to query system power status", false, true};    
     const command_line::arg_descriptor<uint64_t>    arg_bg_mining_min_idle_interval_seconds =  {"bg-mining-min-idle-interval", "Specify min lookback interval in seconds for determining idle state", miner::BACKGROUND_MINING_DEFAULT_MIN_IDLE_INTERVAL_IN_SECONDS, true};
@@ -128,7 +133,11 @@ namespace cryptonote
     m_idle_threshold(BACKGROUND_MINING_DEFAULT_IDLE_THRESHOLD_PERCENTAGE),
     m_mining_target(BACKGROUND_MINING_DEFAULT_MINING_TARGET_PERCENTAGE),
     m_miner_extra_sleep(BACKGROUND_MINING_DEFAULT_MINER_EXTRA_SLEEP_MILLIS),
-    m_block_reward(0)
+    m_block_reward(0),
+    m_adaptive_threads(false),
+    m_adaptive_baseline_hr(0),
+    m_adaptive_low_count(0),
+    m_adaptive_cooldown_until_ms(0)
   {
     m_attrs.set_stack_size(THREAD_STACK_SIZE);
   }
@@ -258,6 +267,11 @@ namespace cryptonote
       return true;
     });
 
+    m_adaptive_interval.do_call([&](){
+      update_adaptive_threads();
+      return true;
+    });
+
     return true;
   }
   //-----------------------------------------------------------------------------------------------------
@@ -342,12 +356,85 @@ namespace cryptonote
       m_threads.push_back(boost::thread(m_attrs, boost::bind(&miner::worker_thread, this)));
   }
   //-----------------------------------------------------------------------------------------------------
+  void miner::update_adaptive_threads()
+  {
+    if (!m_adaptive_threads || !is_mining())
+    {
+      m_adaptive_baseline_hr = 0;
+      m_adaptive_low_count = 0;
+      return;
+    }
+
+    // While autodetect is climbing, baseline isn't valid; recapture once it locks in.
+    if (!m_threads_autodetect.empty())
+    {
+      m_adaptive_baseline_hr = 0;
+      m_adaptive_low_count = 0;
+      return;
+    }
+
+    uint64_t hr = 0;
+    {
+      CRITICAL_REGION_LOCAL(m_last_hash_rates_lock);
+      if (!m_last_hash_rates.empty())
+        hr = std::accumulate(m_last_hash_rates.begin(), m_last_hash_rates.end(), (uint64_t)0) / m_last_hash_rates.size();
+    }
+    if (hr == 0)
+      return;
+
+    if (m_adaptive_baseline_hr == 0)
+    {
+      m_adaptive_baseline_hr = hr;
+      MGINFO("Adaptive mining: baseline locked at " << hr << " H/s");
+      return;
+    }
+
+    const uint64_t now_ms = misc_utils::get_tick_count();
+    if (now_ms < m_adaptive_cooldown_until_ms)
+      return;
+
+    if (hr < (uint64_t)(m_adaptive_baseline_hr * ADAPTIVE_DROP_THRESHOLD))
+    {
+      m_adaptive_low_count++;
+      MGINFO("Adaptive mining: " << hr << " H/s vs baseline " << m_adaptive_baseline_hr
+          << " H/s (sample " << m_adaptive_low_count << "/" << ADAPTIVE_DWELL_SAMPLES << ")");
+      if (m_adaptive_low_count >= ADAPTIVE_DWELL_SAMPLES)
+      {
+        MGINFO("Adaptive mining: hashrate dropped, re-running autodetect");
+        m_adaptive_cooldown_until_ms = now_ms + ADAPTIVE_COOLDOWN_MS;
+        m_adaptive_low_count = 0;
+        m_adaptive_baseline_hr = 0;
+
+        m_threads_autodetect.clear();
+        m_threads_autodetect.push_back({epee::misc_utils::get_ns_count(), (uint64_t)m_total_hashes});
+        m_threads_total = 1;
+
+        {
+          CRITICAL_REGION_LOCAL(m_threads_lock);
+          boost::interprocess::ipcdetail::atomic_write32(&m_stop, 1);
+          while (m_threads_active > 0)
+            misc_utils::sleep_no_w(100);
+          m_threads.clear();
+        }
+        boost::interprocess::ipcdetail::atomic_write32(&m_stop, 0);
+        boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);
+        for (size_t i = 0; i != m_threads_total; i++)
+          m_threads.push_back(boost::thread(m_attrs, boost::bind(&miner::worker_thread, this)));
+      }
+    }
+    else
+    {
+      m_adaptive_low_count = 0;
+    }
+  }
+  //-----------------------------------------------------------------------------------------------------
   void miner::init_options(boost::program_options::options_description& desc)
   {
     command_line::add_arg(desc, arg_extra_messages);
     command_line::add_arg(desc, arg_start_mining);
     command_line::add_arg(desc, arg_donate_mining);
     command_line::add_arg(desc, arg_mining_threads);
+    command_line::add_arg(desc, arg_mining_threads_adaptive);
     command_line::add_arg(desc, arg_bg_mining_enable);
     command_line::add_arg(desc, arg_bg_mining_ignore_battery);    
     command_line::add_arg(desc, arg_bg_mining_min_idle_interval_seconds);
@@ -396,6 +483,20 @@ namespace cryptonote
       if(command_line::has_arg(vm, arg_mining_threads))
       {
         m_threads_total = command_line::get_arg(vm, arg_mining_threads);
+      }
+      if(command_line::get_arg(vm, arg_mining_threads_adaptive))
+      {
+        if (m_threads_total != 0)
+        {
+          MGUSER_YELLOW("--mining-threads-adaptive needs --mining-threads 0 (autodetect), ignoring");
+        }
+        else
+        {
+          m_adaptive_threads = true;
+          MGINFO("Adaptive mining enabled: re-autodetect when hashrate stays below "
+              << (int)(ADAPTIVE_DROP_THRESHOLD * 100) << "% of baseline for "
+              << ADAPTIVE_DWELL_SAMPLES << " samples");
+        }
       }
     }
 

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -342,18 +342,7 @@ namespace cryptonote
       m_threads_total = m_threads_autodetect.size();
     }
 
-    // restart all threads
-    {
-      CRITICAL_REGION_LOCAL(m_threads_lock);
-      boost::interprocess::ipcdetail::atomic_write32(&m_stop, 1);
-      while (m_threads_active > 0)
-        misc_utils::sleep_no_w(100);
-      m_threads.clear();
-    }
-    boost::interprocess::ipcdetail::atomic_write32(&m_stop, 0);
-    boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);
-    for(size_t i = 0; i != m_threads_total; i++)
-      m_threads.push_back(boost::thread(m_attrs, boost::bind(&miner::worker_thread, this)));
+    restart_workers();
   }
   //-----------------------------------------------------------------------------------------------------
   void miner::update_adaptive_threads()
@@ -409,23 +398,28 @@ namespace cryptonote
         m_threads_autodetect.push_back({epee::misc_utils::get_ns_count(), (uint64_t)m_total_hashes});
         m_threads_total = 1;
 
-        {
-          CRITICAL_REGION_LOCAL(m_threads_lock);
-          boost::interprocess::ipcdetail::atomic_write32(&m_stop, 1);
-          while (m_threads_active > 0)
-            misc_utils::sleep_no_w(100);
-          m_threads.clear();
-        }
-        boost::interprocess::ipcdetail::atomic_write32(&m_stop, 0);
-        boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);
-        for (size_t i = 0; i != m_threads_total; i++)
-          m_threads.push_back(boost::thread(m_attrs, boost::bind(&miner::worker_thread, this)));
+        restart_workers();
       }
     }
     else
     {
       m_adaptive_low_count = 0;
     }
+  }
+  //-----------------------------------------------------------------------------------------------------
+  void miner::restart_workers()
+  {
+    {
+      CRITICAL_REGION_LOCAL(m_threads_lock);
+      boost::interprocess::ipcdetail::atomic_write32(&m_stop, 1);
+      while (m_threads_active > 0)
+        misc_utils::sleep_no_w(100);
+      m_threads.clear();
+    }
+    boost::interprocess::ipcdetail::atomic_write32(&m_stop, 0);
+    boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);
+    for (size_t i = 0; i != m_threads_total; i++)
+      m_threads.push_back(boost::thread(m_attrs, boost::bind(&miner::worker_thread, this)));
   }
   //-----------------------------------------------------------------------------------------------------
   void miner::init_options(boost::program_options::options_description& desc)

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -119,6 +119,7 @@ namespace cryptonote
     bool request_block_template();
     void  merge_hr();
     void  update_autodetection();
+    void  update_adaptive_threads();
     
     struct miner_config
     {
@@ -155,6 +156,7 @@ namespace cryptonote
     epee::math_helper::once_a_time_seconds<5> m_update_block_template_interval;
     epee::math_helper::once_a_time_seconds<2> m_update_merge_hr_interval;
     epee::math_helper::once_a_time_seconds<1> m_autodetect_interval;
+    epee::math_helper::once_a_time_seconds<60> m_adaptive_interval;
     std::vector<blobdata> m_extra_messages;
     miner_config m_config;
     std::string m_config_folder_path;    
@@ -167,6 +169,10 @@ namespace cryptonote
     bool m_do_print_hashrate;
     bool m_do_mining;
     std::vector<std::pair<uint64_t, uint64_t>> m_threads_autodetect;
+    bool m_adaptive_threads;
+    uint64_t m_adaptive_baseline_hr;
+    uint32_t m_adaptive_low_count;
+    uint64_t m_adaptive_cooldown_until_ms;
     boost::thread::attributes m_attrs;
 
     // background mining stuffs ..

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -139,7 +139,7 @@ namespace cryptonote
     uint64_t m_diffic;
     uint64_t m_height;
     volatile uint32_t m_thread_index; 
-    volatile uint32_t m_threads_total;
+    std::atomic<uint32_t> m_threads_total;
     std::atomic<uint32_t> m_threads_active;
     uint8_t m_donate_percent;
     uint8_t m_donate_counter;

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -120,6 +120,7 @@ namespace cryptonote
     void  merge_hr();
     void  update_autodetection();
     void  update_adaptive_threads();
+    void  restart_workers();
     
     struct miner_config
     {


### PR DESCRIPTION
a laptop running nervad sees its hashrate drop after a heavy app is opened (browser, IDE, etc.). today the only way back to the local optimum is to restart nervad. with this flag, nervad notices the drop and re-tunes itself.

## Summary
- adds opt-in `--mining-threads-adaptive` flag (only honored with `--mining-threads 0`)
- after the existing autodetect locks in, samples the smoothed average from `m_last_hash_rates` every 60s. if it stays below 85% of baseline for 2 ticks, the existing autodetect re-runs and finds the new optimum. 30 min cooldown between re-runs to avoid flapping
- without the flag (default off), nothing changes

design notes:
- the adaptive check runs on the daemon's idle loop, not on a worker thread, and only when the feature is enabled. cost is one mutex acquire + sum of up to 19 `uint64_t` entries every 60s, all off the hot mining path
- re-trigger reuses the existing autodetect machinery (ramps 1 → N), simple and battle-tested
- reaction is asymmetric: we only re-detect on drops, not on improvements, to avoid flapping when conditions oscillate

## Test plan
- [ ] depends matrix is green
- [ ] start nervad with `--start-mining ADDR --mining-threads 0 --mining-threads-adaptive` on a multi-core machine, see the `Adaptive mining enabled` and `baseline locked at X H/s` log lines after the initial autodetect finishes
- [ ] push the host below 85% of baseline for at least ~2 minutes (heavy app, `stress-ng -c N`, etc.), watch the `sample N/2` log lines accumulate, then `hashrate dropped, re-running autodetect`, then the climb back up to the new optimum
- [ ] confirm no second re-trigger within 30 min (cooldown)
- [ ] run without the flag and confirm the existing autodetect path is unchanged

## Possible follow-ups (probably too far-fetched for this PR)
- **ramp down from N-1 instead of up from 1** on re-trigger. would cut the climb from ~50s to ~20-30s when contention has reduced the optimum, but needs modification of the upward-only `update_autodetection()`
- **hook into `merge_hr()` with an EWMA** instead of the 60s gate. faster reaction (~30-60s vs ~98s) but mixes adaptive logic into a single-purpose function
- **per-thread hashrate tracking** to identify which thread is contention-hit and only restart that one