### PR TITLE
fix(epee): drop per-lock sleep_for(0) from CRITICAL_REGION_LOCAL (Boost 1.89 regression)

### DIFF
--- a/contrib/epee/include/syncobj.h
+++ b/contrib/epee/include/syncobj.h
@@ -150,7 +150,7 @@ namespace epee
   };
 
 
-#define  CRITICAL_REGION_LOCAL(x) {boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));}   epee::critical_region_t<decltype(x)>   critical_region_var(x)
+#define  CRITICAL_REGION_LOCAL(x) epee::critical_region_t<decltype(x)>   critical_region_var(x)
 #define  CRITICAL_REGION_BEGIN(x) { boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep())); epee::critical_region_t<decltype(x)>   critical_region_var(x)
 #define  CRITICAL_REGION_LOCAL1(x) {boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));} epee::critical_region_t<decltype(x)>   critical_region_var1(x)
 #define  CRITICAL_REGION_BEGIN1(x) {  boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep())); epee::critical_region_t<decltype(x)>   critical_region_var1(x)


### PR DESCRIPTION
## Summary

`CRITICAL_REGION_LOCAL` unconditionally ran, before taking the lock:

```cpp
boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));
```

`epee::debug::g_test_dbg_lock_sleep()` is a **test-only** race-injection hook that defaults to `0` (only the daemon's hidden `--test-dbg-lock-sleep` arg ever sets it). On the Boost we shipped before #49 this was effectively a no-op, but **after the Boost 1.89 upgrade (#49), `sleep_for(milliseconds(0))` performs a real `pthread_cond_timedwait`** that costs ~1 ms (timer granularity) on **every** `CRITICAL_REGION_LOCAL` acquisition, in every binary.

This PR removes that sleep from `CRITICAL_REGION_LOCAL`.

## Impact

Most visible in `nerva-wallet-cli --generate-new-wallet`: a new wallet expands the default subaddress lookahead (`50 × 200 = 10,000` subaddresses), and each secure (`mlocked`) subaddress key alloc/free takes this lock several times via `epee::mlocker` (`get_page_size`/`lock`/`unlock`) → ~40,000 × ~1 ms ≈ **~40 s of pure sleeping** (the process looks idle in `top`, ~5% CPU).

Root cause confirmed three ways: gdb stack-sampling (5/5 samples parked in `sleep_for → cond_timedwait` under `CRITICAL_REGION_LOCAL` → `mlocker` → `get_subaddress_spend_public_keys`), `strace -c` (~40k `futex` / ~40k `ETIMEDOUT`, ~0 s of actual syscall work), and a `--subaddress-lookahead` sweep.

## Fix — follows upstream Monero

```diff
-#define  CRITICAL_REGION_LOCAL(x) {boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));}   epee::critical_region_t<decltype(x)>   critical_region_var(x)
+#define  CRITICAL_REGION_LOCAL(x) epee::critical_region_t<decltype(x)>   critical_region_var(x)
```

Upstream Monero hit and fixed the same problem. On `monero/master`, `CRITICAL_REGION_LOCAL` no longer sleeps:

```cpp
// monero/master — contrib/epee/include/syncobj.h
#define  CRITICAL_REGION_LOCAL(x) boost::unique_lock critical_region_var(x)
```

This PR makes the same decision: **drop the sleep from `CRITICAL_REGION_LOCAL` (the hot macro), and keep it in `CRITICAL_REGION_BEGIN` / `_LOCAL1` / `_BEGIN1`** — exactly as upstream keeps it in `_BEGIN` / `_LOCAL1`. `--test-dbg-lock-sleep` therefore still works at those non-hot sites.

**Scope note / intentional divergence:** upstream additionally replaced `epee::critical_section` and `critical_region_t` with `using critical_section = boost::recursive_mutex;` + `boost::unique_lock`. That's a codebase-wide locking-primitive refactor; this PR deliberately keeps Nerva's existing `critical_region_t` to stay scoped to the perf fix. Fully tracking that epee refactor can be done separately.

## Verification (`aarch64-linux-gnu`, built via `depends`/Boost 1.89, measured head-to-head in the same container)

| Binary | `--subaddress-lookahead` | `--generate-new-wallet` |
| --- | --- | --- |
| current release | `50:200` (default) | **44.1 s** |
| current release | `1:1` | 3.0 s |
| **this PR** | `50:200` (default) | **3.2 – 4.5 s** |
| this PR | `1:1` | ~3 s |

~12× faster at the default lookahead, and subaddress count no longer affects timing (`50:200` ≈ `1:1`) — confirming the per-lock sleep was the cost. The residual ~3.5 s is unrelated 2× RSA-4096 SSL cert generation, not touched here.

This is a process-wide change (every `CRITICAL_REGION_LOCAL`), so it also speeds up daemon block sync — measured separately, see comment below.
