### PR TITLE
fix(blockchain): read uncommitted batch blocks in build_block_cache (HF7/CNA v2 sync crash)

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2397,32 +2397,24 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
 
   m_block_cache.reserve(height);
 
-  // Always use a fresh read-only transaction. get_block_sync_size() caps the
-  // batch at BLOCKS_SYNCHRONIZING_SAFE_BATCH_COUNT (256), matching the
-  // stable_height offset of height-256 used by all CNA PoW variants, so
-  // stable_height blocks are always committed and visible to a read txn.
-  // Using the write txn here caused EINVAL from mdb_cursor_open on Windows
-  // (write txn is not valid for read-cursor operations in all LMDB states).
-  MDB_txn *txn;
-  if (auto r = lmdb_txn_begin(m_env, NULL, MDB_RDONLY, &txn, 0))
-    throw0(DB_ERROR(lmdb_error("Failed to create a transaction for the db: ", r).c_str()));
-
-  MDB_cursor *cur = nullptr;
-  if (auto r = mdb_cursor_open(txn, m_block_info, &cur))
-  {
-    mdb_txn_abort(txn);
-    throw0(DB_ERROR(lmdb_error("Failed to open block_info cursor for block cache: ", r).c_str()));
-  }
+  // Read block_info via the standard batch-aware cursor pattern. During batch
+  // sync, block_rtxn_start returns the active write txn and its already-open
+  // block_info cursor, so blocks added in the current (uncommitted) batch are
+  // visible. CNA v2 (HF7) requires this: it caches through height+1, i.e. the
+  // block currently being validated, which is still in the batch write txn.
+  // Reusing the existing cursor (rather than opening a new one) also avoids the
+  // EINVAL that mdb_cursor_open returns for a write txn under MDB_WRITEMAP on
+  // Windows -- the reason #90 switched to a fresh read-only txn, which could not
+  // see the in-batch block and so reintroduced the HF7 sync failure fixed in #65.
+  // Outside a batch, block_rtxn_start opens a fresh read-only txn.
+  TXN_PREFIX_RDONLY();
+  RCURSOR(block_info);
 
   for (uint64_t index = m_block_cache.size(); index < height; ++index)
   {
     MDB_val_set(query, index);
-    if (auto r = mdb_cursor_get(cur, (MDB_val*)&zerokval, &query, MDB_GET_BOTH))
-    {
-      mdb_cursor_close(cur);
-      mdb_txn_abort(txn);
+    if (auto r = mdb_cursor_get(m_cur_block_info, (MDB_val*)&zerokval, &query, MDB_GET_BOTH))
       throw0(DB_ERROR(lmdb_error("Failed to read block_info record for block cache: ", r).c_str()));
-    }
     const mdb_block_info *bi = (const mdb_block_info*)query.mv_data;
     block_cache_data entry;
     entry.hash      = bi->bi_hash;
@@ -2432,8 +2424,6 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
     m_block_cache.push_back(entry);
   }
 
-  mdb_cursor_close(cur);
-  mdb_txn_abort(txn);
   m_block_cache_height.store(height, std::memory_order_release);
   CRITICAL_REGION_END();
 }


### PR DESCRIPTION
## Summary

A full-PoW sync (no `--quicksync`) **crashes/halts at block ~173,500 (HF7)** with:

```
W Failed to read block_info record for block cache: MDB_NOTFOUND: No matching key/data pair found
E Exception at [core::handle_incoming_block()], what=Failed to read block_info record for block cache: MDB_NOTFOUND
I nervad is now disconnected from the network
```

The node then repeatedly drops peers and cannot advance past HF7. Reported by community sync testing (banner `0.2.2.0-013cb0c64`); reproduced here.

## Root cause — the #65 ↔ #90 interaction

- **#65** (`a01db4b`, sync perf) made `get_cna_v2_data` read its hashes from the in-memory block cache, calling **`build_block_cache(height + 1)`** — which must read block `height`, the block currently being validated. At HF7 (173,500) CNA v2 first activates and that block is still inside the **uncommitted batch write txn**. #65 handled this by reusing the write txn in `build_block_cache`.
- **#90** (`51ae77b`, Windows crash fix) switched `build_block_cache` back to a **fresh read-only txn** to avoid an `EINVAL` from `mdb_cursor_open` on a write txn under `MDB_WRITEMAP` on Windows — on the premise that *"all CNA PoW variants look up `height-256`"*. That is true for **CNA v3/v4/v5** (they read the stable height − 256, always committed, which is why the batch is capped at 256), but **false for CNA v2**, which reaches `height + 1`. A read-only txn cannot see the in-batch block → `MDB_NOTFOUND`.

So #90 re-introduced exactly the HF7 failure #65 had fixed. Both commits are already in **v0.2.2.0**, so this affects the release too — it's just **masked by `--quicksync`** (quicksync verification skips `get_block_longhash`, so the CNA v2 path is never exercised). A from-genesis full-PoW sync hits it deterministically at HF7.

`HF7 = 173,500`, `HF8 = 180,000` (mainnet hardfork table) → CNA v2 window is `[173500, 180000)`, matching the observed crash height (173,502).

## Fix

Make `build_block_cache` use the file's standard **batch-aware** read pattern instead of a hand-rolled read-only txn:

```cpp
TXN_PREFIX_RDONLY();
RCURSOR(block_info);
```

- During a batch, `block_rtxn_start` returns the **active write txn** + its cursors, so uncommitted in-batch blocks are visible → **fixes CNA v2 at HF7**.
- `RCURSOR` **reuses the already-open `block_info` cursor** rather than calling `mdb_cursor_open` on the write txn → **keeps #90's Windows `MDB_WRITEMAP` fix** (no `EINVAL`).
- Outside a batch it opens a fresh read-only txn, exactly as before.

This is the same pattern ~15 existing readers (`get_block_timestamp`, `get_block_info_64bit_fields`, …) already use during block add, so it's proven safe on the write-batch path. CNA v3/v4/v5 are unaffected (`get_cna_v3_data` reads committed stable-height blocks via its own read-only txn; v4/v5 go through `build_block_cache` and benefit from the same fix). Net diff: **+13 / −23** in one function.

## Testing

- Compiles for `aarch64-linux-gnu` via the `depends` toolchain.
- **Needs a full-PoW sync test across HF7** (no `--quicksync`, fresh data dir from genesis): it should now pass 173,500 → 180,000 without `MDB_NOTFOUND` and continue syncing. (My local repro is peer-limited to ~18 blk/s, so I'm handing the cross-HF7 sync validation to community testers with faster sync.)

## Notes

- Independent of #97 (the `CRITICAL_REGION_LOCAL` lock-sleep perf fix). That PR's sync-speed past HF7 can't be validated until this crash fix lands, so this should likely merge first.
- Credit: community sync testing surfaced the crash and traced it to the #65/#90 conflict.
