### PR TITLE
fix(common): defer Ctrl-C handling off signal context (FreeBSD coredump)

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -137,6 +137,10 @@ namespace tools
   }
 
   std::function<void(int)> signal_handler::m_handler;
+#if !defined(WIN32)
+  int signal_handler::m_pipe[2] = { -1, -1 };
+  boost::once_flag signal_handler::m_dispatch_once;
+#endif
 
   private_file::private_file() noexcept : m_handle(), m_filename() {}
 

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -183,13 +183,9 @@ namespace tools
       }
       return r;
 #else
-      // The real handler must never run in async-signal context: it locks a
-      // mutex and dispatches into arbitrary C++ (logging, allocation, more
-      // locks). That is undefined behaviour per POSIX. glibc tolerates it in
-      // practice, but FreeBSD's libthr aborts (coredump) when pthread state is
-      // touched from a signal handler. So the signal handler only does
-      // async-signal-safe work (a single write() to a self-pipe) and a
-      // dedicated thread runs m_handler in normal thread context.
+      // Mutex locks + arbitrary C++ in m_handler aren't async-signal-safe;
+      // FreeBSD's libthr aborts when pthread state is touched from a handler.
+      // Defer the real work to a thread fed by an async-signal-safe write().
       boost::call_once(m_dispatch_once, &signal_handler::start_dispatch_thread);
       m_handler = t;
 
@@ -222,21 +218,15 @@ namespace tools
       return TRUE;
     }
 #else
-    /*! \brief async-signal-safe handler for NIX
-     *
-     * Runs in signal context, so it must only call async-signal-safe
-     * functions. It records the signal number on a self-pipe; the dispatch
-     * thread (signal_dispatch_thread) picks it up and runs the real handler.
-     */
+    /*! \brief async-signal-safe NIX handler: records the signal on the
+     *  self-pipe; signal_dispatch_thread runs the real handler. */
     static void posix_handler(int type)
     {
       const unsigned char sig = (unsigned char)type;
-      // write() is async-signal-safe; ignore the result (errno is preserved by
-      // the kernel only across this call, and there is nothing safe to do on
-      // failure inside a signal handler anyway).
+      // write() is async-signal-safe; nothing safe to do on failure.
       const int saved_errno = errno;
       while (write(m_pipe[1], &sig, 1) < 0 && errno == EINTR) {}
-      errno = saved_errno;
+      errno = saved_errno; // restore for the interrupted code
     }
 
     /*! \brief sets up the self-pipe and the dispatch thread (once) */

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -33,10 +33,13 @@
 
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/thread.hpp>
+#include <boost/thread/once.hpp>
 #include <boost/optional.hpp>
 #include <system_error>
 #include <csignal>
 #include <cstdio>
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <string>
@@ -44,6 +47,10 @@
 #ifdef _WIN32
 #include "windows.h"
 #include "misc_log_ex.h"
+#else
+#include <unistd.h>
+#include <fcntl.h>
+#include <cerrno>
 #endif
 
 #include "crypto/hash.h"
@@ -176,6 +183,16 @@ namespace tools
       }
       return r;
 #else
+      // The real handler must never run in async-signal context: it locks a
+      // mutex and dispatches into arbitrary C++ (logging, allocation, more
+      // locks). That is undefined behaviour per POSIX. glibc tolerates it in
+      // practice, but FreeBSD's libthr aborts (coredump) when pthread state is
+      // touched from a signal handler. So the signal handler only does
+      // async-signal-safe work (a single write() to a self-pipe) and a
+      // dedicated thread runs m_handler in normal thread context.
+      boost::call_once(m_dispatch_once, &signal_handler::start_dispatch_thread);
+      m_handler = t;
+
       static struct sigaction sa;
       memset(&sa, 0, sizeof(struct sigaction));
       sa.sa_handler = posix_handler;
@@ -184,7 +201,6 @@ namespace tools
       sigaction(SIGINT, &sa, NULL);
       signal(SIGTERM, posix_handler);
       signal(SIGPIPE, SIG_IGN);
-      m_handler = t;
       return true;
 #endif
     }
@@ -206,10 +222,49 @@ namespace tools
       return TRUE;
     }
 #else
-    /*! \brief handler for NIX */
+    /*! \brief async-signal-safe handler for NIX
+     *
+     * Runs in signal context, so it must only call async-signal-safe
+     * functions. It records the signal number on a self-pipe; the dispatch
+     * thread (signal_dispatch_thread) picks it up and runs the real handler.
+     */
     static void posix_handler(int type)
     {
-      handle_signal(type);
+      const unsigned char sig = (unsigned char)type;
+      // write() is async-signal-safe; ignore the result (errno is preserved by
+      // the kernel only across this call, and there is nothing safe to do on
+      // failure inside a signal handler anyway).
+      const int saved_errno = errno;
+      while (write(m_pipe[1], &sig, 1) < 0 && errno == EINTR) {}
+      errno = saved_errno;
+    }
+
+    /*! \brief sets up the self-pipe and the dispatch thread (once) */
+    static void start_dispatch_thread()
+    {
+      if (pipe(m_pipe) != 0)
+        return;
+      // Make the write end non-blocking so the signal handler can never block.
+      const int flags = fcntl(m_pipe[1], F_GETFL, 0);
+      if (flags != -1)
+        fcntl(m_pipe[1], F_SETFL, flags | O_NONBLOCK);
+      boost::thread(&signal_handler::signal_dispatch_thread).detach();
+    }
+
+    /*! \brief normal-context thread that drains the self-pipe */
+    static void signal_dispatch_thread()
+    {
+      for (;;)
+      {
+        unsigned char sig = 0;
+        const ssize_t r = read(m_pipe[0], &sig, 1);
+        if (r > 0)
+          handle_signal((int)sig);
+        else if (r == 0)
+          return; // pipe closed
+        else if (errno != EINTR)
+          return; // unrecoverable read error
+      }
     }
 #endif
 
@@ -223,6 +278,12 @@ namespace tools
 
     /*! \brief where the installed handler is stored */
     static std::function<void(int)> m_handler;
+#if !defined(WIN32)
+    /*! \brief self-pipe used to defer signal handling out of signal context */
+    static int m_pipe[2];
+    /*! \brief guards one-time setup of the self-pipe and dispatch thread */
+    static boost::once_flag m_dispatch_once;
+#endif
   };
 
   void set_strict_default_file_permissions(bool strict);


### PR DESCRIPTION
On FreeBSD, pressing Ctrl-C on a running daemon aborts in libthr instead of stopping cleanly:

```
Fatal error 'thread 0x... was already on queue.'
  at line 285 in file /usr/src/lib/libthr/thread/thr_cond.c (errno = 19)
Abort trap (core dumped)
```

`signal_handler::posix_handler` does the real work in signal context: `handle_signal()` takes a `boost::mutex` and calls `m_handler` (`stop_p2p` -> `send_stop_signal` for the daemon). That touches pthread mutex/condvar from the handler, which is not async-signal-safe; libthr aborts there, glibc happens not to. At an idle interactive prompt the main loop sits in the console reader's condvar wait (`console_handler.h`), which is the thread SIGINT interrupts.

It's the same `send_stop_signal()` the `exit` command reaches (`stop_daemon` -> `on_stop_daemon`), so Ctrl-C and `exit` are meant to behave the same.

## Fix

Move the work out of signal context. `posix_handler` now only writes the signal number to a self-pipe (`write()` is async-signal-safe); a worker thread, started once via `boost::call_once`, drains the pipe and runs `handle_signal()`/`m_handler` in normal thread context. The interrupted thread no longer makes any pthread call from the handler.

Self-pipe rather than `sem_init` (unnamed semaphores are unsupported on macOS); `pipe()`/`read()`/`write()` work on Linux, FreeBSD and macOS. Windows path unchanged.