### PR TITLE
feat: revalidate txpool at hard fork boundaries

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -601,6 +601,8 @@ block Blockchain::pop_block_from_blockchain()
   block popped_block;
   std::vector<transaction> popped_txs;
 
+  const uint8_t previous_hf_version = get_current_hard_fork_version();
+
   CHECK_AND_ASSERT_THROW_MES(m_db->height() > 1, "Cannot pop the genesis block");
   try
   {
@@ -665,6 +667,13 @@ block Blockchain::pop_block_from_blockchain()
   crypto::hash top_block_hash = get_tail_id(top_block_height);
   m_tx_pool.on_blockchain_dec(top_block_height, top_block_hash);
   invalidate_block_template_cache();
+
+  const uint8_t new_hf_version = get_current_hard_fork_version();
+  if (new_hf_version != previous_hf_version)
+  {
+    MINFO("Validating txpool for v" << (unsigned)new_hf_version);
+    m_tx_pool.validate(new_hf_version);
+  }
 
   return popped_block;
 }
@@ -3757,6 +3766,19 @@ leave:
   m_tx_pool.on_blockchain_inc(new_height, id);
   get_difficulty_for_next_block(); // just to cache it
   invalidate_block_template_cache();
+
+  const uint8_t new_hf_version = get_current_hard_fork_version();
+  if (new_hf_version != hf_version)
+  {
+    // the genesis block is added before everything's setup, and the txpool is empty
+    // when we start from scratch, so we skip this
+    const bool is_genesis_block = new_height == 1;
+    if (!is_genesis_block)
+    {
+      MGINFO("Validating txpool for v" << (unsigned)new_hf_version);
+      m_tx_pool.validate(new_hf_version);
+    }
+  }
 
   std::shared_ptr<tools::Notify> block_notify = m_block_notify;
   if (block_notify)

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1335,61 +1335,66 @@ namespace cryptonote
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
-    size_t tx_weight_limit = get_transaction_weight_limit(version);
-    std::unordered_set<crypto::hash> remove;
+    MINFO("Validating txpool contents for v" << (unsigned)version);
 
-    m_txpool_weight = 0;
-    m_blockchain.for_all_txpool_txes([this, &remove, tx_weight_limit](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata*) {
-      m_txpool_weight += meta.weight;
-      if (meta.weight > tx_weight_limit) {
-        LOG_PRINT_L1("Transaction " << txid << " is too big (" << meta.weight << " bytes), removing it from pool");
-        remove.insert(txid);
-      }
-      else if (m_blockchain.have_tx(txid)) {
-        LOG_PRINT_L1("Transaction " << txid << " is in the blockchain, removing it from pool");
-        remove.insert(txid);
-      }
+    LockedTXN lock(m_blockchain);
+
+    struct tx_entry_t
+    {
+      crypto::hash txid;
+      txpool_tx_meta_t meta;
+    };
+
+    // get all txids
+    std::vector<tx_entry_t> txes;
+    m_blockchain.for_all_txpool_txes([&txes](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata*) {
+      if (!meta.pruned) // skip pruned txes
+        txes.push_back({txid, meta});
       return true;
     }, false);
 
-    size_t n_removed = 0;
-    if (!remove.empty())
+    // take them all out and add them back in, some might fail to validate against the new rules
+    size_t added = 0;
+    size_t take_failed = 0;
+    for (auto &e: txes)
     {
-      LockedTXN lock(m_blockchain);
-      for (const crypto::hash &txid: remove)
+      try
       {
-        try
+        size_t weight;
+        uint64_t fee;
+        cryptonote::transaction tx;
+        cryptonote::blobdata blob;
+        bool relayed, do_not_relay, double_spend_seen, pruned;
+        if (!take_tx(e.txid, tx, blob, weight, fee, relayed, do_not_relay, double_spend_seen, pruned))
         {
-          cryptonote::blobdata txblob = m_blockchain.get_txpool_tx_blob(txid);
-          cryptonote::transaction tx;
-          if (!parse_and_validate_tx_from_blob(txblob, tx))
-          {
-            MERROR("Failed to parse tx from txpool");
-            continue;
-          }
-          // remove tx from db first
-          m_blockchain.remove_txpool_tx(txid);
-          m_txpool_weight -= get_transaction_weight(tx, txblob.size());
-          remove_transaction_keyimages(tx, txid);
-          auto sorted_it = find_tx_in_sorted_container(txid);
-          if (sorted_it == m_txs_by_fee_and_receive_time.end())
-          {
-            LOG_PRINT_L1("Removing tx " << txid << " from tx pool, but it was not found in the sorted txs container!");
-          }
-          else
-          {
-            m_txs_by_fee_and_receive_time.erase(sorted_it);
-          }
-          ++n_removed;
+          // take_tx also fails on transient DB errors where the tx is still valid, so leave it
+          // in place rather than dropping it, and don't run add_tx on an empty transaction
+          MERROR("Failed to take tx " << e.txid << " from txpool for re-validation, leaving it in place");
+          ++take_failed;
+          continue;
         }
-        catch (const std::exception &e)
+
+        cryptonote::tx_verification_context tvc{};
+        // re-add with kept_by_block=false so the full consensus validation path runs against the new fork version
+        if (!add_tx(tx, e.txid, blob, e.meta.weight, tvc, false, relayed, do_not_relay, version))
         {
-          MERROR("Failed to remove invalid tx from pool");
-          // continue
+          MINFO("Failed to re-validate tx " << e.txid << " for v" << (unsigned)version << ", dropped");
+          continue;
         }
+        m_blockchain.update_txpool_tx(e.txid, e.meta);
+        ++added;
       }
-      lock.commit();
+      catch (const std::exception &)
+      {
+        MERROR("Failed to re-validate tx from pool");
+        continue;
+      }
     }
+
+    lock.commit();
+
+    // txes left in place by a failed take_tx were not removed, so exclude them from the count
+    const size_t n_removed = txes.size() - added - take_failed;
     if (n_removed > 0)
       ++m_cookie;
     return n_removed;


### PR DESCRIPTION
Port of Monero PR #7169 (adapted to Nerva v0.15). On a fork crossing, re-run full
validation on pooled txs so ones invalid under the new rules are flushed before
they can be mined or re-added on reorg. Only fires on an actual hf version change.

- **blockchain.cpp**: trigger `validate()` on hf version change in
  `handle_block_to_main_chain` and `pop_block_from_blockchain`
- **tx_pool.cpp**: rewrite `validate()` to take out and re-add each tx via
  `add_tx(kept_by_block=false)`

**Testing:** Sync a node and confirm `Validating txpool for v<N>` logs only when
crossing a fork height (never per-block). On a testnet with a low fork height, put
txs in the mempool, mine across the fork, and confirm still-valid txs survive.