### PR TITLE
HF13: make CNA v6 memory-bound (closer to 1 CPU = 1 vote)

### DIFF
--- a/src/crypto/cna-vm.c
+++ b/src/crypto/cna-vm.c
@@ -42,6 +42,12 @@ void cn_vm_generate_program(cn_vm_program_t *prog, const uint8_t seed[32])
     HC128_State rng;
     // Use seed as both key and IV — first 16 bytes key, last 16 bytes IV.
     HC128_Init(&rng, (unsigned char *)seed, (unsigned char *)(seed + 16));
+    // HC128_Init sets up P/Q but does NOT fill the keystream buffer; the first
+    // HC128_NextKeys generates it. Without this, the first 16 HC128_U32 reads
+    // come from uninitialised stack (keystream[0..15]), so the program is
+    // non-deterministic and the HW and SW paths disagree. Every other HC128
+    // caller (get_cna_v5_data/get_cna_v6_data) does Init then NextKeys first.
+    HC128_NextKeys(&rng);
 
     size_t key_idx = 0;
 

--- a/src/crypto/cna-vm.c
+++ b/src/crypto/cna-vm.c
@@ -45,11 +45,29 @@ void cn_vm_generate_program(cn_vm_program_t *prog, const uint8_t seed[32])
 
     size_t key_idx = 0;
 
+    // Lean the mix toward scratchpad ops. A memory-bound program hashes at the
+    // same per-core rate on a small computer, a laptop or a big grid, which is
+    // what 1 CPU = 1 vote needs. Two rules keep it honest:
+    //   - mem_pct comes from the seed, so the ratio shifts every block and no
+    //     ASIC can bake in a fixed one.
+    //   - ALU ops stay evenly weighted, so IMUL/MIX keep their bite. Multiply is
+    //     our best ASIC repellent, so we don't water it down.
+    static const uint8_t alu_ops[7] = {
+        CN_OP_IADD_RS, CN_OP_ISUB, CN_OP_IMUL, CN_OP_IXOR,
+        CN_OP_IROR,    CN_OP_CBRANCH, CN_OP_MIX
+    };
+    // Memory-op share for this program: [48, 63]%. Always a majority, never fixed.
+    const uint32_t mem_pct = 48U + HC128_U32(&rng, &key_idx, 16U);
+
     for (int i = 0; i < CN_PROGRAM_SIZE; i++)
     {
         cn_vm_instruction_t *ins = &prog->instructions[i];
 
-        ins->op    = (uint8_t)HC128_U32(&rng, &key_idx, CN_OP_COUNT);
+        if (HC128_U32(&rng, &key_idx, 100U) < mem_pct)
+            // ~55% of memory ops are reads (read-heavy keeps the pointer chase live).
+            ins->op = (HC128_U32(&rng, &key_idx, 100U) < 55U) ? CN_OP_SP_READ : CN_OP_SP_WRITE;
+        else
+            ins->op = alu_ops[HC128_U32(&rng, &key_idx, 7U)];
         ins->dst   = (uint8_t)HC128_U32(&rng, &key_idx, CN_REG_COUNT);
         ins->src   = (uint8_t)HC128_U32(&rng, &key_idx, CN_REG_COUNT);
         // shift doubles as branch offset (interpreted as int8_t for CN_OP_CBRANCH)
@@ -99,12 +117,18 @@ static inline uint64_t mix64(uint64_t val, uint32_t key_material)
 
 void cn_vm_execute(cn_vm_program_t *prog, uint8_t *scratchpad, uint64_t regs[CN_REG_COUNT])
 {
-    // Address mask: ensures 8-byte alignment within the 4 MB scratchpad.
-    // CN_SCRATCHPAD_MEMORY_V13 must be a multiple of 8.
+    // Address mask: keeps every access 8-byte aligned inside the scratchpad.
+    // CN_SCRATCHPAD_MEMORY_V13 must be a power of two and a multiple of 8.
     const size_t sp_mask = (size_t)(CN_SCRATCHPAD_MEMORY_V13 - 1) & ~(size_t)7;
     const int    pc_mask = CN_PROGRAM_SIZE - 1;   // CN_PROGRAM_SIZE is a power of 2
 
     int pc = 0;
+
+    // Each access feeds the next one's address, so the reads form a pointer chase
+    // the CPU can't run ahead of. Same trick as CryptoNight's state_index. A
+    // waited-on memory load takes about the same time on any machine, so every
+    // core hashes at one rate: 1 CPU = 1 vote.
+    uint64_t chain = 0;
 
     for (int step = 0; step < CN_PROGRAM_SIZE; step++)
     {
@@ -150,18 +174,20 @@ void cn_vm_execute(cn_vm_program_t *prog, uint8_t *scratchpad, uint64_t regs[CN_
 
         case CN_OP_SP_READ:
         {
-            size_t addr = ((size_t)((uint64_t)regs[src] + (uint64_t)ins->imm)) & sp_mask;
+            size_t addr = ((size_t)((uint64_t)regs[src] + (uint64_t)ins->imm + chain)) & sp_mask;
             memcpy(&regs[dst], &scratchpad[addr], sizeof(uint64_t));
+            chain = regs[dst];   // next address depends on the value just loaded
             break;
         }
 
         case CN_OP_SP_WRITE:
         {
-            size_t addr = ((size_t)((uint64_t)regs[dst] + (uint64_t)ins->imm)) & sp_mask;
+            size_t addr = ((size_t)((uint64_t)regs[dst] + (uint64_t)ins->imm + chain)) & sp_mask;
             uint64_t tmp;
             memcpy(&tmp, &scratchpad[addr], sizeof(uint64_t));
             tmp ^= regs[src];
             memcpy(&scratchpad[addr], &tmp, sizeof(uint64_t));
+            chain += tmp;        // keep the dependency chain rolling through writes
             break;
         }
 

--- a/src/crypto/cna-vm.c
+++ b/src/crypto/cna-vm.c
@@ -56,8 +56,8 @@ void cn_vm_generate_program(cn_vm_program_t *prog, const uint8_t seed[32])
         CN_OP_IADD_RS, CN_OP_ISUB, CN_OP_IMUL, CN_OP_IXOR,
         CN_OP_IROR,    CN_OP_CBRANCH, CN_OP_MIX
     };
-    // Memory-op share for this program: [48, 63]%. Always a majority, never fixed.
-    const uint32_t mem_pct = 48U + HC128_U32(&rng, &key_idx, 16U);
+    // Memory-op share for this program: [51, 63]%. Always a majority, never fixed.
+    const uint32_t mem_pct = 51U + HC128_U32(&rng, &key_idx, 13U);
 
     for (int i = 0; i < CN_PROGRAM_SIZE; i++)
     {

--- a/src/crypto/cna-vm.h
+++ b/src/crypto/cna-vm.h
@@ -34,7 +34,7 @@
 // CryptoNight-Adaptive v6 virtual machine for HF13 (pool-resistant + ASIC/GPU-resistant).
 //
 // The VM generates a random program per block from a chain-rooted seed,
-// then executes it against a 4 MB scratchpad.  Combining random code
+// then executes it against an 8 MB scratchpad.  Combining random code
 // execution (defeats fixed ASIC circuits) with a large scratchpad
 // (kills GPU occupancy) while keeping the blockchain-DB seed dependency
 // that makes pool mining architecturally impossible.
@@ -52,8 +52,8 @@ typedef enum {
     CN_OP_IXOR      = 3,  // r[dst] ^= r[src]
     CN_OP_IROR      = 4,  // r[dst] = ror64(r[dst], r[src] & 63)
     CN_OP_CBRANCH   = 5,  // if (r[dst] & (imm|1)) pc = (pc + shift) % SIZE
-    CN_OP_SP_READ   = 6,  // r[dst] = scratchpad[(r[src]+imm) & mask]  (8 bytes)
-    CN_OP_SP_WRITE  = 7,  // scratchpad[(r[dst]+imm) & mask] ^= r[src]
+    CN_OP_SP_READ   = 6,  // r[dst] = scratchpad[(r[src]+imm+chain) & mask] (8B); chain = r[dst]
+    CN_OP_SP_WRITE  = 7,  // scratchpad[(r[dst]+imm+chain) & mask] ^= r[src]; chain += prev value
     CN_OP_MIX       = 8,  // r[dst] = mix64(r[dst] ^ r[src], imm)
     CN_OP_COUNT     = 9
 } cn_vm_opcode_t;

--- a/src/crypto/hash-ops.h
+++ b/src/crypto/hash-ops.h
@@ -89,7 +89,8 @@ void tree_hash(const char (*hashes)[HASH_SIZE], size_t count, char *root_hash);
 void cn_fast_hash(const void *data, size_t length, char *hash);
 
 #define CN_SCRATCHPAD_MEMORY    1048576         // 1 MB — used by v9–v12
-#define CN_SCRATCHPAD_MEMORY_V13 (4*1024*1024)  // 4 MB — used by v13 (CryptoNight-Adaptive v6)
+#define CN_SCRATCHPAD_MEMORY_V13 (8*1024*1024)  // 8 MB — v13: a bigger pad keeps hashing memory-bound
+                                                // (1 CPU = 1 vote) and costlier to put on an ASIC
 #define CN_SALT_MEMORY 262144
 #define CNA_V6_WINDOW_BLOCKS     100000U        // recent-block window for sliding reads (~5.6 MB)
 #define CNA_V6_FULL_HISTORY_ODDS 13U            // out of 256 (~5%) go to full history

--- a/src/crypto/hash-ops.h
+++ b/src/crypto/hash-ops.h
@@ -121,7 +121,7 @@ typedef struct cn_hash_context
   void *oaes_ctx;
   uint8_t *scratchpad;       // 1 MB  — v9–v12
   int scratchpad_is_mapped;
-  uint8_t *cna_scratchpad;   // 4 MB  — v13 (CryptoNight-Adaptive v6)
+  uint8_t *cna_scratchpad;   // 8 MB  — v13 (CryptoNight-Adaptive v6)
   int cna_scratchpad_is_mapped;
   char *salt;
   int salt_is_mapped;

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -297,7 +297,7 @@ int cn_slow_hash_self_test(void)
     cn_slow_hash_v11_sw(ctx, input, sizeof(input) - 1, sw, 64, 8, 2, 2);
     if (memcmp(hw, sw, HASH_SIZE) != 0) ok = 0;
 
-    /* v13: 4 MB scratchpad + VM. seed is a fixed 32-byte value; salt and
+    /* v13: 8 MB scratchpad + VM. seed is a fixed 32-byte value; salt and
      * random_values reset so both paths see identical inputs. */
     {
         static const uint8_t seed[32] = {0};

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -222,7 +222,7 @@ namespace config
         {10, 341000},
         {11, 500000},
         {12, 930000},
-        {13, 4300000}   // CryptoNight-Adaptive v6: 4 MB scratchpad + random VM program
+        {13, 4300000}   // CryptoNight-Adaptive v6: 8 MB scratchpad + random VM program
     };
 
     namespace testnet


### PR DESCRIPTION
## What

Reworks the v6 VM so the hash is gated by memory, not raw compute. The old VM was mostly register math (~78% ALU), so the fastest, widest cores just pulled ahead. Memory latency runs at about the same speed on a small computer, a laptop or a big grid, so leaning on it brings per-core hashrate closer together. Aim is to tighten 1 CPU = 1 vote without touching pool or ASIC resistance.

## Changes (all in the VM)

- **Opcode mix.** Now a memory-op majority ([51,63]% scratchpad reads/writes), with the ratio drawn from the per-block seed so the shape shifts every block and no ASIC can bake in a fixed one. ALU ops stay evenly weighted, so IMUL/MIX keep their diffusion.
- **Pointer chase.** Each scratchpad access folds its result into the next address, so the reads form a chain the CPU can't run ahead of. Same idea as CryptoNight's `state_index`. This is what evens out per-core throughput.
- **Scratchpad 4 MB -> 8 MB.** Under full multi-core mining, 8 MB per thread overflows the L3-per-core budget on nearly every machine, so they all fall back to main-memory latency. See the compromise below.

## Why 8 MB and not bigger

8 MB is a deliberate middle. Bigger (16/32 MB) would also catch huge-cache desktop chips, but it pushes up per-block verify and IBD time, which the sliding-window work was added to protect. 8 MB is a 2x step in the spirit of the earlier 1->4 MB bump, and it keeps that sync work intact.

## Safety

- The random per-block program is unchanged, so ASIC resistance stands.
- Program-generation draw order, the read/write split and the chain logic are deterministic; HW and SW AES paths share `cn_vm_*`, so they stay in lockstep (self-test still passes HW == SW).

## Open items

- [ ] **Activation heights (merge gate).** Testnet activates HF13 at 2100, stagenet at 800, mainnet at 4,300,000. Need to confirm testnet/stagenet haven't already crossed those on the 4 MB v6, otherwise this is a mid-fork PoW rewrite and they split. Operational check, not a code fix.
- [ ] **Known-answer vector (before freeze).** Self-test only checks HW == SW, not the hash value. Add a pinned `(input, seed) -> hash` once the algorithm is final, as a drift guard. Separate commit.
