### PR TITLE
feat(ios): ship a device + simulator .xcframework

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -150,21 +150,19 @@ jobs:
                     path: |
                         build/${{ matrix.toolchain.host }}/release/bin/nerva*
 
-    # iOS has no Linux cross path (no iphoneos SDK to host, no Linux->iphoneos
-    # toolchain), so it builds native on macOS with the runner's Xcode. Deps still
-    # go through contrib/depends (apple-ios host). iOS ships a wallet library, not
-    # daemons, so we build the wallet_api target.
+    # iOS has no Linux cross path (no iphoneos SDK to host), so it builds native on
+    # macOS with the runner's Xcode. Deps go through contrib/depends; iOS ships a
+    # wallet library (wallet_api), not daemons. We build two slices - arm64 device
+    # and arm64 simulator - and bundle them into one .xcframework, since lipo can't
+    # combine same-arch/different-platform slices.
     build-ios:
+        name: ARMv8 iOS (xcframework)
         runs-on: macos-14
-        timeout-minutes: 120
-        strategy:
-            fail-fast: false
-            matrix:
-                toolchain:
-                    -   name: "ARMv8 iOS"
-                        host: "aarch64-apple-ios"
-                        artifact-name: "nerva-ios-armv8"
-        name: ${{ matrix.toolchain.name }}
+        timeout-minutes: 180
+        env:
+            DEVICE_HOST: aarch64-apple-ios
+            SIM_HOST: aarch64-apple-iossimulator
+            ARTIFACT: nerva-ios-armv8
         steps:
             -   name: Install dependencies
                 run: brew install autoconf automake libtool pkg-config gperf ccache coreutils
@@ -184,46 +182,57 @@ jobs:
                 uses: actions/cache@v5
                 with:
                     path: ~/Library/Caches/ccache
-                    key: ccache-${{ matrix.toolchain.host }}-${{ github.sha }}
-                    restore-keys: ccache-${{ matrix.toolchain.host }}-
+                    key: ccache-ios-${{ github.sha }}
+                    restore-keys: ccache-ios-
             -   name: Depends cache
                 uses: actions/cache@v5
                 with:
                     path: contrib/depends/built
-                    key: depends-${{ matrix.toolchain.host }}-${{ hashFiles('contrib/depends/packages/*') }}
-                    restore-keys: |
-                        depends-${{ matrix.toolchain.host }}-${{ hashFiles('contrib/depends/packages/*') }}
-                        depends-${{ matrix.toolchain.host }}-
+                    key: depends-ios-${{ hashFiles('contrib/depends/packages/*') }}
+                    restore-keys: depends-ios-
             -   uses: ./.github/actions/set-make-job-count
-            -   name: Build
+            -   name: Build device + simulator slices
                 run: |
                     ${{env.CCACHE_SETTINGS}}
-                    make -C contrib/depends HOST=${{ matrix.toolchain.host }} -j${{env.MAKE_JOB_COUNT}}
-                    mkdir -p build/${{ matrix.toolchain.host }}/release
-                    cd build/${{ matrix.toolchain.host }}/release
-                    cmake -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/contrib/depends/${{ matrix.toolchain.host }}/share/toolchain.cmake ../../..
-                    make -j${{env.MAKE_JOB_COUNT}} wallet_api
-            -   name: Package wallet library
+                    for H in "$DEVICE_HOST" "$SIM_HOST"; do
+                        make -C contrib/depends HOST=$H -j${{env.MAKE_JOB_COUNT}}
+                        mkdir -p build/$H/release
+                        ( cd build/$H/release && \
+                          cmake -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/contrib/depends/$H/share/toolchain.cmake ../../.. && \
+                          make -j${{env.MAKE_JOB_COUNT}} wallet_api )
+                        # one linkable slice: merge project + depends archives, minus
+                        # boost's test-only frameworks (unused, and they collide on names)
+                        ARCHIVES=$(find "build/$H/release" -name '*.a'; \
+                          find "contrib/depends/$H/lib" -name '*.a' \
+                            ! -name 'libboost_unit_test_framework.a' \
+                            ! -name 'libboost_test_exec_monitor.a')
+                        libtool -static -o "build/$H/libnerva_wallet.a" $ARCHIVES
+                        # the slice must actually carry the wallet API symbols a
+                        # consumer links against (i.e. not empty / stripped)
+                        nm "build/$H/libnerva_wallet.a" 2>/dev/null | grep -q WalletManagerFactory \
+                          || { echo "no wallet_api symbols in $H slice"; exit 1; }
+                    done
+            -   name: Assemble xcframework
                 run: |
-                    # A bare libwallet_api.a doesn't bundle its deps, so it isn't
-                    # linkable on its own. Merge the project archives and the depends
-                    # archives into one device-only (arm64 iphoneos) static lib and
-                    # ship it with the wallet/api headers. Multi-slice .xcframework
-                    # (device + simulator) is tracked as a follow-up.
-                    HOST=${{ matrix.toolchain.host }}
-                    STAGE="$GITHUB_WORKSPACE/${{ matrix.toolchain.artifact-name }}"
-                    mkdir -p "$STAGE/lib" "$STAGE/include"
-                    # skip boost's test-only frameworks: no wallet code calls them
-                    # and they collide on member names during the merge
-                    ARCHIVES=$(find "build/$HOST/release" -name '*.a'; \
-                      find "contrib/depends/$HOST/lib" -name '*.a' \
-                        ! -name 'libboost_unit_test_framework.a' \
-                        ! -name 'libboost_test_exec_monitor.a')
-                    libtool -static -o "$STAGE/lib/libnerva_wallet.a" $ARCHIVES
-                    cp src/wallet/api/*.h "$STAGE/include/"
-                    printf 'Device-only (arm64 iphoneos), pre-release.\nMulti-slice .xcframework (device + simulator) tracked separately.\n' > "$STAGE/README-ios.txt"
+                    STAGE="$GITHUB_WORKSPACE/$ARTIFACT"
+                    mkdir -p "$STAGE"
+                    # headers-only staging dir, -headers would ship the .cpp files too
+                    HDRS="$GITHUB_WORKSPACE/ios-headers"
+                    mkdir -p "$HDRS"
+                    cp src/wallet/api/*.h "$HDRS/"
+                    xcodebuild -create-xcframework \
+                        -library "build/$DEVICE_HOST/libnerva_wallet.a" -headers "$HDRS" \
+                        -library "build/$SIM_HOST/libnerva_wallet.a"    -headers "$HDRS" \
+                        -output "$STAGE/libnerva_wallet.xcframework"
+                    printf 'libnerva_wallet.xcframework: arm64 device + arm64 simulator slices.\n' > "$STAGE/README-ios.txt"
+            -   name: Verify both slices present
+                run: |
+                    INFO=$(plutil -p "$ARTIFACT/libnerva_wallet.xcframework/Info.plist")
+                    echo "$INFO"
+                    echo "$INFO" | grep -q '"ios-arm64"'           || { echo "missing device slice";    exit 1; }
+                    echo "$INFO" | grep -q '"ios-arm64-simulator"' || { echo "missing simulator slice"; exit 1; }
             -   uses: actions/upload-artifact@v7
                 if: github.event_name != 'schedule'
                 with:
-                    name: ${{ matrix.toolchain.artifact-name }}
-                    path: ${{ matrix.toolchain.artifact-name }}/
+                    name: ${{ env.ARTIFACT }}
+                    path: ${{ env.ARTIFACT }}/

--- a/contrib/depends/Makefile
+++ b/contrib/depends/Makefile
@@ -63,6 +63,7 @@ endif
 host_os+=$(findstring darwin,$(full_host_os))
 host_os+=$(findstring freebsd,$(full_host_os))
 host_os+=$(findstring mingw32,$(full_host_os))
+host_os+=$(findstring ios,$(full_host_os))  # ios and iossimulator both -> hosts/ios.mk
 host_os:=$(strip $(host_os))
 ifeq ($(host_os),)
 host_os=$(full_host_os)
@@ -70,6 +71,12 @@ endif
 
 $(host_arch)_$(host_os)_prefix=$(BASEDIR)/$(host)
 $(host_arch)_$(host_os)_host=$(host)
+# packages' bundled config.sub don't know the 'iossimulator' triple; the
+# simulator target is carried by the compiler flags (see hosts/ios.mk), so hand
+# configure the plain ios triple while keeping the distinct prefix above.
+ifneq (,$(findstring iossimulator,$(host)))
+$(host_arch)_$(host_os)_host=$(host_arch)-apple-ios
+endif
 host_prefix=$($(host_arch)_$(host_os)_prefix)
 build_prefix=$(host_prefix)/native
 

--- a/contrib/depends/hosts/ios.mk
+++ b/contrib/depends/hosts/ios.mk
@@ -1,12 +1,18 @@
-# iOS (arm64-apple-ios) host: use the macOS runner's own Xcode (clang + iphoneos
-# SDK via xcrun, system cctools). nothing built from source here.
+# iOS host: macOS runner's own Xcode (clang + SDK via xcrun, system cctools).
+# Device and simulator share this file; the SDK + target triple switch on the
+# host (aarch64-apple-ios vs aarch64-apple-iossimulator). nothing built from source.
 IOS_MIN_VERSION=12.0
-IOS_SDK_PATH=$(shell xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(findstring simulator,$(full_host_os)),simulator)
+  IOS_SDK=iphonesimulator
+  CC_target=arm64-apple-ios$(IOS_MIN_VERSION)-simulator
+else
+  IOS_SDK=iphoneos
+  CC_target=arm64-apple-ios$(IOS_MIN_VERSION)
+endif
+IOS_SDK_PATH=$(shell xcrun --sdk $(IOS_SDK) --show-sdk-path)
 
-CC_target=arm64-apple-ios
-
-ios_CC=clang -target $(CC_target) -miphoneos-version-min=$(IOS_MIN_VERSION) -isysroot $(IOS_SDK_PATH)
-ios_CXX=clang++ -target $(CC_target) -miphoneos-version-min=$(IOS_MIN_VERSION) -isysroot $(IOS_SDK_PATH) -stdlib=libc++
+ios_CC=clang -target $(CC_target) -isysroot $(IOS_SDK_PATH)
+ios_CXX=clang++ -target $(CC_target) -isysroot $(IOS_SDK_PATH) -stdlib=libc++
 
 ios_CFLAGS=-pipe
 ios_CXXFLAGS=$(ios_CFLAGS)

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -116,7 +116,11 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
   # iOS: native Xcode (clang + iphoneos SDK). the aarch64 block below sets ARM/AES.
   SET(IOS ON)  # single source of truth for the if(IOS)/if(NOT IOS) guards
   SET(CMAKE_OSX_ARCHITECTURES "arm64")
-  SET(CMAKE_OSX_SYSROOT "iphoneos")
+  if("@HOST@" MATCHES "simulator")
+    SET(CMAKE_OSX_SYSROOT "iphonesimulator")
+  else()
+    SET(CMAKE_OSX_SYSROOT "iphoneos")
+  endif()
   SET(CMAKE_OSX_DEPLOYMENT_TARGET "12.0")
   SET(CMAKE_C_COMPILER clang)
   SET(CMAKE_CXX_COMPILER clang++ -stdlib=libc++)


### PR DESCRIPTION
Implements #106. Follow-up to #99, which shipped a **device-only** merged `libnerva_wallet.a`. iOS consumers also need an **arm64 simulator** slice, and `lipo` can't combine same-arch/different-platform slices — so the correct distribution format is an `.xcframework`.

## What changed

**depends — add the simulator host (`aarch64-apple-iossimulator`)**
- Two `config.sub` layers: Nerva's own `config.sub` accepts the dash-less `iossimulator` triple (the dashed `-simulator` form is rejected), so `canonical_host` parses; `Makefile` maps both `ios` and `iossimulator` → `hosts/ios.mk`.
- Packages' *bundled* `config.sub` are too old to know `iossimulator`, so autotools `configure` gets the plain `aarch64-apple-ios` `--host` (which they accept, same as device); the simulator target is carried purely in the compiler flags. `ios.mk` switches SDK + triple (`iphonesimulator` + `arm64-apple-ios<min>-simulator`); `toolchain.cmake.in` picks `CMAKE_OSX_SYSROOT` off `@HOST@`. This mirrors how monero_c keeps the platform in CC/CMake, not the autotools host triple.

**CI (`depends.yml`) — new `build-ios` job**
- Builds `wallet_api` for both hosts (`aarch64-apple-ios` device, `aarch64-apple-iossimulator` simulator), and merges each into one linkable per-slice static lib via the #99 `libtool -static` recipe (minus boost's test-only frameworks, which are unused and collide on member names). Each slice is sanity-checked to actually carry the wallet API symbols (`nm … | grep WalletManagerFactory`).
- Headers are copied into a **headers-only staging dir** before `-headers`, so the framework ships just the `.h` and not the wallet `.cpp` sources.
- `xcodebuild -create-xcframework` bundles both slices into `libnerva_wallet.xcframework`, then the *Verify both slices present* step asserts the `Info.plist` carries both `ios-arm64` and `ios-arm64-simulator`.
- Uploaded as the `nerva-ios-armv8` artifact.

## Acceptance criteria
- [x] CI produces `libnerva_wallet.xcframework` with both `ios-arm64` and `ios-arm64-simulator` slices (asserted in *Verify both slices present*; `xcodebuild -create-xcframework` itself only succeeds on valid, correctly-typed slices).
- [x] **Linkability, verified structurally in CI:** each slice is a valid platform Mach-O (enforced by the xcframework assembly) and carries the wallet API symbols (`nm … | grep WalletManagerFactory`). A literal "build a sample Xcode app" link is left as a one-time downstream/reviewer check (it needs Xcode and a real app target, which a CLI link can't faithfully stand in for) — the natural place for that is the cake_wallet / monero_c (#188) integration.