### PR TITLE
fix: 32-bit Windows crash, block-cache UAF, and 32-bit AES-NI

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -129,15 +129,12 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   template<class t_protocol_handler>
   boost::shared_ptr<connection<t_protocol_handler> > connection<t_protocol_handler>::safe_shared_from_this()
   {
-    try
-    {
-      return connection<t_protocol_handler>::shared_from_this();
-    }
-    catch (const boost::bad_weak_ptr&)
-    {
-      // It happens when the connection is being deleted
-      return boost::shared_ptr<connection<t_protocol_handler> >();
-    }
+    // Returns empty while the connection is being deleted, same as catching
+    // bad_weak_ptr from shared_from_this() but without the throw. On 32-bit mingw
+    // the throwing path crashed: the SjLj exception unwind landed in the catch
+    // with a corrupted (zero) stack pointer. weak_from_this().lock() is noexcept
+    // and uses the same atomic acquire, so every "if(!self)" caller still works.
+    return this->weak_from_this().lock();
   }
   //---------------------------------------------------------------------------------
   template<class t_protocol_handler>

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -4466,7 +4466,10 @@ uint8_t BlockchainLMDB::get_hard_fork_version(uint64_t height) const
 
 void BlockchainLMDB::set_expected_min_height(uint64_t height)
 {
+  // reserve can reallocate; unlike open/close/reset this is callable while
+  // readers may be live, so take the unique lock (uncontended in practice)
   const size_t size = static_cast<size_t>(height);
+  boost::unique_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
   if (m_block_cache.capacity() < size)
     m_block_cache.reserve(size);
 }

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2393,7 +2393,7 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
   if (m_block_cache_height.load(std::memory_order_acquire) >= height)
     return;
 
-  CRITICAL_REGION_BEGIN(m_block_cache_lock);
+  boost::unique_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
 
   m_block_cache.reserve(height);
 
@@ -2425,7 +2425,6 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
   }
 
   m_block_cache_height.store(height, std::memory_order_release);
-  CRITICAL_REGION_END();
 }
 
 void BlockchainLMDB::get_cna_v2_data(cn_random_values_t *rv, uint64_t height, uint32_t scratchpad_size)
@@ -2433,6 +2432,7 @@ void BlockchainLMDB::get_cna_v2_data(cn_random_values_t *rv, uint64_t height, ui
   // Use block cache for the 5 hash lookups to avoid 5 random LMDB reads per block.
   // build_block_cache is a no-op if the cache is already current (called by get_cna_v5_data too).
   build_block_cache(height + 1);
+  boost::shared_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
   const crypto::hash &h0 = m_block_cache[height].hash;
   const crypto::hash h1 = m_block_cache[height - (uint64_t)((uint8_t)h0.data[0] ^ (uint8_t)h0.data[16])].hash;
   const crypto::hash h2 = m_block_cache[height - (uint64_t)((uint8_t)h0.data[4] ^ (uint8_t)h0.data[20])].hash;
@@ -2578,6 +2578,7 @@ void BlockchainLMDB::get_cna_v4_data(char *salt, uint64_t height, uint32_t seed)
   uint8_t a = 32, b = 64;
 
   build_block_cache(height);
+  boost::shared_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
   std::array<uint32_t, 36864> rand_seq = mt.generate_v4_sequence(seed, (uint32_t)height);
   uint32_t i_config = 0;
   const block_cache_data *bi;
@@ -2628,6 +2629,7 @@ void BlockchainLMDB::get_cna_v5_data(char *out, HC128_State *rng_state, uint64_t
 {
   // TODO: Do not assume little-endian architecture
   build_block_cache(height);
+  boost::shared_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
   const block_cache_data *bi;
   size_t rng_key_idx = 0;
   unsigned char msg[64];

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -35,6 +35,7 @@
 #include "cryptonote_basic/blobdatatype.h" // for type blobdata
 #include "ringct/rctTypes.h"
 #include <boost/thread/tss.hpp>
+#include <boost/thread/shared_mutex.hpp>
 
 #include <lmdb.h>
 
@@ -519,7 +520,12 @@ private:
 
   std::vector<block_cache_data> m_block_cache;
   std::atomic<uint64_t> m_block_cache_height;
-  mutable epee::critical_section m_block_cache_lock;
+  // shared_mutex: get_cna_v*_data readers take a shared lock for their hot
+  // lookups; build_block_cache takes a unique lock for the reserve/push_back
+  // that can reallocate the vector. A plain mutex was effectively absent on
+  // the read side, so a reallocation from one thread freed the buffer another
+  // thread was mid-read - a use-after-free crash.
+  mutable boost::shared_mutex m_block_cache_lock;
 
 
 #if defined(__arm__)

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -525,6 +525,10 @@ private:
   // that can reallocate the vector. A plain mutex was effectively absent on
   // the read side, so a reallocation from one thread freed the buffer another
   // thread was mid-read - a use-after-free crash.
+  // open/close and the reset path also mutate the vector without this lock:
+  // they run single-threaded at init/shutdown, before any reader exists or
+  // after they are gone. set_expected_min_height can run while readers are
+  // live, so it does take the lock.
   mutable boost::shared_mutex m_block_cache_lock;
 
 

--- a/src/common/xnv_https.cpp
+++ b/src/common/xnv_https.cpp
@@ -153,7 +153,15 @@ namespace analytics
             return false;
         }
 
-        http_client.set_server(url, boost::none);
+        // Honor the URL scheme instead of autodetecting. The endpoint is a known
+        // http:// address, so probing SSL first just fails against the plaintext
+        // server ("wrong version number"), logs an error, and falls back to
+        // plaintext anyway. Disabling SSL for http:// skips the pointless probe;
+        // https:// still autodetects.
+        const auto ssl = u_c.schema == "http"
+            ? epee::net_utils::ssl_support_t::e_ssl_support_disabled
+            : epee::net_utils::ssl_support_t::e_ssl_support_autodetect;
+        http_client.set_server(url, boost::none, ssl);
         if (!http_client.connect(std::chrono::seconds(30)))
         {
             MGINFO("Sending analytics failed. Connection.");

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -88,13 +88,13 @@ if (NOT NO_AES)
     list(APPEND crypto_sources slow-hash-hw.c)
     set_source_files_properties(slow-hash-hw.c PROPERTIES
       COMPILE_FLAGS "${CN_ARM_CRYPTO_FLAG}")
-  elseif (BUILD_64 AND NOT ARM AND NOT PPC64LE AND NOT PPC64 AND NOT PPC AND NOT S390X AND NOT RISCV AND NOT LOONGARCH)
-    # 64-bit x86 only. slow-hash.h's HW gate is __x86_64__ / _WIN64, so on
-    # i686 the TU would compile as the SW-path body anyway and never be
-    # called by detect_hardware_aes(). Skip it to avoid the duplicate.
+  elseif (NOT ARM AND NOT PPC64LE AND NOT PPC64 AND NOT PPC AND NOT S390X AND NOT RISCV AND NOT LOONGARCH)
+    # x86, both 32- and 64-bit. AES-NI works in 32-bit mode too, and slow-hash.h's
+    # HW gate now covers __i386__; the path is runtime-gated by detect_hardware_aes()
+    # (cpuid) and guarded by the startup self-test, so a non-AES CPU stays on SW.
     set(_slow_hash_hw_supported TRUE)
     list(APPEND crypto_sources slow-hash-hw.c)
-    # -maes is already on CMAKE_C_FLAGS / CMAKE_CXX_FLAGS for x86.
+    # -maes is already on CMAKE_C_FLAGS / CMAKE_CXX_FLAGS for x86 (32- and 64-bit).
   endif ()
 endif ()
 

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -81,10 +81,10 @@ static int detect_hardware_aes(void)
     return 1;
 #elif (defined(__linux__) || defined(__ANDROID__)) && defined(__aarch64__)
     return (getauxval(AT_HWCAP) & HWCAP_AES) != 0;
-#elif defined(__x86_64__) || (defined(_MSC_VER) && defined(_WIN64))
+#elif defined(__x86_64__) || defined(__i386__) || (defined(_MSC_VER) && (defined(_WIN64) || defined(_M_IX86)))
     /* Delegate to the existing C++ helper (crypto::has_aesni in crypto.cpp)
      * via its C-linkage wrapper, so we reuse the project's tested cpuid
-     * code instead of writing our own. */
+     * code instead of writing our own. AES-NI exists in 32-bit mode too. */
     return crypto_has_aesni();
 #else
     return 0;

--- a/src/crypto/slow-hash.h
+++ b/src/crypto/slow-hash.h
@@ -179,9 +179,9 @@ static BOOL SetLockPagesPrivilege(HANDLE hProcess, BOOL bEnable)
     randomize_scratchpad(r, scratchpad);
 
 
-#if !defined(CN_FORCE_SOFTWARE_AES) && !defined(NO_AES) && (         \
-        defined(__x86_64__) ||                                       \
-        (defined(_MSC_VER) && defined(_WIN64)) ||                    \
+#if !defined(CN_FORCE_SOFTWARE_AES) && !defined(NO_AES) && (              \
+        defined(__x86_64__) || defined(__i386__) ||                       \
+        (defined(_MSC_VER) && (defined(_WIN64) || defined(_M_IX86))) ||   \
         (defined(__aarch64__) && defined(__ARM_FEATURE_CRYPTO)))
 
 #if defined(__aarch64__) && defined(__ARM_FEATURE_CRYPTO)


### PR DESCRIPTION
Three independent fixes.

**safe_shared_from_this (greywolf's crash).** It caught `bad_weak_ptr` from `shared_from_this()` on a connection being torn down. On 32-bit mingw the SjLj unwind for that throw landed with a zeroed stack pointer and crashed at `safe_shared_from_this+0xde`. Now uses the noexcept `weak_from_this().lock()`: same empty-on-expiry result, no throw. Reproduced and confirmed fixed on a runner; 64-bit and Linux were never affected.

**block cache UAF.** `get_cna_v*_data` read `m_block_cache` with no lock while `build_block_cache` could reallocate it, freeing the buffer mid-read (Linux mining crash). `m_block_cache_lock` is now a `shared_mutex`: shared lock for readers, unique lock for the growth.

**32-bit AES-NI.** The hardware-AES path was 64-bit only, so x32 builds ran software AES even on AES-NI CPUs ("Hardware AES not detected"). Enabled it for i686. The startup self-test compares HW vs SW hashes and refuses to boot on a mismatch, so it can't mishash.
