### PR TITLE
Fully static musl Linux builds

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -75,6 +75,22 @@ jobs:
                         host: "aarch64-linux-gnu"
                         packages: "python3 gperf g++-aarch64-linux-gnu"
                         artifact-name: "nerva-linux-armv8"
+                    -   name: "ARM v8 musl"
+                        host: "aarch64-unknown-linux-musl"
+                        packages: "python3 gperf"
+                        artifact-name: "nerva-linux-armv8-musl"
+                    -   name: "x86_64 musl"
+                        host: "x86_64-unknown-linux-musl"
+                        packages: "python3 gperf"
+                        artifact-name: "nerva-linux-x86_64-musl"
+                    -   name: "i686 musl"
+                        host: "i686-unknown-linux-musl"
+                        packages: "python3 gperf"
+                        artifact-name: "nerva-linux-i686-musl"
+                    -   name: "ARM v7 musl"
+                        host: "armv7-unknown-linux-musleabihf"
+                        packages: "python3 gperf"
+                        artifact-name: "nerva-linux-armv7-musl"
                     -   name: "i686 Win"
                         host: "i686-w64-mingw32"
                         packages: "python3 g++-mingw-w64-i686"
@@ -138,6 +154,23 @@ jobs:
                 run: |
                     update-alternatives --set ${{ matrix.toolchain.host }}-g++ $(which ${{ matrix.toolchain.host }}-g++-posix)
                     update-alternatives --set ${{ matrix.toolchain.host }}-gcc $(which ${{ matrix.toolchain.host }}-gcc-posix)
+            -   name: Fetch musl cross toolchain
+                # No apt musl cross packages exist and musl.cc is unreachable from CI,
+                # so pull the matching cross-tools toolchain (the tarball is named by
+                # the host triple), checksum it, and put it on PATH; depends then finds
+                # <triple>-gcc by name.
+                if: ${{ contains(matrix.toolchain.host, 'musl') }}
+                env:
+                    XTOOLS_TAG: "20250206"
+                run: |
+                    cd /opt
+                    BASE="https://github.com/cross-tools/musl-cross/releases/download/${XTOOLS_TAG}"
+                    curl -fsSL --retry 3 -O "${BASE}/${{ matrix.toolchain.host }}.tar.xz"
+                    curl -fsSL --retry 3 -O "${BASE}/${{ matrix.toolchain.host }}.tar.xz.sha256"
+                    SUM=$(awk '{print $1}' "${{ matrix.toolchain.host }}.tar.xz.sha256")
+                    echo "${SUM}  ${{ matrix.toolchain.host }}.tar.xz" | sha256sum -c -
+                    tar -xf "${{ matrix.toolchain.host }}.tar.xz"
+                    echo "/opt/${{ matrix.toolchain.host }}/bin" >> "$GITHUB_PATH"
             -   uses: ./.github/actions/set-make-job-count
             -   name: Build
                 run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,19 @@ if (ARM_ID STREQUAL "aarch64" OR ARM_ID STREQUAL "arm64" OR ARM_ID STREQUAL "arm
     set(ARCH "armv8-a")
 endif ()
 
+# Detect a musl libc target (e.g. aarch64-linux-musl). Unlike glibc, musl ships
+# no execinfo.h and links cleanly as a fully static binary, so a couple of the
+# choices below (stack tracing, -static) branch on this.
+execute_process(
+    COMMAND ${CMAKE_C_COMPILER} -dumpmachine
+    OUTPUT_VARIABLE NERVA_COMPILER_TRIPLE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+if (NERVA_COMPILER_TRIPLE MATCHES "musl")
+    set(MUSL_LIBC 1)
+    message(STATUS "Detected musl libc target (${NERVA_COMPILER_TRIPLE})")
+endif ()
+
 if (ARCH_ID STREQUAL "ppc64le")
     set(PPC64LE 1)
     set(PPC64 0)
@@ -527,7 +540,12 @@ add_definitions("-DBLOCKCHAIN_DB=${BLOCKCHAIN_DB}")
 # Can't install hook in static build on OSX, because OSX linker does not support --wrap
 # On ARM, having libunwind package (with .so's only) installed breaks static link.
 # When possible, avoid stack tracing using libunwind in favor of using easylogging++.
-if (APPLE OR NETBSD)
+if (MUSL_LIBC)
+    # musl has no execinfo.h (easylogging++ backtraces) and we don't ship a
+    # static libunwind for it, so stack tracing on exception is unavailable here.
+    set(DEFAULT_STACK_TRACE OFF)
+    set(LIBUNWIND_LIBRARIES "")
+elseif (APPLE OR NETBSD)
     set(DEFAULT_STACK_TRACE OFF)
     set(LIBUNWIND_LIBRARIES "")
 elseif (DEPENDS AND NOT LINUX)
@@ -1061,8 +1079,12 @@ else ()
             # On Windows, this is as close to fully-static as we get:
             # this leaves only deps on /c/Windows/system32/*.dll
             set(STATIC_FLAGS "-static")
+        elseif (MUSL_LIBC)
+            # musl links cleanly when fully static (no glibc NSS dlopen problem),
+            # so we can drop the glibc version dependency entirely here.
+            set(STATIC_FLAGS "-static")
         elseif (NOT (APPLE OR FREEBSD OR OPENBSD OR DRAGONFLY))
-            # On Linux, we don't support fully static build, but these can be static
+            # On glibc Linux, we don't support fully static build, but these can be static
             set(STATIC_FLAGS "-static-libgcc -static-libstdc++")
         endif ()
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${STATIC_FLAGS} ")

--- a/contrib/depends/hosts/linux.mk
+++ b/contrib/depends/hosts/linux.mk
@@ -11,6 +11,9 @@ linux_debug_CXXFLAGS=$(linux_debug_CFLAGS)
 linux_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
 
 ifeq (86,$(findstring 86,$(build_arch)))
+# glibc x86 targets build with the host's multilib gcc. musl x86 targets must
+# not: they fall through to their own cross toolchain (default_host_CC).
+ifeq (,$(findstring musl,$(host)))
 i686_linux_CC=gcc -m32
 i686_linux_CXX=g++ -m32
 i686_linux_AR=ar
@@ -24,6 +27,7 @@ x86_64_linux_AR=ar
 x86_64_linux_RANLIB=ranlib
 x86_64_linux_NM=nm
 x86_64_linux_STRIP=strip
+endif
 else
 i686_linux_CC=$(default_host_CC) -m32
 i686_linux_CXX=$(default_host_CXX) -m32

--- a/contrib/depends/packages/openssl.mk
+++ b/contrib/depends/packages/openssl.mk
@@ -36,6 +36,7 @@ $(package)_config_opts_freebsd=-fPIC -Wa,--noexecstack
 $(package)_config_opts_x86_64_linux=linux-x86_64
 $(package)_config_opts_i686_linux=linux-generic32
 $(package)_config_opts_arm_linux=linux-generic32
+$(package)_config_opts_armv7_linux=linux-generic32
 $(package)_config_opts_aarch64_linux=linux-generic64
 $(package)_config_opts_arm_android=--static android-arm
 $(package)_config_opts_aarch64_android=--static android-arm64


### PR DESCRIPTION
Adds a fully static musl build for each Linux arch (aarch64, x86_64, i686, armv7), alongside the existing glibc builds. The musl binaries link no glibc at all, so they run on any Linux regardless of glibc version. Fixes the "version `GLIBC_2.xx' not found" failures on older boards like the Jetson Nano (glibc 2.27).

Changes:
- CMakeLists: detect musl, disable the stack-trace hook (no execinfo.h on musl), and link `-static`. glibc Linux keeps `-static-libgcc -static-libstdc++`.
- depends.yml: one musl matrix entry per arch. No apt musl cross packages exist and musl.cc is unreachable from the runners, so a step fetches the cross-tools toolchain (pinned to a GCC 14 release: C17 default, runs on the 20.04 container) and puts it on PATH.
- depends: linux.mk no longer forces the musl x86 targets onto the host gcc; openssl.mk gets an armv7 target.

Verified in CI: all jobs green, existing glibc/Windows/Mac/FreeBSD/Android/iOS targets unchanged.