### PR TITLE
fix(hf13): try harder for huge pages and stop degrading silently

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -55,6 +55,9 @@
   #include <fstream>
 #endif
 
+//tools::setup_large_pages_win
+#include <iostream>
+
 #include "unbound.h"
 
 #include "include_base_utils.h"
@@ -79,6 +82,7 @@ using namespace epee;
   #include <windows.h>
   #include <shlobj.h>
   #include <strsafe.h>
+  #include <ntsecapi.h>
 #else 
   #include <sys/file.h>
   #include <sys/utsname.h>
@@ -825,6 +829,55 @@ std::string get_nix_version_display_string()
 #endif // !defined NO_AES
     return true;
   }
+
+#ifdef WIN32
+  namespace
+  {
+    bool grant_lock_pages_privilege()
+    {
+      // current user's SID
+      HANDLE token = NULL;
+      if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token))
+        return false;
+      BYTE user_buf[sizeof(TOKEN_USER) + SECURITY_MAX_SID_SIZE];
+      DWORD len = 0;
+      const BOOL got_user = GetTokenInformation(token, TokenUser, user_buf, sizeof(user_buf), &len);
+      CloseHandle(token);
+      if (!got_user)
+        return false;
+      PSID sid = reinterpret_cast<TOKEN_USER*>(user_buf)->User.Sid;
+
+      // add SeLockMemoryPrivilege to the account rights; the LSA route works
+      // on every edition (Home has no gpedit/secpol). Needs an elevated prompt.
+      LSA_OBJECT_ATTRIBUTES attrs;
+      memset(&attrs, 0, sizeof(attrs));
+      LSA_HANDLE policy = NULL;
+      if (LsaOpenPolicy(NULL, &attrs, POLICY_CREATE_ACCOUNT | POLICY_LOOKUP_NAMES, &policy) != 0)
+        return false;
+      wchar_t name[] = L"SeLockMemoryPrivilege";
+      LSA_UNICODE_STRING right;
+      right.Buffer = name;
+      right.Length = (USHORT)(sizeof(name) - sizeof(wchar_t)); // bytes, without the null
+      right.MaximumLength = (USHORT)sizeof(name);
+      const NTSTATUS status = LsaAddAccountRights(policy, sid, &right, 1);
+      LsaClose(policy);
+      return status == 0;
+    }
+  }
+
+  int setup_large_pages_win()
+  {
+    if (grant_lock_pages_privilege())
+    {
+      std::cout << "\"Lock pages in memory\" granted to your user. "
+        "Log out and back in (or reboot), then mining can use large pages." << std::endl;
+      return 0;
+    }
+    std::cout << "Could not grant \"Lock pages in memory\". "
+      "Run this from an elevated (administrator) prompt." << std::endl;
+    return 1;
+  }
+#endif
 
   bool on_startup()
   {

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -164,6 +164,14 @@ namespace tools
 
   bool check_aesni();
 
+#ifdef WIN32
+  // Windows: add "Lock pages in memory" to the current user via the LSA
+  // policy so mining can use large pages. Needs an elevated prompt, takes
+  // effect on the next logon. Prints what it did and returns the process
+  // exit code.
+  int setup_large_pages_win();
+#endif
+
   bool on_startup();
 
   /*! \brief Defines a signal handler for win32 and *nix

--- a/src/crypto/hash-ops.h
+++ b/src/crypto/hash-ops.h
@@ -114,6 +114,18 @@ typedef struct cn_random_values
   int8_t values[CN_RANDOM_VALUES];
 } cn_random_values_t;
 
+/* Backing-page tier of a scratchpad/salt allocation. Stored in the
+ * *_is_mapped context fields; ordered so any tier >= CN_PAGES_PLAIN_MMAP
+ * is released with munmap/VirtualFree and 0 keeps the legacy meaning
+ * "release with free()". Higher tier = fewer TLB misses on the 8 MB pad. */
+#define CN_PAGES_MALLOC     0   /* plain malloc, base pages (worst case)   */
+#define CN_PAGES_PLAIN_MMAP 1   /* mmap, base pages                        */
+#define CN_PAGES_THP        2   /* mmap + THP/superpage hint (best effort) */
+#define CN_PAGES_HUGE       3   /* explicit hugetlb / large pages          */
+
+/* Human-readable name for a CN_PAGES_* tier (miner logs / status). */
+const char *cn_page_tier_name(int tier);
+
 typedef struct cn_hash_context
 {
   /* Software-AES path always has its context allocated so the runtime

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -30,6 +30,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -150,36 +151,134 @@ void cn_slow_hash_v13(cn_hash_context_t *ctx, const void *data, size_t length, c
                 cn_slow_hash_v13_sw(ctx, data, length, hash, seed));
 }
 
+const char *cn_page_tier_name(int tier)
+{
+    switch (tier)
+    {
+    case CN_PAGES_HUGE:       return "huge pages";
+    case CN_PAGES_THP:        return "transparent huge pages";
+    case CN_PAGES_PLAIN_MMAP: return "normal pages (mmap)";
+    default:                  return "normal pages (malloc)";
+    }
+}
+
+/* Allocate `size` bytes on the largest page size the OS will give us, and
+ * return the CN_PAGES_* tier it landed on (hash-ops.h). Stays silent on
+ * purpose; the caller decides whether the tier is worth a user-facing
+ * warning (the miner does, block validation does not care).
+ *
+ * Tier ladder per platform:
+ *   Windows:  MEM_LARGE_PAGES (one retry after working-set trim) -> malloc
+ *   Linux:    MAP_HUGETLB -> mmap + madvise(MADV_HUGEPAGE) (THP) -> mmap
+ *   FreeBSD:  mmap + MAP_ALIGNED_SUPER (transparent superpages) -> mmap
+ *   others:   mmap -> malloc (no huge-page mechanism exposed) */
 static int allocate_hugepage(size_t size, void **hp)
 {
 #if defined(_MSC_VER) || defined(__MINGW32__)
-    SetLockPagesPrivilege(GetCurrentProcess(), TRUE);
-    *hp = VirtualAlloc(*hp, size, MEM_LARGE_PAGES | MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-    if (*hp == NULL) {
-        *hp = malloc(size);
-        return 0;
+    /* Large pages need the SeLockMemory privilege ("Lock pages in memory")
+     * and physically contiguous memory, which fragments away with uptime.
+     * No THP equivalent on Windows, so the only fallback is malloc. */
+    const SIZE_T lp_min = GetLargePageMinimum();
+    if (lp_min != 0 && SetLockPagesPrivilege(GetCurrentProcess(), TRUE))
+    {
+        /* VirtualAlloc rejects large-page requests that are not a multiple
+         * of the large-page size, so round up (mmap does the same rounding
+         * for hugetlb on Linux). Costs at most one extra large page for the
+         * salt and the 1 MB legacy pad. */
+        const SIZE_T lp_size = (size + lp_min - 1) & ~(lp_min - 1);
+        *hp = VirtualAlloc(NULL, lp_size, MEM_LARGE_PAGES | MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        if (*hp == NULL) {
+            /* Contiguous memory fragments with uptime; trimming our own
+             * working set nudges the memory manager to free contiguous runs
+             * and one retry rescues a good share of borderline failures
+             * (same technique as XMRig). Only worth it while the privilege
+             * is held - without it large pages can never succeed. */
+            SetProcessWorkingSetSize(GetCurrentProcess(), (SIZE_T)-1, (SIZE_T)-1);
+            *hp = VirtualAlloc(NULL, lp_size, MEM_LARGE_PAGES | MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        }
+        if (*hp != NULL)
+            return CN_PAGES_HUGE;
     }
-#else
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
-    *hp = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, 0, 0);
-#else
-    *hp = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, 0, 0);
-#endif
-    if (*hp == MAP_FAILED) {
-        *hp = malloc(size);
-        return 0;
+    *hp = malloc(size);
+    return CN_PAGES_MALLOC;
+#elif defined(__FreeBSD__)
+    /* No hugetlb pool on FreeBSD; superpages are transparent. The aligned
+     * mapping plus a full prefault lets the VM promote it to superpages. */
+    *hp = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_ALIGNED_SUPER, -1, 0);
+    if (*hp != MAP_FAILED) {
+        memset(*hp, 0, size);
+        return CN_PAGES_THP;
     }
+    *hp = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (*hp != MAP_FAILED)
+        return CN_PAGES_PLAIN_MMAP;
+    *hp = malloc(size);
+    return CN_PAGES_MALLOC;
+#elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
+    *hp = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (*hp != MAP_FAILED)
+        return CN_PAGES_PLAIN_MMAP;
+    *hp = malloc(size);
+    return CN_PAGES_MALLOC;
+#else
+    *hp = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
+    if (*hp != MAP_FAILED)
+        return CN_PAGES_HUGE;
+    /* No hugetlb pool reserved (vm.nr_hugepages). Take regular pages and
+     * hint transparent huge pages; with THP enabled the prefault typically
+     * lands the region on 2 MB pages right away, which is most of what the
+     * v13 pointer chase wants. */
+    *hp = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (*hp != MAP_FAILED) {
+        int thp = -1;
+#ifdef MADV_HUGEPAGE
+        thp = madvise(*hp, size, MADV_HUGEPAGE);
 #endif
-
-    return 1;
+        memset(*hp, 0, size);
+        return (thp == 0) ? CN_PAGES_THP : CN_PAGES_PLAIN_MMAP;
+    }
+    *hp = malloc(size);
+    return CN_PAGES_MALLOC;
+#endif
 }
 
-static void free_hugepage(void *hp, size_t size, int is_mapped)
+#if !defined(_MSC_VER) && !defined(__MINGW32__) && defined(__linux__)
+/* munmap length must be a multiple of the huge page size for hugetlb
+ * mappings; the kernel rounds up at mmap time but does not tell us, so
+ * read the default size (Hugepagesize in /proc/meminfo) once. */
+static size_t default_hugepage_size(void)
 {
-    if (is_mapped) {
+    static unsigned long kb = 0;
+    if (kb == 0)
+    {
+        char line[128];
+        FILE *f = fopen("/proc/meminfo", "r");
+        if (f != NULL)
+        {
+            while (fgets(line, sizeof(line), f) && sscanf(line, "Hugepagesize: %lu kB", &kb) != 1)
+                ;
+            fclose(f);
+        }
+        if (kb == 0)
+            kb = 2048;
+    }
+    return (size_t)kb * 1024;
+}
+#endif
+
+static void free_hugepage(void *hp, size_t size, int page_tier)
+{
+    if (page_tier) {
 #if defined(_MSC_VER) || defined(__MINGW32__)
         VirtualFree(hp, 0, MEM_RELEASE);
 #else
+#if defined(__linux__)
+        if (page_tier == CN_PAGES_HUGE)
+        {
+            const size_t hps = default_hugepage_size();
+            size = (size + hps - 1) & ~(hps - 1);
+        }
+#endif
         munmap(hp, size);
 #endif
     } else {

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -162,6 +162,32 @@ const char *cn_page_tier_name(int tier)
     }
 }
 
+#ifdef __linux__
+/* madvise(MADV_HUGEPAGE) returns success even when transparent huge pages
+ * are switched off system-wide (transparent_hugepage=never), in which case
+ * the hint is a no-op and the region stays on 4 KB pages. Read the mode once
+ * so we only claim the THP tier when the hint can actually take effect; a
+ * mode we cannot read is treated as "might work" so a real THP mapping is
+ * never hidden. */
+static int thp_hint_effective(void)
+{
+    static int effective = -1;
+    if (effective < 0)
+    {
+        char line[128];
+        FILE *f = fopen("/sys/kernel/mm/transparent_hugepage/enabled", "r");
+        effective = 1;
+        if (f != NULL)
+        {
+            if (fgets(line, sizeof(line), f) && strstr(line, "[never]"))
+                effective = 0;
+            fclose(f);
+        }
+    }
+    return effective;
+}
+#endif
+
 /* Allocate `size` bytes on the largest page size the OS will give us, and
  * return the CN_PAGES_* tier it landed on (hash-ops.h). Stays silent on
  * purpose; the caller decides whether the tier is worth a user-facing
@@ -237,6 +263,14 @@ static int allocate_hugepage(size_t size, void **hp)
         thp = madvise(*hp, size, MADV_HUGEPAGE);
 #endif
         memset(*hp, 0, size);
+#ifdef __linux__
+        /* madvise accepted the hint but that is not a promise of huge pages;
+         * if THP is off system-wide we are on 4 KB pages, so report plain
+         * mmap and let the miner warn instead of claiming a tier we did not
+         * get. */
+        if (thp == 0 && !thp_hint_effective())
+            return CN_PAGES_PLAIN_MMAP;
+#endif
         return (thp == 0) ? CN_PAGES_THP : CN_PAGES_PLAIN_MMAP;
     }
     *hp = malloc(size);

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -221,7 +221,9 @@ static int allocate_hugepage(size_t size, void **hp)
     *hp = malloc(size);
     return CN_PAGES_MALLOC;
 #else
-    *hp = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
+    /* MAP_POPULATE faults the huge pages in now instead of one by one
+     * during the first hash. */
+    *hp = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE, -1, 0);
     if (*hp != MAP_FAILED)
         return CN_PAGES_HUGE;
     /* No hugetlb pool reserved (vm.nr_hugepages). Take regular pages and

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -639,8 +639,8 @@ namespace cryptonote
       CRITICAL_REGION_END();
       if (tier < good_tier && template_version >= 13 && !m_slow_pages_warned.exchange(true))
         MGUSER_YELLOW("Mining is running on normal memory pages, hashrate will be lower. "
-            "Huge/large pages were not available (Windows: enable \"Lock pages in memory\" for your user; "
-            "Linux: set vm.nr_hugepages or leave transparent hugepages enabled). "
+            "Windows: run 'nervad --setup-large-pages' once as administrator, then log out and back in. "
+            "Linux: set vm.nr_hugepages or leave transparent hugepages enabled. "
             "Freeing memory or rebooting, then restarting mining, retries the allocation.");
     }
     block b;

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -114,6 +114,7 @@ namespace cryptonote
     m_pbc(pbc),
     m_height(0),
     m_threads_active(0),
+    m_slow_pages_warned(false),
     m_pausers_count(0),
     m_threads_total(0),
     m_donate_percent(MINING_DEFAULT_DONATION_LEVEL),
@@ -480,6 +481,8 @@ namespace cryptonote
 
     boost::interprocess::ipcdetail::atomic_write32(&m_stop, 0);
     boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);
+    // page situation can change between sessions, warn again if still bad
+    m_slow_pages_warned = false;
     set_is_background_mining_enabled(do_background);
     set_ignore_battery(ignore_battery);
     
@@ -612,6 +615,33 @@ namespace cryptonote
     {
       MERROR("Unable to allocate hash context, terminating miner thread");
       return false;
+    }
+    // Report which pages the v13 scratchpad landed on. The allocation used to
+    // fall back to normal pages silently and mining just looked slow until the
+    // next reboot, with nothing in the log explaining why.
+    {
+      const int tier = hash_context->cna_scratchpad_is_mapped;
+      // one INFO line for the session; per-thread detail stays at debug since
+      // tiers can differ per thread when the reserved pages run out mid-spawn
+      if (th_local_index == 0)
+        MGINFO("Mining scratchpads on " << crypto::cn_page_tier_name(tier));
+      MDEBUG("Miner thread [" << th_local_index << "] scratchpad on " << crypto::cn_page_tier_name(tier));
+#if defined(__APPLE__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
+      const int good_tier = CN_PAGES_PLAIN_MMAP; // best this platform offers, nothing to warn about
+#else
+      const int good_tier = CN_PAGES_THP;
+#endif
+      // the 8 MB pad only matters once CNA v6 (v13) is what we mine, no point
+      // nagging pre-fork miners about it
+      uint8_t template_version = 0;
+      CRITICAL_REGION_BEGIN(m_template_lock);
+      template_version = m_template.major_version;
+      CRITICAL_REGION_END();
+      if (tier < good_tier && template_version >= 13 && !m_slow_pages_warned.exchange(true))
+        MGUSER_YELLOW("Mining is running on normal memory pages, hashrate will be lower. "
+            "Huge/large pages were not available (Windows: enable \"Lock pages in memory\" for your user; "
+            "Linux: set vm.nr_hugepages or leave transparent hugepages enabled). "
+            "Freeing memory or rebooting, then restarting mining, retries the allocation.");
     }
     block b;
     ++m_threads_active;

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -43,6 +43,7 @@
 #include "file_io_utils.h"
 #include "common/command_line.h"
 #include "common/util.h"
+#include "common/threadpool.h"
 #include "string_coding.h"
 #include "string_tools.h"
 #include "storages/portable_storage_template_helper.h"
@@ -65,6 +66,9 @@
   #include <sys/resource.h>
   #include <sys/times.h>
   #include <time.h>
+  #include <fstream>
+  #include <set>
+  #include <sched.h>
 #elif defined(__FreeBSD__)
   #include <devstat.h>
   #include <errno.h>
@@ -75,8 +79,12 @@
   #include <sys/sysctl.h>
   #include <sys/times.h>
   #include <sys/types.h>
+  #include <sys/param.h>
+  #include <sys/cpuset.h>
   #include <unistd.h>
 #endif
+
+#include <map>
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "miner"
@@ -102,6 +110,166 @@ namespace cryptonote
     const command_line::arg_descriptor<uint64_t>    arg_bg_mining_min_idle_interval_seconds =  {"bg-mining-min-idle-interval", "Specify min lookback interval in seconds for determining idle state", miner::BACKGROUND_MINING_DEFAULT_MIN_IDLE_INTERVAL_IN_SECONDS, true};
     const command_line::arg_descriptor<uint16_t>     arg_bg_mining_idle_threshold_percentage =  {"bg-mining-idle-threshold", "Specify minimum avg idle percentage over lookback interval", miner::BACKGROUND_MINING_DEFAULT_IDLE_THRESHOLD_PERCENTAGE, true};
     const command_line::arg_descriptor<uint16_t>     arg_bg_mining_miner_target_percentage =  {"bg-mining-miner-target", "Specify maximum percentage cpu use by miner(s)", miner::BACKGROUND_MINING_DEFAULT_MINING_TARGET_PERCENTAGE, true};
+    const command_line::arg_descriptor<bool>        arg_mining_affinity = {"mining-affinity", "Pin mining threads to physical cores, one per core and inside a single L3 group when they fit", false, true};
+
+    /* Mining thread affinity. The v13 scratchpad is 8 MB per thread and only
+     * hashes at full speed while it stays resident in L3; every scheduler
+     * migration refills it from DRAM into another cache. The plan pins one
+     * worker per physical core (SMT siblings skipped) and, when the thread
+     * count fits, keeps all of them inside a single L3 group (the last one,
+     * the OS and foreground apps land on the first cores) so the other
+     * chiplet is left to the user's apps. Unreadable topology means an empty
+     * plan and no pinning at all. */
+    // (windows processor group, cpu index); group is -1 outside windows
+    typedef std::pair<int, int> cpu_slot;
+
+#if defined(__linux__)
+    std::vector<std::pair<cpu_slot, long>> enumerate_cores()
+    {
+      std::vector<std::pair<cpu_slot, long>> cores;
+      cpu_set_t allowed;
+      if (sched_getaffinity(0, sizeof(allowed), &allowed) != 0)
+        return cores;
+      std::set<std::pair<long, long>> seen;
+      for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu)
+      {
+        if (!CPU_ISSET(cpu, &allowed))
+          continue;
+        const std::string base = "/sys/devices/system/cpu/cpu" + std::to_string(cpu);
+        long pkg = -1, core = -1;
+        std::ifstream(base + "/topology/physical_package_id") >> pkg;
+        std::ifstream(base + "/topology/core_id") >> core;
+        // SMT siblings share (package, core); no core ids means nothing gets skipped
+        if (core >= 0 && !seen.insert(std::make_pair(pkg, core)).second)
+          continue;
+        long l3 = -1;
+        std::string shared;
+        if (std::getline(std::ifstream(base + "/cache/index3/shared_cpu_list"), shared) && !shared.empty())
+          l3 = atol(shared.c_str());
+        cores.push_back(std::make_pair(cpu_slot(-1, cpu), l3));
+      }
+      return cores;
+    }
+#elif defined(_WIN32)
+    /* Local replicas of the Win7 processor-group topology types, fixed
+     * Windows ABI. The build targets an older _WIN32_WINNT globally and
+     * bumping it in one TU would compile boost and class miner at a
+     * different API level than the rest of the tree, so the SDK types stay
+     * out of this file and the two functions come from kernel32 at runtime
+     * (older Windows keeps running, it just does not pin). */
+    typedef struct { KAFFINITY Mask; WORD Group; WORD Reserved[3]; } nv_group_affinity_t;
+    typedef struct { BYTE Flags; BYTE EfficiencyClass; BYTE Reserved[20]; WORD GroupCount; nv_group_affinity_t GroupMask[1]; } nv_processor_relationship_t;
+    typedef struct { BYTE Level; BYTE Associativity; WORD LineSize; DWORD CacheSize; DWORD Type; BYTE Reserved[20]; nv_group_affinity_t GroupMask; } nv_cache_relationship_t;
+    typedef struct { DWORD Relationship; DWORD Size; union { nv_processor_relationship_t Processor; nv_cache_relationship_t Cache; } u; } nv_slpi_ex_t;
+    enum { nv_relation_processor_core = 0, nv_relation_cache = 2, nv_relation_all = 0xffff };
+    typedef BOOL (WINAPI *glpi_ex_t)(DWORD, nv_slpi_ex_t*, PDWORD);
+    typedef BOOL (WINAPI *set_thread_group_affinity_t)(HANDLE, const nv_group_affinity_t*, nv_group_affinity_t*);
+
+    std::vector<std::pair<cpu_slot, long>> enumerate_cores()
+    {
+      std::vector<std::pair<cpu_slot, long>> cores;
+      const glpi_ex_t glpi_ex = (glpi_ex_t)(void*)GetProcAddress(GetModuleHandleA("kernel32.dll"), "GetLogicalProcessorInformationEx");
+      if (glpi_ex == NULL)
+        return cores;
+      DWORD len = 0;
+      glpi_ex(nv_relation_all, NULL, &len);
+      if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || len == 0)
+        return cores;
+      std::vector<BYTE> buf(len);
+      if (!glpi_ex(nv_relation_all, (nv_slpi_ex_t*)buf.data(), &len))
+        return cores;
+      std::vector<nv_group_affinity_t> l3s;
+      for (BYTE *p = buf.data(); p < buf.data() + len; p += ((const nv_slpi_ex_t*)p)->Size)
+      {
+        const nv_slpi_ex_t *info = (const nv_slpi_ex_t*)p;
+        if (info->Relationship == nv_relation_cache && info->u.Cache.Level == 3)
+          l3s.push_back(info->u.Cache.GroupMask);
+      }
+      for (BYTE *p = buf.data(); p < buf.data() + len; p += ((const nv_slpi_ex_t*)p)->Size)
+      {
+        const nv_slpi_ex_t *info = (const nv_slpi_ex_t*)p;
+        if (info->Relationship != nv_relation_processor_core)
+          continue;
+        const nv_group_affinity_t &ga = info->u.Processor.GroupMask[0];
+        int bit = -1;
+        for (int b = 0; b < (int)(8 * sizeof(KAFFINITY)); ++b)
+          if (ga.Mask & ((KAFFINITY)1 << b)) { bit = b; break; }  // first SMT sibling
+        if (bit < 0)
+          continue;
+        long l3 = -1;
+        for (size_t i = 0; i < l3s.size(); ++i)
+          if (l3s[i].Group == ga.Group && (l3s[i].Mask & ga.Mask)) { l3 = (long)i; break; }
+        cores.push_back(std::make_pair(cpu_slot((int)ga.Group, bit), l3));
+      }
+      return cores;
+    }
+#elif defined(__FreeBSD__)
+    std::vector<std::pair<cpu_slot, long>> enumerate_cores()
+    {
+      std::vector<std::pair<cpu_slot, long>> cores;
+      int ncpu = 0, tpc = 1;
+      size_t sz = sizeof(ncpu);
+      if (sysctlbyname("hw.ncpu", &ncpu, &sz, NULL, 0) != 0 || ncpu <= 0)
+        return cores;
+      sz = sizeof(tpc);
+      if (sysctlbyname("kern.smp.threads_per_core", &tpc, &sz, NULL, 0) != 0 || tpc <= 0)
+        tpc = 1;
+      // SMT siblings get adjacent ids, so one cpu every threads_per_core
+      for (int cpu = 0; cpu < ncpu; cpu += tpc)
+        cores.push_back(std::make_pair(cpu_slot(-1, cpu), (long)-1));
+      return cores;
+    }
+#else
+    // macOS and the rest only offer advisory affinity, stay hands off
+    std::vector<std::pair<cpu_slot, long>> enumerate_cores() { return {}; }
+#endif
+
+    std::vector<cpu_slot> plan_mining_affinity(size_t threads)
+    {
+      std::vector<cpu_slot> plan;
+      const std::vector<std::pair<cpu_slot, long>> cores = enumerate_cores();
+      if (threads == 0 || cores.size() < 2)
+        return plan;
+      std::map<long, std::vector<cpu_slot>> groups;
+      for (size_t i = 0; i < cores.size(); ++i)
+        if (cores[i].second >= 0)
+          groups[cores[i].second].push_back(cores[i].first);
+      for (std::map<long, std::vector<cpu_slot>>::reverse_iterator it = groups.rbegin(); it != groups.rend(); ++it)
+        if (it->second.size() >= threads)
+          return std::vector<cpu_slot>(it->second.begin(), it->second.begin() + threads);
+      for (size_t i = 0; i < cores.size() && i < threads; ++i)
+        plan.push_back(cores[i].first);
+      return plan;
+    }
+
+    bool pin_this_thread(const cpu_slot &slot)
+    {
+#if defined(__linux__)
+      cpu_set_t set;
+      CPU_ZERO(&set);
+      CPU_SET(slot.second, &set);
+      // pid 0 = calling thread; unlike pthread_setaffinity_np this exists in
+      // glibc, musl and bionic alike
+      return sched_setaffinity(0, sizeof(set), &set) == 0;
+#elif defined(_WIN32)
+      static const set_thread_group_affinity_t set_ga = (set_thread_group_affinity_t)(void*)GetProcAddress(GetModuleHandleA("kernel32.dll"), "SetThreadGroupAffinity");
+      if (set_ga == NULL)
+        return false;
+      nv_group_affinity_t ga;
+      memset(&ga, 0, sizeof(ga));
+      ga.Group = (WORD)slot.first;
+      ga.Mask = (KAFFINITY)1 << slot.second;
+      return set_ga(GetCurrentThread(), &ga, NULL) != 0;
+#elif defined(__FreeBSD__)
+      cpuset_t set;
+      CPU_ZERO(&set);
+      CPU_SET(slot.second, &set);
+      return cpuset_setaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, sizeof(set), &set) == 0;
+#else
+      (void)slot;
+      return false;
+#endif
+    }
   }
 
 
@@ -115,6 +283,7 @@ namespace cryptonote
     m_height(0),
     m_threads_active(0),
     m_slow_pages_warned(false),
+    m_mining_affinity(false),
     m_pausers_count(0),
     m_threads_total(0),
     m_donate_percent(MINING_DEFAULT_DONATION_LEVEL),
@@ -292,6 +461,22 @@ namespace cryptonote
     m_hashes = 0;
   }
   //-----------------------------------------------------------------------------------------------------
+  void miner::build_affinity_plan()
+  {
+    m_affinity_plan.clear();
+    if (!m_mining_affinity)
+      return;
+    m_affinity_plan = plan_mining_affinity(m_threads_total);
+    if (!m_affinity_plan.empty())
+    {
+      MGINFO("Pinning " << m_affinity_plan.size() << " mining thread(s), one per physical core");
+      // warm the lazy pool here, off the pinned miner threads
+      tools::threadpool::getInstance();
+    }
+    else
+      MGINFO("Mining affinity requested but cpu topology is unavailable, not pinning");
+  }
+  //-----------------------------------------------------------------------------------------------------
   void miner::update_autodetection()
   {
     if (m_threads_autodetect.empty())
@@ -342,6 +527,7 @@ namespace cryptonote
     }
     boost::interprocess::ipcdetail::atomic_write32(&m_stop, 0);
     boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);
+    build_affinity_plan();
     for(size_t i = 0; i != m_threads_total; i++)
       m_threads.push_back(boost::thread(m_attrs, boost::bind(&miner::worker_thread, this)));
   }
@@ -357,6 +543,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg_bg_mining_min_idle_interval_seconds);
     command_line::add_arg(desc, arg_bg_mining_idle_threshold_percentage);
     command_line::add_arg(desc, arg_bg_mining_miner_target_percentage);
+    command_line::add_arg(desc, arg_mining_affinity);
   }
   //-----------------------------------------------------------------------------------------------------
   bool miner::init(const boost::program_options::variables_map& vm, network_type nettype)
@@ -411,6 +598,7 @@ namespace cryptonote
         return false;
       }
     }
+    m_mining_affinity = command_line::get_arg(vm, arg_mining_affinity);
     if(!cryptonote::get_account_address_from_str(info, nettype, DONATION_ADDR))
     {
       LOG_ERROR("Invalid donation address, starting daemon canceled");
@@ -483,6 +671,7 @@ namespace cryptonote
     boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);
     // page situation can change between sessions, warn again if still bad
     m_slow_pages_warned = false;
+    build_affinity_plan();
     set_is_background_mining_enabled(do_background);
     set_ignore_battery(ignore_battery);
     
@@ -610,6 +799,13 @@ namespace cryptonote
     uint64_t height = 0;
     uint64_t local_diff = 0;
     uint32_t local_template_ver = 0;
+    if (th_local_index < m_affinity_plan.size())
+    {
+      if (pin_this_thread(m_affinity_plan[th_local_index]))
+        MDEBUG("Miner thread [" << th_local_index << "] pinned to cpu " << m_affinity_plan[th_local_index].second);
+      else
+        MDEBUG("Miner thread [" << th_local_index << "] could not be pinned");
+    }
     crypto::cn_hash_context_t *hash_context = crypto::cn_hash_context_create();
     if (hash_context == NULL)
     {

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -140,6 +140,9 @@ namespace cryptonote
     volatile uint32_t m_thread_index; 
     volatile uint32_t m_threads_total;
     std::atomic<uint32_t> m_threads_active;
+    // one user-facing warning per mining session when the v13 scratchpad
+    // ends up on slow pages, instead of a line per thread
+    std::atomic<bool> m_slow_pages_warned;
     uint8_t m_donate_percent;
     uint8_t m_donate_counter;
     volatile bool m_donating;

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -34,6 +34,8 @@
 #include <boost/program_options.hpp>
 #include <boost/logic/tribool_fwd.hpp>
 #include <atomic>
+#include <utility>
+#include <vector>
 #include "cryptonote_basic.h"
 #include "verification_context.h"
 #include "difficulty.h"
@@ -75,6 +77,9 @@ namespace cryptonote
     bool set_block_template(const block& bl, const uint64_t& diffic, uint64_t height, uint64_t block_reward);
     bool on_block_chain_update();
     bool start(const account_public_address& adr, size_t threads_count, bool do_background = false, bool ignore_battery = false);
+    // set before start() so a front end (e.g. NervaOne) can toggle core
+    // pinning over RPC without the daemon being launched with the flag
+    void set_mining_affinity(bool on) { m_mining_affinity = on; }
     uint64_t get_speed() const;
     uint32_t get_threads_count() const;
     void send_stop_signal();
@@ -116,6 +121,7 @@ namespace cryptonote
 
   private:
     bool worker_thread();
+    void build_affinity_plan();
     bool request_block_template();
     void  merge_hr();
     void  update_autodetection();
@@ -143,6 +149,9 @@ namespace cryptonote
     // one user-facing warning per mining session when the v13 scratchpad
     // ends up on slow pages, instead of a line per thread
     std::atomic<bool> m_slow_pages_warned;
+    // (windows group, cpu) per worker, built at start(); empty = no pinning
+    std::vector<std::pair<int, int>> m_affinity_plan;
+    bool m_mining_affinity;
     uint8_t m_donate_percent;
     uint8_t m_donate_counter;
     volatile bool m_donating;

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -139,6 +139,14 @@ namespace daemon_args
   , false
   };
 
+  const command_line::arg_descriptor<bool> arg_setup_large_pages = {
+    "setup-large-pages"
+  , "Grant \"Lock pages in memory\" to the current user so mining can use large pages, then exit. "
+    "Run once from an administrator prompt, takes effect after logging out and back in. Windows only, "
+    "Linux and FreeBSD need no setup"
+  , false
+  };
+
   const command_line::arg_descriptor<bool> arg_nodns = {
     "no-dns"
   , "Do not use DNS to get seed nodes, update links or anything else from the web"

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -132,6 +132,7 @@ int main(int argc, char const * argv[])
       command_line::add_arg(visible_options, command_line::arg_help);
       command_line::add_arg(visible_options, command_line::arg_version);
       command_line::add_arg(visible_options, daemon_args::arg_os_version);
+      command_line::add_arg(visible_options, daemon_args::arg_setup_large_pages);
       command_line::add_arg(visible_options, daemon_args::arg_config_file);
 
       // Settings
@@ -197,6 +198,18 @@ int main(int argc, char const * argv[])
     {
       std::cout << "OS: " << tools::get_os_version_string() << ENDL;
       return 0;
+    }
+
+    if (command_line::get_arg(vm, daemon_args::arg_setup_large_pages))
+    {
+#if defined(WIN32)
+      return tools::setup_large_pages_win();
+#else
+      std::cout << "Nothing to set up on this platform. Linux gets transparent hugepages "
+        "automatically (reserve vm.nr_hugepages yourself if you want guaranteed pages), "
+        "FreeBSD superpages just work, macOS exposes no huge page mechanism." << ENDL;
+      return 0;
+#endif
     }
 
     std::string config = command_line::get_arg(vm, daemon_args::arg_config_file);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1268,6 +1268,7 @@ namespace cryptonote
       res.status = "Already mining";
       return true;
     }
+    miner.set_mining_affinity(req.mining_affinity);
     if(!miner.start(info.address, static_cast<size_t>(req.threads_count), req.do_background_mining, req.ignore_battery))
     {
       res.status = "Failed, mining not started";

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -596,13 +596,15 @@ namespace cryptonote
       uint64_t    threads_count;
       bool        do_background_mining;
       bool        ignore_battery;
+      bool        mining_affinity;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(miner_address)
         KV_SERIALIZE(threads_count)
-        KV_SERIALIZE(do_background_mining)        
-        KV_SERIALIZE(ignore_battery)        
+        KV_SERIALIZE(do_background_mining)
+        KV_SERIALIZE(ignore_battery)
+        KV_SERIALIZE_OPT(mining_affinity, false)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;


### PR DESCRIPTION
Follow-up to the hashrate findings on discord. allocate_hugepage() fell back to plain malloc silently when huge pages were unavailable, so v13 mining just looked slow until the next reboot with nothing in the log explaining why.

What it does now:
- Linux: hugetlb, then a THP hint on regular pages (usually still 2 MB pages on default distro settings), then malloc
- Windows: large-page requests rounded up to GetLargePageMinimum() (the 1 MB pad and the salt could never qualify before), plus one retry after trimming our working set when the first attempt fails while SeLockMemory is held
- FreeBSD: superpage-aligned mapping, prefaulted so the kernel can promote it
- macOS/other BSDs: unchanged, just labeled honestly

New one-shot `nervad --setup-large-pages` for Windows: grants "Lock pages in memory" to your user through the LSA policy (works on Home which has no gpedit), run once as administrator and relogon. Explicit on purpose, the daemon never touches system policy on its own. Linux and FreeBSD need no setup.

Miner threads log which page tier their scratchpad landed on, and there is one visible warning per mining session (user log category, shows at every log level) when it ends up on plain pages, with instructions on how to fix it.

No consensus impact: page backing changes speed, not hash values. The PoW itself is untouched.



Follow-up to the affinity findings: new opt-in `--mining-affinity` pins one mining thread per physical core when mining starts (SMT siblings skipped), and keeps the whole set inside a single L3 group when the thread count fits, so the other chiplet stays with your apps. Per-thread, no privileges, dies with the process, off by default. Unreadable topology means it just does not pin.
