### PR TITLE
fix: lock the block cache in get_cna_v6_data

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2724,6 +2724,7 @@ void BlockchainLMDB::get_cna_v6_data(char *out, HC128_State *rng_state, uint64_t
   // and reduces post-HF13 sync time regardless of chain length.  The remaining
   // ~5% draw from the full history to preserve pool resistance.
   build_block_cache(height);
+  boost::shared_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
   const uint64_t window_size = (height > (uint64_t)CNA_V6_WINDOW_BLOCKS) ? (uint64_t)CNA_V6_WINDOW_BLOCKS : height;
   const uint64_t window_base = height - window_size;
 


### PR DESCRIPTION
Follow-up to #108, flagged by @sn1f3rt during that review.

#108 fixed a block-cache use-after-free for the `get_cna_v2/v4/v5_data` readers by holding a `boost::shared_lock` across their reads of `m_block_cache`. `get_cna_v6_data` — the CNA-v6 mining path that landed on `master` with HF13 (#101) — was missing the same guard: after `build_block_cache(height)` it reads `m_block_cache` in its hot loop (`bi = &m_block_cache[pick_index()]`) with no lock held, so a concurrent thread that grows the cache (`reserve`/`push_back`) can reallocate the vector and leave those pointers dangling.

## Fix
Take the same shared lock the other readers use, right after the `build_block_cache` call. `build_block_cache` acquires the unique lock internally and releases it before we take the shared lock, so there is no re-entrant deadlock, and `get_cna_v6_data` never calls `build_block_cache` again inside the loop.

```cpp
build_block_cache(height);
boost::shared_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
```

One line; the include and the `shared_mutex` are already present from #108.
