### PR TITLE
fix(miner): don't pin mining threads on Android

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -123,7 +123,14 @@ namespace cryptonote
     // (windows processor group, cpu index); group is -1 outside windows
     typedef std::pair<int, int> cpu_slot;
 
-#if defined(__linux__)
+// Android is excluded on purpose (falls through to the empty enumerator
+// below, so --mining-affinity is a no-op there). Phone SoCs are big.LITTLE
+// and expose no L3, so the plan's fallback pins one worker per core starting
+// at cpu0, the LITTLE (efficiency) cluster, cutting the hashrate several-fold
+// until Android's cpuset controller overrides the pin on a screen-state
+// change. Nothing to gain either: no big shared L3 to keep the scratchpad
+// resident in, and Android's own scheduler already places threads well.
+#if defined(__linux__) && !defined(__ANDROID__)
     std::vector<std::pair<cpu_slot, long>> enumerate_cores()
     {
       std::vector<std::pair<cpu_slot, long>> cores;


### PR DESCRIPTION
## What

`--mining-affinity` pins one mining worker per physical core starting at `cpu0`. On a big.LITTLE phone `cpu0` is the LITTLE (efficiency) cluster, so this pins the miner onto the slowest cores and cuts the hashrate several-fold (about 25 h/s pinned vs 200 unpinned in testing). It recovers only when Android's cpuset controller overrides our affinity on a screen-state change.

Two things conspire: mobile SoCs expose no shared L3, so the L3-grouping in the plan never applies and it always falls back to "first N cores"; and Android actively manages per-app cpusets, so a manual pin fights the OS.

This excludes Android from the core enumerator so `--mining-affinity` is a no-op there (falls through to the same empty enumerator macOS already uses). There's nothing to gain from pinning on a phone anyway: no big shared L3 to keep the 8 MB scratchpad resident in, and the OS scheduler already places threads well (hence the steady 200 h/s unpinned).

## Scope

This targets Android specifically, not ARM in general. The harm comes from *heterogeneous* cores: when the fast and slow clusters differ, pinning to the wrong ones is a large penalty. Homogeneous ARM (all cores identical) keeps affinity, because pinning one worker per core there just prevents scheduler migration between equal cores, which can only help or be neutral, never the several-fold hit seen on big.LITTLE. So there's no reason to disable it on those, and doing so would needlessly drop a working optimisation.

One gap left open on purpose: a big.LITTLE **Linux** SBC running the daemon directly could still hit the same first-N-cores trap. Affinity is opt-in (default off), and a general fix would need heterogeneity detection that the HF14 work won't need (see below), so it's not worth carrying.

## Note on HF14

Affinity is a v13-era optimisation; the HF14 work already in progress doesn't rely on it, so this won't be a concern there.