### PR TITLE
fix: anchor quicksync to checkpoints and harden the loader

### DIFF
--- a/src/checkpoints/quicksync.cpp
+++ b/src/checkpoints/quicksync.cpp
@@ -32,6 +32,7 @@
 
 #include "quicksync.h"
 
+#include "checkpoints.h"
 #include "common/dns_utils.h"
 #include "string_tools.h"
 #include "storages/portable_storage_template_helper.h" // epee json include
@@ -47,19 +48,36 @@ namespace cryptonote
 {
   quicksync::quicksync() { }
   //---------------------------------------------------------------------------
-  bool quicksync::check_block(uint32_t height, const crypto::hash h) const
+  bool quicksync::check_block(uint64_t height, const crypto::hash &h, bool &is_present) const
   {
+    is_present = false;
+
     if (!m_is_loaded)
       return false;
 
     auto it = m_data.find(height);
-    
-    if(it == m_data.end())
+
+    if (it == m_data.end())
       return false;
 
-    if (it->second != h)
-      return false;
-
+    is_present = true;
+    return it->second == h;
+  }
+  //---------------------------------------------------------------------------
+  bool quicksync::check_against_checkpoints(const checkpoints &cp) const
+  {
+    for (const auto &point : cp.get_points())
+    {
+      const uint64_t height = point.first;
+      auto it = m_data.find(height);
+      if (it == m_data.end())
+        continue;
+      if (it->second != point.second)
+      {
+        MERROR("Quick sync hash at height " << height << " conflicts with hardcoded checkpoint; rejecting quick sync file");
+        return false;
+      }
+    }
     return true;
   }
   //---------------------------------------------------------------------------
@@ -85,29 +103,57 @@ namespace cryptonote
     }
 
     uint32_t quicksync_magic = 0x149f943e;
-    
+
     uint32_t comp = 0;
     import_file.read ((char*)&comp, sizeof(comp));
-    
+
     if (comp != quicksync_magic)
     {
       MERROR("Quick sync file magic incorrect. ignoring file");
       return false;
     }
 
-    import_file.read ((char*)&m_min, sizeof(m_min));
-    import_file.read ((char*)&m_max, sizeof(m_max));
+    if (!import_file.read((char*)&m_min, sizeof(m_min)) ||
+        !import_file.read((char*)&m_max, sizeof(m_max)))
+    {
+      MERROR("Quick sync file header truncated. ignoring file");
+      return false;
+    }
+
+    if (m_min > m_max)
+    {
+      MERROR("Quick sync file header invalid: min " << m_min << " > max " << m_max << ". ignoring file");
+      return false;
+    }
+
+    // Bound the entry count by the real file size so a hostile header can't drive a huge allocation.
+    const std::streampos data_start = import_file.tellg();
+    import_file.seekg(0, std::ios::end);
+    const std::streamoff bytes_available = import_file.tellg() - data_start;
+    import_file.seekg(data_start);
+
+    const uint64_t count = (uint64_t)m_max - (uint64_t)m_min;
+    if (data_start == std::streampos(-1) || bytes_available < 0 ||
+        (uint64_t)bytes_available < count * sizeof(crypto::hash))
+    {
+      MERROR("Quick sync file truncated: header declares " << count << " hashes but file is too small. ignoring file");
+      return false;
+    }
 
     LOG_PRINT_L0("Loading quick sync data for blocks " << m_min << " - " << m_max);
 
-    uint32_t count = m_max - m_min;
-    uint32_t x = m_min;
+    uint64_t height = m_min;
 
-    for (uint32_t i = 0; i < count; i++)
+    for (uint64_t i = 0; i < count; i++)
     {
       crypto::hash h = crypto::null_hash;
-      import_file.read ((char*)&h.data, 32);
-      m_data[x++] = h;
+      if (!import_file.read((char*)&h.data, sizeof(h.data)))
+      {
+        MERROR("Quick sync file read failed at block " << height << ". ignoring file");
+        m_data.clear();
+        return false;
+      }
+      m_data[height++] = h;
     }
 
     m_is_loaded = true;

--- a/src/checkpoints/quicksync.h
+++ b/src/checkpoints/quicksync.h
@@ -37,11 +37,16 @@
 
 namespace cryptonote
 {
+  class checkpoints;
+
   class quicksync
   {
   public:
     quicksync();
-    bool check_block(uint32_t height, const crypto::hash h) const;
+    // is_present lets callers tell "absent" apart from "present but mismatching".
+    bool check_block(uint64_t height, const crypto::hash &h, bool &is_present) const;
+    // Trust anchor: rejects the file if any hash conflicts with a hardcoded checkpoint.
+    bool check_against_checkpoints(const checkpoints &cp) const;
     bool load(const std::string &qs_file);
     bool is_loaded() { return m_is_loaded; }
     uint32_t min() { return m_min; }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3570,27 +3570,26 @@ leave:
   crypto::hash proof_of_work;
   memset(proof_of_work.data, 0xff, sizeof(proof_of_work.data));
 
-  // Both skips below are bounded to the range the hardcoded checkpoints pin, and
-  // gated by --fast-block-sync; FAKECHAIN inherits the mainnet config but never
+  // Gated by --fast-block-sync; FAKECHAIN inherits the mainnet config but never
   // reaches that height.
   const uint64_t assume_valid_height = cryptonote::get_config(m_nettype).ASSUME_VALID_HEIGHT;
   const bool assume_valid = m_fast_sync && m_nettype != FAKECHAIN && assume_valid_height != 0 && blockchain_height < assume_valid_height;
 
-  // Above the highest checkpoint the file is unanchored, so PoW is always required.
-  const bool quicksync_active = m_fast_sync && m_nettype != FAKECHAIN && blockchain_height <= m_checkpoints.get_max_height();
+  // Quicksync is trusted only up to the checkpoint height it was anchored against
+  // (m_quicksync_max_height, captured at set_quicksync before any DNS/JSON checkpoints);
+  // above that it is unanchored, so PoW is always required.
+  const bool quicksync_active = m_fast_sync && m_nettype != FAKECHAIN && blockchain_height <= m_quicksync_max_height;
   bool quicksync_has_block = false;
   const bool quicksync_match = m_quicksync.check_block(blockchain_height, id, quicksync_has_block);
-
-  // A present-but-mismatching entry must fail hard, not fall through to the assume-valid skip.
-  if (quicksync_active && quicksync_has_block && !quicksync_match)
-  {
-    MERROR_VER("Block with id: " << id << " at height " << blockchain_height << " does not match the quick sync hash");
-    bvc.m_verifivation_failed = true;
-    goto leave;
-  }
-
   const bool quicksync_verified = quicksync_active && quicksync_match;
-  if (!quicksync_verified && !assume_valid)
+
+  // A present-but-mismatching entry could be a forged block or a wrong/corrupt file;
+  // let PoW decide rather than trusting the file or stalling the node on a bad file.
+  const bool quicksync_conflict = quicksync_active && quicksync_has_block && !quicksync_match;
+  if (quicksync_conflict)
+    MWARNING("Block with id: " << id << " at height " << blockchain_height << " does not match the quick sync hash; verifying PoW");
+
+  if ((!quicksync_verified && !assume_valid) || quicksync_conflict)
   {
     get_block_longhash(m_hash_context, this, bl, proof_of_work, blockchain_height);
 
@@ -4116,7 +4115,11 @@ void Blockchain::set_quicksync(quicksync&& qs)
     MERROR("Quick sync data conflicts with hardcoded checkpoints; ignoring quick sync file");
     return;
   }
-  m_quicksync = qs;
+  // Pin the trusted range to the checkpoints just validated against. This runs
+  // before DNS/JSON checkpoints load, so it is the hardcoded checkpoint max and
+  // can't be stretched at runtime.
+  m_quicksync_max_height = m_checkpoints.get_max_height();
+  m_quicksync = std::move(qs);
 }
 //------------------------------------------------------------------
 bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3570,22 +3570,26 @@ leave:
   crypto::hash proof_of_work;
   memset(proof_of_work.data, 0xff, sizeof(proof_of_work.data));
 
-  // An earlier revision skipped PoW for the entire checkpoint zone unconditionally
-  // (an unanchored, dangerous skip) and that was removed. The assume-valid skip
-  // below is the deliberate, bounded replacement: PoW is dropped only for blocks
-  // beneath a hardcoded checkpoint that already pins them by hash, and only during
-  // flag-gated fast sync.
-  // FIXME: height parameter is not used...should it be used or should it not
-  // be a parameter?
-  // validate proof_of_work versus difficulty target
-
-  // Skip PoW for deep historical blocks below ASSUME_VALID_HEIGHT during sync
-  // (anchored by a checkpoint). Gated by --fast-block-sync; FAKECHAIN excluded
-  // as it inherits the mainnet config but never reaches that height.
+  // Both skips below are bounded to the range the hardcoded checkpoints pin, and
+  // gated by --fast-block-sync; FAKECHAIN inherits the mainnet config but never
+  // reaches that height.
   const uint64_t assume_valid_height = cryptonote::get_config(m_nettype).ASSUME_VALID_HEIGHT;
   const bool assume_valid = m_fast_sync && m_nettype != FAKECHAIN && assume_valid_height != 0 && blockchain_height < assume_valid_height;
 
-  const bool quicksync_verified = m_quicksync.check_block(blockchain_height, id);
+  // Above the highest checkpoint the file is unanchored, so PoW is always required.
+  const bool quicksync_active = m_fast_sync && m_nettype != FAKECHAIN && blockchain_height <= m_checkpoints.get_max_height();
+  bool quicksync_has_block = false;
+  const bool quicksync_match = m_quicksync.check_block(blockchain_height, id, quicksync_has_block);
+
+  // A present-but-mismatching entry must fail hard, not fall through to the assume-valid skip.
+  if (quicksync_active && quicksync_has_block && !quicksync_match)
+  {
+    MERROR_VER("Block with id: " << id << " at height " << blockchain_height << " does not match the quick sync hash");
+    bvc.m_verifivation_failed = true;
+    goto leave;
+  }
+
+  const bool quicksync_verified = quicksync_active && quicksync_match;
   if (!quicksync_verified && !assume_valid)
   {
     get_block_longhash(m_hash_context, this, bl, proof_of_work, blockchain_height);
@@ -4103,7 +4107,17 @@ void Blockchain::set_enforce_dns_checkpoints(bool enforce_checkpoints)
 {
   m_enforce_dns_checkpoints = enforce_checkpoints;
 }
-
+//------------------------------------------------------------------
+void Blockchain::set_quicksync(quicksync&& qs)
+{
+  // Reject an unanchored/forged file rather than trusting it to skip PoW.
+  if (!qs.check_against_checkpoints(m_checkpoints))
+  {
+    MERROR("Quick sync data conflicts with hardcoded checkpoints; ignoring quick sync file");
+    return;
+  }
+  m_quicksync = qs;
+}
 //------------------------------------------------------------------
 bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
 {

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1067,6 +1067,7 @@ namespace cryptonote
     checkpoints m_checkpoints;
     bool m_enforce_dns_checkpoints;
     quicksync m_quicksync;
+    uint64_t m_quicksync_max_height = 0; // top checkpoint quicksync was anchored against; PoW-skip ceiling
 
     HardFork *m_hardfork;
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -738,7 +738,7 @@ namespace cryptonote
     bool update_checkpoints(const std::string& file_path, bool check_dns);
 
     quicksync get_quicksync() const { return m_quicksync; }
-    void set_quicksync(quicksync&& qs) { m_quicksync = qs; }
+    void set_quicksync(quicksync&& qs);
 
     // user options, must be called before calling init()
 


### PR DESCRIPTION
Closes #114.

Anchors the quicksync trust system to the compiled-in checkpoints and hardens the loader. Three defects, one root cause: the downloaded `quicksync.raw` was trusted with no cryptographic anchor and no bounds.

## Changes

**`quicksync::load()` hardening (H1)**
- Check every header/hash read succeeds; reject `min > max`.
- Compute the entry count in 64-bit and bound it by the actual file size before allocating, so a corrupt/hostile header can't drive an unbounded allocation (previously `count = m_max - m_min` underflowed to ~4.29e9 and OOM'd).
- Store 64-bit heights (was a `uint32_t` counter that could wrap).

**Checkpoint anchoring (C1)**
- New `quicksync::check_against_checkpoints()` compares every quicksync hash at a hardcoded-checkpoint height and rejects the whole file on any conflict.
- `Blockchain::set_quicksync()` is now a validating setter that drops a conflicting file instead of trusting it, and records the checkpoint height it validated against (`m_quicksync_max_height`). This runs during `handle_command_line`, before DNS/JSON checkpoints load, so it captures the hardcoded checkpoint max.

**Consume path (C1 + M2)** (`handle_block_to_main_chain`)
- Quicksync may only skip PoW when `--fast-block-sync` is on and `height <= m_quicksync_max_height` (the checkpoint height it was anchored against). Above that the file is unanchored, so PoW is always required. Because the ceiling is captured before DNS/JSON checkpoints load, runtime checkpoints can't stretch the trusted range past what was validated. Also fixes quicksync ignoring `--fast-block-sync 0`.
- A quicksync entry that is present but whose hash mismatches now falls back to full PoW (with a warning) rather than being trusted or hard-failing: a real block still verifies, a forged one still fails PoW, and a wrong/corrupt file only loses the skip-speedup instead of stalling the node.

Net effect: quicksync becomes a checkpoint-anchored PoW-skip within the validated range, and defers to PoW everywhere else.

## Testing

- `make obj_checkpoints` and `make obj_cryptonote_core` build clean; all static libraries link. (The only unresolved symbol in a full `nervad` link is the pre-existing `_IOPSGetTimeRemainingEstimate` from `miner.cpp` on native macOS, unrelated to this change.)
- Unit-tested `quicksync::load()`, `check_against_checkpoints()`, and `check_block()` via a standalone harness linked against `libcheckpoints.a` (17/17): parser rejects `min > max` / truncated / oversized-count / short-body files with no OOM, the checkpoint cross-check accepts matching and rejects conflicting files, and `check_block` distinguishes absent / matching / mismatching. (See PR comment for the full case list.)
- Reviewed against the export format (`quicksync_file.cpp` writes `[start, stop]` inclusive): the file-size bound has one hash of slack versus `count = m_max - m_min`, so a valid file is never rejected.
- Only one caller of the changed `check_block` signature exists (the consume path). testnet/stagenet have no compiled-in checkpoints, so `m_quicksync_max_height` is 0 and quicksync is inert there (safe).

## Scope

C1/H1/M2 only. The `assume_valid` fast-sync behavior below the HF13 height is unchanged and remains checkpoint-anchored. Other review findings are tracked separately.
