### PR TITLE
Hard fork 14: CLSAG + Bulletproofs+, CryptoNight-Adaptive v7

### DIFF
--- a/contrib/hf14checks/CMakeLists.txt
+++ b/contrib/hf14checks/CMakeLists.txt
@@ -1,0 +1,59 @@
+# Out-of-tree checks for the HF14 port (#117, tracking issue #116).
+# Deliberately NOT wired into the main build: configure the tree once, build
+# it, then point this at the build directory and run the binaries.
+#
+#   cmake -S contrib/hf14checks -B contrib/hf14checks/build \
+#         -DNERVA_BUILD=/path/to/nerva/build
+#   cmake --build contrib/hf14checks/build
+#   ctest --test-dir contrib/hf14checks/build --output-on-failure
+cmake_minimum_required(VERSION 3.10)
+project(hf14checks C CXX)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
+
+get_filename_component(NERVA_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
+set(NERVA_BUILD "${NERVA_ROOT}/build" CACHE PATH "A configured and built nerva build directory")
+
+if (NOT EXISTS "${NERVA_BUILD}/src/crypto/libcncrypto.a")
+  message(FATAL_ERROR "NERVA_BUILD=${NERVA_BUILD} does not look like a built tree (build the daemon first)")
+endif ()
+
+include_directories(
+  "${NERVA_ROOT}/src"
+  "${NERVA_ROOT}/contrib/epee/include"
+  "${NERVA_ROOT}/external/easylogging++"
+  "${NERVA_ROOT}/external"
+  "${NERVA_ROOT}/external/rapidjson/include")
+
+find_package(Boost REQUIRED COMPONENTS serialization thread chrono system filesystem regex)
+find_package(Threads REQUIRED)
+find_package(OpenSSL REQUIRED)
+
+set(NERVA_LIBS
+  "${NERVA_BUILD}/src/ringct/libringct.a"
+  "${NERVA_BUILD}/src/ringct/libringct_basic.a"
+  "${NERVA_BUILD}/src/cryptonote_basic/libcryptonote_basic.a"
+  "${NERVA_BUILD}/src/serialization/libserialization.a"
+  "${NERVA_BUILD}/src/device/libdevice.a"
+  "${NERVA_BUILD}/src/crypto/libcncrypto.a"
+  "${NERVA_BUILD}/src/common/libcommon.a"
+  "${NERVA_BUILD}/contrib/epee/src/libepee.a"
+  "${NERVA_BUILD}/external/easylogging++/libeasylogging.a")
+
+enable_testing()
+
+function(hf14check name)
+  add_executable(${name} ${ARGN})
+  target_link_libraries(${name}
+    -Wl,--start-group ${NERVA_LIBS} -Wl,--end-group
+    ${Boost_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto
+    sodium unbound Threads::Threads ${CMAKE_DL_LIBS})
+  add_test(NAME ${name} COMMAND ${name})
+endfunction()
+
+hf14check(t_bp_plus t_bp_plus.cpp)
+hf14check(t_clsag t_clsag.cpp)
+hf14check(t_serialization t_serialization.cpp)
+hf14check(t_fee_weight t_fee_weight.cpp)
+hf14check(t_cna_v7 t_cna_v7.cpp)

--- a/contrib/hf14checks/check.h
+++ b/contrib/hf14checks/check.h
@@ -1,0 +1,42 @@
+// Tiny check framework for the HF14 out-of-tree harness. Deliberately no
+// gtest: these binaries build against the normal tree and run anywhere.
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+
+static int hf14checks_failures = 0;
+static int hf14checks_checks = 0;
+
+#define CHECK_TRUE(expr) \
+    do { \
+        ++hf14checks_checks; \
+        if (!(expr)) { \
+            ++hf14checks_failures; \
+            std::fprintf(stderr, "FAIL %s:%d: expected true: %s\n", __FILE__, __LINE__, #expr); \
+        } \
+    } while (0)
+
+#define CHECK_FALSE(expr) \
+    do { \
+        ++hf14checks_checks; \
+        if (expr) { \
+            ++hf14checks_failures; \
+            std::fprintf(stderr, "FAIL %s:%d: expected false: %s\n", __FILE__, __LINE__, #expr); \
+        } \
+    } while (0)
+
+#define RUN(fn) \
+    do { \
+        std::printf("-- %s\n", #fn); \
+        fn(); \
+    } while (0)
+
+static int check_summary(const char *name)
+{
+    if (hf14checks_failures == 0)
+        std::printf("%s: %d checks, all passed\n", name, hf14checks_checks);
+    else
+        std::printf("%s: %d of %d checks FAILED\n", name, hf14checks_failures, hf14checks_checks);
+    return hf14checks_failures == 0 ? 0 : 1;
+}

--- a/contrib/hf14checks/rct_samples.h
+++ b/contrib/hf14checks/rct_samples.h
@@ -1,0 +1,67 @@
+// Real ring signatures for the HF14 glue checks: genRctSimple output at a
+// given bp_version, with a synthetic ring per input. bp_version 2 must come
+// out type 5 (Bulletproof2), 3 -> type 6 (CLSAG + BP), 4 -> type 7
+// (CLSAG + BP+); the callers assert that.
+#pragma once
+
+#include <vector>
+
+#include "ringct/rctOps.h"
+#include "ringct/rctSigs.h"
+#include "device/device.hpp"
+
+static rct::rctSig make_sample_sig(int bp_version, size_t nin, size_t nout, size_t ring_size)
+{
+  using namespace rct;
+
+  ctkeyV inSk;
+  ctkeyM mixRing;
+  keyV destinations, amount_keys;
+  std::vector<xmr_amount> inamounts, outamounts;
+  std::vector<unsigned int> index;
+  const xmr_amount fee = 5000;
+
+  xmr_amount total = 0;
+  for (size_t i = 0; i < nin; ++i)
+  {
+    const xmr_amount amount = 1000000 + i;
+    total += amount;
+    inamounts.push_back(amount);
+
+    ctkey sk, pk;
+    skpkGen(sk.dest, pk.dest);
+    sk.mask = skGen();
+    // v2 = rct::H, the generator every genRctSimple_v2/_v3 commitment uses
+    pk.mask = commit(amount, sk.mask, true);
+    inSk.push_back(sk);
+
+    ctkeyV ring(ring_size);
+    for (size_t j = 0; j < ring_size; ++j)
+    {
+      ring[j].dest = pkGen();
+      ring[j].mask = pkGen();
+    }
+    const size_t real = i % ring_size;
+    ring[real] = pk;
+    mixRing.push_back(ring);
+    index.push_back((unsigned int)real);
+  }
+
+  xmr_amount left = total - fee;
+  for (size_t o = 0; o < nout; ++o)
+  {
+    key osk, opk;
+    skpkGen(osk, opk);
+    destinations.push_back(opk);
+    amount_keys.push_back(skGen());
+    const xmr_amount amt = (o + 1 == nout) ? left : (total - fee) / nout;
+    outamounts.push_back(amt);
+    left -= amt;
+  }
+
+  ctkeyV outSk;
+  const RCTConfig cfg{RangeProofPaddedBulletproof, bp_version};
+  return genRctSimple(zero(), inSk, destinations, inamounts, outamounts, fee,
+                      mixRing, amount_keys, NULL, NULL, index, outSk, cfg,
+                      hw::get_device("default"));
+}

--- a/contrib/hf14checks/t_bp_plus.cpp
+++ b/contrib/hf14checks/t_bp_plus.cpp
@@ -1,0 +1,156 @@
+// Bulletproofs+ battery, ported from Monero master 52f02f2
+// tests/unit_tests/bulletproofs_plus.cpp. Test bodies are kept as upstream
+// wrote them; only the gtest scaffolding is replaced. Covers valid proofs
+// (zero, max, random, multi-output, aggregated batches), invalid scalars,
+// and torsioned points on every proof element.
+#include "check.h"
+
+#include "string_tools.h"
+#include "ringct/rctOps.h"
+#include "ringct/rctSigs.h"
+#include "ringct/bulletproofs_plus.h"
+#include "crypto/crypto.h"
+
+using namespace rct;
+
+static void valid_zero()
+{
+  BulletproofPlus proof = bulletproof_plus_PROVE(0, skGen());
+  CHECK_TRUE(bulletproof_plus_VERIFY(proof));
+}
+
+static void valid_max()
+{
+  BulletproofPlus proof = bulletproof_plus_PROVE(0xffffffffffffffff, skGen());
+  CHECK_TRUE(bulletproof_plus_VERIFY(proof));
+}
+
+static void valid_random()
+{
+  for (int n = 0; n < 8; ++n)
+  {
+    BulletproofPlus proof = bulletproof_plus_PROVE(crypto::rand<uint64_t>(), skGen());
+    CHECK_TRUE(bulletproof_plus_VERIFY(proof));
+  }
+}
+
+static void valid_multi_random()
+{
+  for (int n = 0; n < 8; ++n)
+  {
+    size_t outputs = 2 + n;
+    std::vector<uint64_t> amounts;
+    keyV gamma;
+    for (size_t i = 0; i < outputs; ++i)
+    {
+      amounts.push_back(crypto::rand<uint64_t>());
+      gamma.push_back(skGen());
+    }
+    BulletproofPlus proof = bulletproof_plus_PROVE(amounts, gamma);
+    CHECK_TRUE(bulletproof_plus_VERIFY(proof));
+  }
+}
+
+static void valid_aggregated()
+{
+  static const size_t N_PROOFS = 8;
+  std::vector<BulletproofPlus> proofs(N_PROOFS);
+  for (size_t n = 0; n < N_PROOFS; ++n)
+  {
+    size_t outputs = 2 + n;
+    std::vector<uint64_t> amounts;
+    keyV gamma;
+    for (size_t i = 0; i < outputs; ++i)
+    {
+      amounts.push_back(crypto::rand<uint64_t>());
+      gamma.push_back(skGen());
+    }
+    proofs[n] = bulletproof_plus_PROVE(amounts, gamma);
+  }
+  CHECK_TRUE(bulletproof_plus_VERIFY(proofs));
+}
+
+static void invalid_8()
+{
+  key invalid_amount = zero();
+  invalid_amount[8] = 1;
+  BulletproofPlus proof = bulletproof_plus_PROVE(invalid_amount, skGen());
+  CHECK_FALSE(bulletproof_plus_VERIFY(proof));
+}
+
+static void invalid_31()
+{
+  key invalid_amount = zero();
+  invalid_amount[31] = 1;
+  BulletproofPlus proof = bulletproof_plus_PROVE(invalid_amount, skGen());
+  CHECK_FALSE(bulletproof_plus_VERIFY(proof));
+}
+
+static const char * const torsion_elements[] =
+{
+  "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa",
+  "0000000000000000000000000000000000000000000000000000000000000000",
+  "26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc85",
+  "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+  "26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc05",
+  "0000000000000000000000000000000000000000000000000000000000000080",
+  "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a",
+};
+
+static void invalid_torsion()
+{
+  BulletproofPlus proof = bulletproof_plus_PROVE(7329838943733, skGen());
+  CHECK_TRUE(bulletproof_plus_VERIFY(proof));
+  for (const auto &xs: torsion_elements)
+  {
+    key x;
+    CHECK_TRUE(epee::string_tools::hex_to_pod(xs, x));
+    CHECK_FALSE(isInMainSubgroup(x));
+    for (auto &k: proof.V)
+    {
+      const key org_k = k;
+      addKeys(k, org_k, x);
+      CHECK_FALSE(bulletproof_plus_VERIFY(proof));
+      k = org_k;
+    }
+    for (auto &k: proof.L)
+    {
+      const key org_k = k;
+      addKeys(k, org_k, x);
+      CHECK_FALSE(bulletproof_plus_VERIFY(proof));
+      k = org_k;
+    }
+    for (auto &k: proof.R)
+    {
+      const key org_k = k;
+      addKeys(k, org_k, x);
+      CHECK_FALSE(bulletproof_plus_VERIFY(proof));
+      k = org_k;
+    }
+    const key org_A = proof.A;
+    addKeys(proof.A, org_A, x);
+    CHECK_FALSE(bulletproof_plus_VERIFY(proof));
+    proof.A = org_A;
+    const key org_A1 = proof.A1;
+    addKeys(proof.A1, org_A1, x);
+    CHECK_FALSE(bulletproof_plus_VERIFY(proof));
+    proof.A1 = org_A1;
+    const key org_B = proof.B;
+    addKeys(proof.B, org_B, x);
+    CHECK_FALSE(bulletproof_plus_VERIFY(proof));
+    proof.B = org_B;
+  }
+}
+
+int main()
+{
+  RUN(valid_zero);
+  RUN(valid_max);
+  RUN(valid_random);
+  RUN(valid_multi_random);
+  RUN(valid_aggregated);
+  RUN(invalid_8);
+  RUN(invalid_31);
+  RUN(invalid_torsion);
+  return check_summary("t_bp_plus");
+}

--- a/contrib/hf14checks/t_clsag.cpp
+++ b/contrib/hf14checks/t_clsag.cpp
@@ -1,0 +1,181 @@
+// CLSAG battery, ported from Monero master 52f02f2 tests/unit_tests/ringct.cpp
+// TEST(ringct, CLSAG). Body kept as upstream wrote it; gtest scaffolding
+// replaced. Covers a correct signature plus every tamper case upstream
+// exercises: bad message, index, z, C, p, P at creation; empty / short /
+// long / corrupted s, bad c1, bad I, bad D, torsioned D, swapped I and D
+// at verification.
+#include "check.h"
+
+#include "string_tools.h"
+#include "ringct/rctOps.h"
+#include "ringct/rctSigs.h"
+#include "device/device.hpp"
+
+using namespace rct;
+
+static void clsag_battery()
+{
+  const size_t N = 11;
+  const size_t idx = 5;
+  ctkeyV pubs;
+  key p, t, t2, u;
+  const key message = identity();
+  ctkey backup;
+  clsag sig;
+
+  for (size_t i = 0; i < N; ++i)
+  {
+    key sk;
+    ctkey tmp;
+
+    skpkGen(sk, tmp.dest);
+    skpkGen(sk, tmp.mask);
+
+    pubs.push_back(tmp);
+  }
+
+  // Set P[idx]
+  skpkGen(p, pubs[idx].dest);
+
+  // Set C[idx]
+  t = skGen();
+  u = skGen();
+  addKeys2(pubs[idx].mask, t, u, H);
+
+  // Set commitment offset
+  key Cout;
+  t2 = skGen();
+  addKeys2(Cout, t2, u, H);
+
+  // Prepare generation inputs
+  ctkey insk;
+  insk.dest = p;
+  insk.mask = t;
+
+  // bad message
+  sig = proveRctCLSAGSimple(zero(), pubs, insk, t2, Cout, idx, hw::get_device("default"));
+  CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+
+  // bad index at creation
+  try
+  {
+    sig = proveRctCLSAGSimple(message, pubs, insk, t2, Cout, (idx + 1) % N, hw::get_device("default"));
+    CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  }
+  catch (...) { /* either exception, or failure to verify above */ }
+
+  // bad z at creation
+  try
+  {
+    ctkey insk2;
+    insk2.dest = insk.dest;
+    insk2.mask = skGen();
+    sig = proveRctCLSAGSimple(message, pubs, insk2, t2, Cout, idx, hw::get_device("default"));
+    CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  }
+  catch (...) { /* either exception, or failure to verify above */ }
+
+  // bad C at creation
+  backup = pubs[idx];
+  pubs[idx].mask = scalarmultBase(skGen());
+  try
+  {
+    sig = proveRctCLSAGSimple(message, pubs, insk, t2, Cout, idx, hw::get_device("default"));
+    CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  }
+  catch (...) { /* either exception, or failure to verify above */ }
+  pubs[idx] = backup;
+
+  // bad p at creation
+  try
+  {
+    ctkey insk2;
+    insk2.dest = skGen();
+    insk2.mask = insk.mask;
+    sig = proveRctCLSAGSimple(message, pubs, insk2, t2, Cout, idx, hw::get_device("default"));
+    CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  }
+  catch (...) { /* either exception, or failure to verify above */ }
+
+  // bad P at creation
+  backup = pubs[idx];
+  pubs[idx].dest = scalarmultBase(skGen());
+  try
+  {
+    sig = proveRctCLSAGSimple(message, pubs, insk, t2, Cout, idx, hw::get_device("default"));
+    CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  }
+  catch (...) { /* either exception, or failure to verify above */ }
+  pubs[idx] = backup;
+
+  // Test correct signature
+  sig = proveRctCLSAGSimple(message, pubs, insk, t2, Cout, idx, hw::get_device("default"));
+  CHECK_TRUE(verRctCLSAGSimple(message, sig, pubs, Cout));
+
+  // empty s
+  auto sbackup = sig.s;
+  sig.s.clear();
+  CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  sig.s = sbackup;
+
+  // too few s elements
+  key backup_key;
+  backup_key = sig.s.back();
+  sig.s.pop_back();
+  CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  sig.s.push_back(backup_key);
+
+  // too many s elements
+  sig.s.push_back(skGen());
+  CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  sig.s.pop_back();
+
+  // bad s in clsag at verification
+  for (auto &s: sig.s)
+  {
+    backup_key = s;
+    s = skGen();
+    CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+    s = backup_key;
+  }
+
+  // bad c1 in clsag at verification
+  backup_key = sig.c1;
+  sig.c1 = skGen();
+  CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  sig.c1 = backup_key;
+
+  // bad I in clsag at verification
+  backup_key = sig.I;
+  sig.I = scalarmultBase(skGen());
+  CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  sig.I = backup_key;
+
+  // bad D in clsag at verification
+  backup_key = sig.D;
+  sig.D = scalarmultBase(skGen());
+  CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  sig.D = backup_key;
+
+  // D not in main subgroup in clsag at verification
+  backup_key = sig.D;
+  key x;
+  CHECK_TRUE(epee::string_tools::hex_to_pod("c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa", x));
+  sig.D = addKeys(sig.D, x);
+  CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  sig.D = backup_key;
+
+  // swapped I and D in clsag at verification
+  std::swap(sig.I, sig.D);
+  CHECK_FALSE(verRctCLSAGSimple(message, sig, pubs, Cout));
+  std::swap(sig.I, sig.D);
+
+  // check it's still good, in case we failed to restore
+  CHECK_TRUE(verRctCLSAGSimple(message, sig, pubs, Cout));
+}
+
+int main()
+{
+  RUN(clsag_battery);
+  return check_summary("t_clsag");
+}

--- a/contrib/hf14checks/t_cna_v7.cpp
+++ b/contrib/hf14checks/t_cna_v7.cpp
@@ -1,0 +1,303 @@
+// CNA v7 has no upstream to diff against, so it gets a standalone reference:
+// the fill and the chase are reimplemented here from the spec in cna-vm.h and
+// the commit message, and compared bit-for-bit against the library. On top of
+// that, full-hash properties: determinism, the two review regressions (seed
+// tail sensitivity, zero-seed buffer population), the ~63% mutation coverage
+// the residency argument rests on, and the HW/SW self-test.
+#include "check.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+// hash-ops.h and cna-vm.h are C headers and pull stdint only for C
+using std::uint8_t; using std::uint16_t; using std::uint32_t; using std::uint64_t;
+using std::size_t;
+
+extern "C" {
+#include "crypto/hash-ops.h"
+#include "crypto/cna-vm.h"
+}
+
+// ---------------------------------------------------------------------------
+// Reference implementation. Plain scalar C++, no code shared with cna-vm.c
+// or slow-hash-impl.h beyond the instruction struct and the constants.
+// ---------------------------------------------------------------------------
+
+static uint64_t ref_ror64(uint64_t x, unsigned n)
+{
+  n &= 63;
+  return n ? (x >> n) | (x << (64 - n)) : x;
+}
+
+static uint64_t ref_mix64(uint64_t val, uint32_t key_material)
+{
+  uint64_t k = (uint64_t)key_material * UINT64_C(0x9e3779b97f4a7c15);
+  val ^= k;
+  val ^= val >> 30;
+  val *= UINT64_C(0xbf58476d1ce4e5b9);
+  val ^= val >> 27;
+  val *= UINT64_C(0x94d049bb133111eb);
+  val ^= val >> 31;
+  return val;
+}
+
+// One v7 pass: CN_V7_SEGMENTS x [serial chase, program slice]. The walk maps
+// the chain value into the buffer via the high word of chain * qwords, writes
+// each cell back XORed with the live chain, and hands the read values to
+// SP_READ in order. wchain folds into regs[0] at the end of the pass.
+static void ref_execute_v7(const cn_vm_program_t *prog, uint8_t *buffer, uint64_t buffer_qwords,
+                           uint8_t *pad, uint64_t regs[CN_REG_COUNT], uint64_t *chain_state)
+{
+  const size_t sp_mask   = (size_t)(CN_SCRATCHPAD_MEMORY_V14 - 1) & ~(size_t)7;
+  const int    seg_hops  = CN_V7_HOPS / CN_V7_SEGMENTS;
+  const int    seg_steps = CN_PROGRAM_SIZE / CN_V7_SEGMENTS;
+
+  int pc = 0;
+  unsigned consume = 0;
+  uint64_t wchain = 0;
+  uint64_t chain = *chain_state;
+  std::vector<uint64_t> vals(CN_V7_HOPS);
+
+  for (int seg = 0; seg < CN_V7_SEGMENTS; seg++)
+  {
+    chain ^= regs[seg & (CN_REG_COUNT - 1)];
+    for (int h = 0; h < seg_hops; h++)
+    {
+      const uint64_t idx = (uint64_t)(((unsigned __int128)chain * buffer_qwords) >> 64);
+      uint64_t v;
+      memcpy(&v, buffer + idx * sizeof(uint64_t), sizeof(uint64_t));
+      const uint64_t mut = v ^ chain;
+      memcpy(buffer + idx * sizeof(uint64_t), &mut, sizeof(uint64_t));
+      chain = v + (uint64_t)h;
+      vals[seg * seg_hops + h] = v;
+    }
+
+    for (int step = 0; step < seg_steps; step++)
+    {
+      const cn_vm_instruction_t *ins = &prog->instructions[pc & (CN_PROGRAM_SIZE - 1)];
+      int next_pc = pc + 1;
+      const uint8_t dst = ins->dst;
+      const uint8_t src = ins->src;
+
+      switch ((cn_vm_opcode_t)ins->op)
+      {
+      case CN_OP_IADD_RS: regs[dst] += regs[src] << (ins->shift & 3); break;
+      case CN_OP_ISUB:    regs[dst] -= regs[src]; break;
+      case CN_OP_IMUL:    regs[dst] *= regs[src]; break;
+      case CN_OP_IXOR:    regs[dst] ^= regs[src]; break;
+      case CN_OP_IROR:    regs[dst] = ref_ror64(regs[dst], (unsigned)(regs[src] & 63)); break;
+      case CN_OP_CBRANCH:
+        if (regs[dst] & ((uint64_t)ins->imm | 1))
+          next_pc = (pc + (int)((int8_t)ins->shift) + CN_PROGRAM_SIZE) & (CN_PROGRAM_SIZE - 1);
+        break;
+      case CN_OP_SP_READ:
+        regs[dst] ^= vals[consume & (CN_V7_HOPS - 1)] + (uint64_t)ins->imm;
+        consume++;
+        break;
+      case CN_OP_SP_WRITE:
+      {
+        const size_t addr = ((size_t)(regs[dst] + (uint64_t)ins->imm + wchain)) & sp_mask;
+        uint64_t tmp;
+        memcpy(&tmp, &pad[addr], sizeof(uint64_t));
+        tmp ^= regs[src];
+        memcpy(&pad[addr], &tmp, sizeof(uint64_t));
+        wchain += tmp;
+        break;
+      }
+      case CN_OP_MIX:     regs[dst] = ref_mix64(regs[dst] ^ regs[src], ins->imm); break;
+      default: break;
+      }
+      pc = next_pc;
+    }
+  }
+
+  *chain_state = chain;
+  regs[0] ^= wchain;
+}
+
+// The buffer fill: all 32 seed bytes folded into the start value, then the
+// xorshift-multiply map per cell.
+static void ref_fill(uint8_t *buffer, uint64_t buffer_qwords, const uint8_t seed[32])
+{
+  uint64_t fx = UINT64_C(0x9e3779b97f4a7c15);
+  for (int sj = 0; sj < 4; sj++)
+  {
+    uint64_t sq;
+    memcpy(&sq, seed + sj * sizeof(uint64_t), sizeof(uint64_t));
+    fx = (fx ^ sq) * UINT64_C(0xbf58476d1ce4e5b9);
+    fx ^= fx >> 29;
+  }
+  if (fx == 0)
+    fx = UINT64_C(0x9e3779b97f4a7c15);
+  uint64_t *bw = (uint64_t *)buffer;
+  for (uint64_t bi = 0; bi < buffer_qwords; bi++)
+  {
+    fx = (fx ^ (fx >> 29)) * UINT64_C(0xbf58476d1ce4e5b9);
+    bw[bi] = fx;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+// cn_vm_execute_v7 against the reference: same program, same fill, several
+// passes, buffer sizes including a non-power-of-two qword count. Buffer, pad,
+// registers and chain must agree bit-for-bit.
+static void chase_matches_reference()
+{
+  const uint64_t sizes_qwords[] = {
+    (1u << 17),          // 1 MB
+    (1u << 18) + 3,      // ~2 MB, odd length: no power-of-two assumption
+    393216,              // 3 MB
+  };
+  uint8_t seed[32];
+  for (int i = 0; i < 32; i++)
+    seed[i] = (uint8_t)(i * 41 + 7);
+
+  cn_vm_program_t prog;
+  cn_vm_generate_program(&prog, seed);
+
+  for (uint64_t bq : sizes_qwords)
+  {
+    std::vector<uint8_t> buf_lib(bq * 8), buf_ref(bq * 8);
+    std::vector<uint8_t> pad_lib(CN_SCRATCHPAD_MEMORY_V14), pad_ref(CN_SCRATCHPAD_MEMORY_V14);
+    ref_fill(buf_lib.data(), bq, seed);
+    ref_fill(buf_ref.data(), bq, seed);
+    for (size_t i = 0; i < pad_lib.size(); i++)
+      pad_lib[i] = pad_ref[i] = (uint8_t)(i * 13 + 5);
+
+    uint64_t regs_lib[CN_REG_COUNT], regs_ref[CN_REG_COUNT];
+    for (int r = 0; r < CN_REG_COUNT; r++)
+      regs_lib[r] = regs_ref[r] = UINT64_C(0x0123456789abcdef) * (r + 1) + bq;
+    uint64_t chain_lib = 0xfeedface + bq, chain_ref = chain_lib;
+
+    const int passes = 16;
+    for (int p = 0; p < passes; p++)
+    {
+      cn_vm_execute_v7(&prog, buf_lib.data(), bq, pad_lib.data(), regs_lib, &chain_lib);
+      ref_execute_v7(&prog, buf_ref.data(), bq, pad_ref.data(), regs_ref, &chain_ref);
+    }
+
+    CHECK_TRUE(memcmp(buf_lib.data(), buf_ref.data(), buf_lib.size()) == 0);
+    CHECK_TRUE(memcmp(pad_lib.data(), pad_ref.data(), pad_lib.size()) == 0);
+    CHECK_TRUE(memcmp(regs_lib, regs_ref, sizeof(regs_lib)) == 0);
+    CHECK_TRUE(chain_lib == chain_ref);
+  }
+}
+
+static const char SAMPLE_DATA[] = "This is a test which is longer than 43 bytes for cna v7";
+
+static void hash_v14(cn_hash_context_t *ctx, const uint8_t seed[32], const void *data, size_t len, char out[HASH_SIZE])
+{
+  cn_slow_hash_v14(ctx, data, len, out, seed);
+}
+
+// Same input, same seed: same hash, across calls and across contexts.
+static void hash_is_deterministic()
+{
+  uint8_t seed[32];
+  for (int i = 0; i < 32; i++)
+    seed[i] = (uint8_t)(200 - i);
+  char h1[HASH_SIZE], h2[HASH_SIZE], h3[HASH_SIZE];
+  cn_hash_context_t *ctx1 = cn_hash_context_create();
+  cn_hash_context_t *ctx2 = cn_hash_context_create();
+  hash_v14(ctx1, seed, SAMPLE_DATA, sizeof(SAMPLE_DATA) - 1, h1);
+  hash_v14(ctx1, seed, SAMPLE_DATA, sizeof(SAMPLE_DATA) - 1, h2);
+  hash_v14(ctx2, seed, SAMPLE_DATA, sizeof(SAMPLE_DATA) - 1, h3);
+  CHECK_TRUE(memcmp(h1, h2, HASH_SIZE) == 0);
+  CHECK_TRUE(memcmp(h1, h3, HASH_SIZE) == 0);
+
+  // and the data still matters
+  hash_v14(ctx2, seed, SAMPLE_DATA, sizeof(SAMPLE_DATA) - 2, h3);
+  CHECK_TRUE(memcmp(h1, h3, HASH_SIZE) != 0);
+
+  cn_hash_context_free(ctx1);
+  cn_hash_context_free(ctx2);
+}
+
+// The two review regressions. Seeds sharing their first 8 bytes must produce
+// different hashes and (near-)completely different buffers: the fill folds
+// all 32 seed bytes, not just the first qword. And an all-zero seed must
+// still populate the buffer: the fold starts off the fill map's fixed point.
+static void seed_tail_and_zero_seed()
+{
+  uint8_t seed_a[32] = {0}, seed_b[32] = {0};
+  for (int i = 0; i < 8; i++)
+    seed_a[i] = seed_b[i] = (uint8_t)(i + 1);
+  seed_b[31] = 1;
+
+  cn_hash_context_t *ctx_a = cn_hash_context_create();
+  cn_hash_context_t *ctx_b = cn_hash_context_create();
+  char ha[HASH_SIZE], hb[HASH_SIZE];
+  hash_v14(ctx_a, seed_a, SAMPLE_DATA, sizeof(SAMPLE_DATA) - 1, ha);
+  hash_v14(ctx_b, seed_b, SAMPLE_DATA, sizeof(SAMPLE_DATA) - 1, hb);
+  CHECK_TRUE(memcmp(ha, hb, HASH_SIZE) != 0);
+
+  const uint64_t *ba = (const uint64_t *)ctx_a->cna_v7_buffer;
+  const uint64_t *bb = (const uint64_t *)ctx_b->cna_v7_buffer;
+  size_t equal = 0;
+  for (size_t i = 0; i < 4096; i++)
+    equal += (ba[i] == bb[i]);
+  std::printf("   seed-tail: %zu of 4096 sampled qwords equal\n", equal);
+  CHECK_TRUE(equal < 8);
+
+  const uint8_t zero_seed[32] = {0};
+  hash_v14(ctx_a, zero_seed, SAMPLE_DATA, sizeof(SAMPLE_DATA) - 1, ha);
+  uint64_t acc = 0;
+  for (size_t i = 0; i < CN_V7_BUFFER / sizeof(uint64_t); i += 4096)
+    acc |= ba[i];
+  CHECK_TRUE(acc != 0);
+
+  cn_hash_context_free(ctx_a);
+  cn_hash_context_free(ctx_b);
+}
+
+// The residency argument: the chase must mutate ~63% of the buffer
+// (1 - 1/e for qwords/hops touches). Compare the post-hash buffer against an
+// independent fill; a wrong fill transcription would show ~100% here, a
+// short-counted chase well under 58%.
+static void chase_coverage()
+{
+  uint8_t seed[32];
+  for (int i = 0; i < 32; i++)
+    seed[i] = (uint8_t)(i * 3 + 11);
+
+  cn_hash_context_t *ctx = cn_hash_context_create();
+  char h[HASH_SIZE];
+  hash_v14(ctx, seed, SAMPLE_DATA, sizeof(SAMPLE_DATA) - 1, h);
+
+  const uint64_t bq = CN_V7_BUFFER / sizeof(uint64_t);
+  std::vector<uint8_t> fill(CN_V7_BUFFER);
+  ref_fill(fill.data(), bq, seed);
+
+  const uint64_t *post = (const uint64_t *)ctx->cna_v7_buffer;
+  const uint64_t *pre = (const uint64_t *)fill.data();
+  uint64_t mutated = 0;
+  for (uint64_t i = 0; i < bq; i++)
+    mutated += (post[i] != pre[i]);
+  const double ratio = (double)mutated / (double)bq;
+  std::printf("   chase mutated %.1f%% of the buffer\n", 100.0 * ratio);
+  CHECK_TRUE(ratio > 0.58 && ratio < 0.68);
+
+  cn_hash_context_free(ctx);
+}
+
+// HW and SW AES paths agree (runs the in-tree self-test, which since the
+// review fix uses a varied seed and asserts the buffer is populated).
+static void hw_sw_self_test()
+{
+  CHECK_TRUE(cn_slow_hash_self_test() == 1);
+}
+
+int main()
+{
+  RUN(chase_matches_reference);
+  RUN(hash_is_deterministic);
+  RUN(seed_tail_and_zero_seed);
+  RUN(chase_coverage);
+  RUN(hw_sw_self_test);
+  return check_summary("t_cna_v7");
+}

--- a/contrib/hf14checks/t_cna_v7.cpp
+++ b/contrib/hf14checks/t_cna_v7.cpp
@@ -43,35 +43,40 @@ static uint64_t ref_mix64(uint64_t val, uint32_t key_material)
   return val;
 }
 
-// One v7 pass: CN_V7_SEGMENTS x [serial chase, program slice]. The walk maps
-// the chain value into the buffer via the high word of chain * qwords, writes
-// each cell back XORed with the live chain, and hands the read values to
-// SP_READ in order. wchain folds into regs[0] at the end of the pass.
+// One v7 pass: CN_V7_SEGMENTS x [serial chase, program slice], where the
+// segment lengths come from the program (sum CN_V7_HOPS) so the rhythm is
+// per-nonce. Each hop builds its address from a program operand pair plus the
+// live chain, maps it through the high word of the product with qwords, writes
+// the cell back XORed with that address material, and steps the operand source
+// by a stride taken from the loaded value. SP_READ takes the chased values in
+// order. wchain folds into regs[0] at the end of the pass.
 static void ref_execute_v7(const cn_vm_program_t *prog, uint8_t *buffer, uint64_t buffer_qwords,
                            uint8_t *pad, uint64_t regs[CN_REG_COUNT], uint64_t *chain_state)
 {
   const size_t sp_mask   = (size_t)(CN_SCRATCHPAD_MEMORY_V14 - 1) & ~(size_t)7;
-  const int    seg_hops  = CN_V7_HOPS / CN_V7_SEGMENTS;
   const int    seg_steps = CN_PROGRAM_SIZE / CN_V7_SEGMENTS;
 
   int pc = 0;
-  unsigned consume = 0;
+  unsigned consume = 0, filled = 0, walk_pc = 0;
   uint64_t wchain = 0;
   uint64_t chain = *chain_state;
   std::vector<uint64_t> vals(CN_V7_HOPS);
 
   for (int seg = 0; seg < CN_V7_SEGMENTS; seg++)
   {
-    chain ^= regs[seg & (CN_REG_COUNT - 1)];
-    for (int h = 0; h < seg_hops; h++)
+    const int hops = (int)prog->seg_hops[seg];
+    for (int h = 0; h < hops; h++)
     {
-      const uint64_t idx = (uint64_t)(((unsigned __int128)chain * buffer_qwords) >> 64);
+      const cn_vm_instruction_t *hop = &prog->instructions[walk_pc & (CN_PROGRAM_SIZE - 1)];
+      const uint64_t material = regs[hop->src] + (uint64_t)hop->imm + chain;
+      const uint64_t idx = (uint64_t)(((unsigned __int128)material * buffer_qwords) >> 64);
       uint64_t v;
       memcpy(&v, buffer + idx * sizeof(uint64_t), sizeof(uint64_t));
-      const uint64_t mut = v ^ chain;
+      const uint64_t mut = v ^ material;
       memcpy(buffer + idx * sizeof(uint64_t), &mut, sizeof(uint64_t));
       chain = v + (uint64_t)h;
-      vals[seg * seg_hops + h] = v;
+      walk_pc += 1u + (unsigned)(v & 3u);
+      vals[filled++] = v;
     }
 
     for (int step = 0; step < seg_steps; step++)

--- a/contrib/hf14checks/t_cna_v7.cpp
+++ b/contrib/hf14checks/t_cna_v7.cpp
@@ -68,7 +68,8 @@ static void ref_execute_v7(const cn_vm_program_t *prog, uint8_t *buffer, uint64_
     for (int h = 0; h < hops; h++)
     {
       const cn_vm_instruction_t *hop = &prog->instructions[walk_pc & (CN_PROGRAM_SIZE - 1)];
-      const uint64_t material = regs[hop->src] + (uint64_t)hop->imm + chain;
+      const uint8_t hop_reg = (uint8_t)((hop->src + (unsigned)h) & (CN_REG_COUNT - 1));
+      const uint64_t material = regs[hop_reg] + (uint64_t)hop->imm + chain;
       const uint64_t idx = (uint64_t)(((unsigned __int128)material * buffer_qwords) >> 64);
       uint64_t v;
       memcpy(&v, buffer + idx * sizeof(uint64_t), sizeof(uint64_t));

--- a/contrib/hf14checks/t_fee_weight.cpp
+++ b/contrib/hf14checks/t_fee_weight.cpp
@@ -1,0 +1,170 @@
+// Fee and weight arithmetic on real serialized type-7 transactions.
+//
+// The wallet's estimators live in an anonymous namespace (wallet2.cpp:812
+// estimate_rct_tx_size, :874 estimate_tx_weight) so they cannot be linked;
+// they are transcribed here verbatim and checked against the linkable
+// consensus side. If wallet2.cpp changes, this transcription must follow.
+//
+// Three claims are pinned:
+//  - the wallet's BP+ clawback equals what consensus adds to a real
+//    transaction's weight (get_transaction_weight - blob size), exactly,
+//    across output counts;
+//  - the size estimator upper-bounds real serialized type-7 transactions,
+//    tightly;
+//  - with the legacy flags the estimator reproduces the pre-HF14 numbers,
+//    so pre-fork fees do not move.
+#include "check.h"
+#include "rct_samples.h"
+
+#include <cstring>
+
+#include "cryptonote_basic/cryptonote_basic.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
+
+// --- transcribed from src/wallet/wallet2.cpp:812, log lines dropped ---
+static size_t wallet_estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra_size,
+                                          bool bulletproof, bool clsag, bool bulletproof_plus)
+{
+  size_t size = 0;
+
+  // tx prefix
+  size += 1 + 6;
+  size += n_inputs * (1+6+(mixin+1)*2+32);
+  size += n_outputs * (6+32);
+  size += extra_size;
+
+  // rct signatures
+  size += 1;
+  if (bulletproof || bulletproof_plus)
+  {
+    size_t log_padded_outputs = 0;
+    while ((1<<log_padded_outputs) < n_outputs)
+      ++log_padded_outputs;
+    size += (2 * (6 + log_padded_outputs) + (bulletproof_plus ? 6 : (4 + 5))) * 32 + 3;
+  }
+  else
+    size += (2*64*32+32+64*32) * n_outputs;
+
+  if (clsag)
+    size += n_inputs * (32 * (mixin+1) + 64);
+  else
+    size += n_inputs * (64 * (mixin+1) + 32);
+
+  size += 32 * n_inputs;
+  if (clsag || bulletproof_plus)
+    size += 8 * n_outputs;
+  else
+    size += 2 * 32 * n_outputs;
+  size += 32 * n_outputs;
+  size += 4;
+  return size;
+}
+
+// --- the clawback arithmetic from src/wallet/wallet2.cpp:874, applied to the
+// transaction's real output count instead of estimate_tx_weight's
+// n_outputs + 1 (the change output is already real here) ---
+static uint64_t wallet_clawback(int real_outputs)
+{
+  if (real_outputs <= 2)
+    return 0;
+  const uint64_t bp_base = (32 * (6 + 7 * 2)) / 2;
+  size_t log_padded_outputs = 2;
+  while ((1<<log_padded_outputs) < real_outputs)
+    ++log_padded_outputs;
+  uint64_t nlr = 2 * (6 + log_padded_outputs);
+  const uint64_t bp_size = 32 * (6 + nlr);
+  return (bp_base * (1<<log_padded_outputs) - bp_size) * 4 / 5;
+}
+
+// A serializable transaction around a real signature: version 2, nin ring
+// inputs, nout outputs, empty extra. Only the shape matters to the weight
+// and size arithmetic.
+static cryptonote::transaction make_tx(int bp_version, size_t nin, size_t nout, size_t ring)
+{
+  cryptonote::transaction tx;
+  tx.version = 2;
+  tx.unlock_time = 0;
+  for (size_t i = 0; i < nin; ++i)
+  {
+    cryptonote::txin_to_key in;
+    in.amount = 0;
+    in.key_offsets.assign(ring, 1);
+    const rct::key ki = rct::pkGen();
+    memcpy(&in.k_image, ki.bytes, 32);
+    tx.vin.push_back(in);
+  }
+  for (size_t o = 0; o < nout; ++o)
+  {
+    cryptonote::txout_to_key tk;
+    const rct::key pk = rct::pkGen();
+    memcpy(&tk.key, pk.bytes, 32);
+    cryptonote::tx_out out;
+    out.amount = 0;
+    out.target = tk;
+    tx.vout.push_back(out);
+  }
+  tx.extra.clear();
+  tx.rct_signatures = make_sample_sig(bp_version, nin, nout, ring);
+  return tx;
+}
+
+static void clawback_equals_consensus()
+{
+  const size_t nouts[] = {2, 3, 4, 5, 8, 16};
+  for (size_t nout : nouts)
+  {
+    cryptonote::transaction tx = make_tx(4, 2, nout, 8);
+    CHECK_TRUE(tx.rct_signatures.type == rct::RCTTypeBulletproofPlus);
+    const cryptonote::blobdata blob = cryptonote::t_serializable_object_to_blob(tx);
+    const uint64_t weight = cryptonote::get_transaction_weight(tx, blob.size());
+    const uint64_t consensus = weight - blob.size();
+    const uint64_t wallet = wallet_clawback((int)nout);
+    std::printf("   %2zu outputs: blob %5zu, clawback consensus %5llu, wallet %5llu\n",
+                nout, blob.size(), (unsigned long long)consensus, (unsigned long long)wallet);
+    CHECK_TRUE(consensus == wallet);
+  }
+}
+
+static void estimator_covers_real_type7_txs()
+{
+  struct { size_t nin, nout, ring; } shapes[] = {
+    {1, 2, 4}, {2, 2, 8}, {2, 3, 8}, {4, 4, 16}, {2, 16, 8},
+  };
+  for (const auto &s : shapes)
+  {
+    cryptonote::transaction tx = make_tx(4, s.nin, s.nout, s.ring);
+    const cryptonote::blobdata blob = cryptonote::t_serializable_object_to_blob(tx);
+    const size_t est = wallet_estimate_rct_tx_size((int)s.nin, (int)(s.ring - 1), (int)s.nout, 0,
+                                                   true, true, true);
+    std::printf("   %zu-in/%zu-out/ring %2zu: real %5zu, estimated %5zu (overshoot %zd)\n",
+                s.nin, s.nout, s.ring, blob.size(), est, (ssize_t)est - (ssize_t)blob.size());
+    // The estimator over-budgets exactly where its comments say it does:
+    // 6 bytes per amount varint (real: 1 byte, amounts are 0 here), 2 per
+    // key offset (real: 1, offsets are 1), 7 for version+unlock (real: 5)
+    // and 4 for the fee (real: 2, fee is 5000). Everything else it counts
+    // must match the serializer to the byte, so the overshoot is exact:
+    // any drift in the estimator or the serializer breaks the equality.
+    const size_t expected_overshoot = s.nin * (4 + s.ring) + 4 * s.nout + 4;
+    CHECK_TRUE(est == blob.size() + expected_overshoot);
+
+    // the weight the fee is computed on is covered too
+    const uint64_t weight = cryptonote::get_transaction_weight(tx, blob.size());
+    CHECK_TRUE(est + wallet_clawback((int)s.nout) >= weight);
+  }
+}
+
+static void legacy_estimates_unchanged()
+{
+  // golden values computed from origin/master's estimate_rct_tx_size
+  // (wallet2.cpp:802 there), which has no clsag/bulletproof_plus arguments
+  CHECK_TRUE(wallet_estimate_rct_tx_size(2, 7, 2, 0, true, false, false) == 2281);
+  CHECK_TRUE(wallet_estimate_rct_tx_size(1, 10, 2, 0, true, false, false) == 1848);
+}
+
+int main()
+{
+  RUN(clawback_equals_consensus);
+  RUN(estimator_covers_real_type7_txs);
+  RUN(legacy_estimates_unchanged);
+  return check_summary("t_fee_weight");
+}

--- a/contrib/hf14checks/t_serialization.cpp
+++ b/contrib/hf14checks/t_serialization.cpp
@@ -1,0 +1,177 @@
+// The 6/7 renumbering through all three encoders, on real signatures.
+// bp_version 2/3/4 must produce type bytes 5/6/7 (Monero's 5/6 are our 6/7;
+// our 5 is already Bulletproof2 on chain), and each type must roundtrip
+// bit-stable through the binary archive, the boost archive and the JSON
+// encoder. The JSON leg goes through a string, which exercises the read_hex
+// fix (rapidjson GetStringLength vs Size).
+#include "check.h"
+#include "rct_samples.h"
+
+#include <sstream>
+
+#include "serialization/binary_archive.h"
+#include "cryptonote_basic/cryptonote_boost_serialization.h"
+#include <boost/archive/portable_binary_oarchive.hpp>
+#include <boost/archive/portable_binary_iarchive.hpp>
+#include "serialization/json_object.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+// The wire encoding of a signature: base + prunable, exactly the fields the
+// network serializes (message and mixRing are reconstructed by the daemon).
+// Used as the canonical comparator for every encoder.
+static bool bin_dump(rct::rctSig &s, size_t nin, size_t nout, size_t mixin, std::string &blob)
+{
+  std::stringstream ss;
+  binary_archive<true> ar(ss);
+  if (!s.serialize_rctsig_base(ar, nin, nout))
+    return false;
+  if (!s.p.serialize_rctsig_prunable(ar, s.type, nin, nout, mixin))
+    return false;
+  blob = ss.str();
+  return true;
+}
+
+static bool bin_parse(rct::rctSig &s, size_t nin, size_t nout, size_t mixin, const std::string &blob)
+{
+  std::istringstream ss(blob);
+  binary_archive<false> ar(ss);
+  if (!s.serialize_rctsig_base(ar, nin, nout))
+    return false;
+  if (!s.p.serialize_rctsig_prunable(ar, s.type, nin, nout, mixin))
+    return false;
+  return true;
+}
+
+static const size_t NIN = 2, NOUT = 3, RING = 8, MIXIN = RING - 1;
+
+// What the daemon does to a parsed signature before verifying: outPk.dest
+// comes from the tx outputs and CLSAG I from the tx key images (restored
+// from the original here), while the range proof's V is recomputed from the
+// serialized outPk masks the way expand_transaction_1 does. If the parsed
+// masks or proof were off, verification below would catch it.
+static void expand_parsed(rct::rctSig &back, const rct::rctSig &orig)
+{
+  for (size_t i = 0; i < back.outPk.size(); ++i)
+    back.outPk[i].dest = orig.outPk[i].dest;
+  if (back.type == rct::RCTTypeBulletproofPlus && !back.p.bulletproofs_plus.empty())
+  {
+    rct::BulletproofPlus &bp = back.p.bulletproofs_plus[0];
+    bp.V.resize(back.outPk.size());
+    for (size_t i = 0; i < back.outPk.size(); ++i)
+      bp.V[i] = rct::scalarmultKey(back.outPk[i].mask, rct::INV_EIGHT);
+  }
+  else if (back.type == rct::RCTTypeCLSAG && !back.p.bulletproofs.empty())
+  {
+    rct::Bulletproof &bp = back.p.bulletproofs[0];
+    bp.V.resize(back.outPk.size());
+    for (size_t i = 0; i < back.outPk.size(); ++i)
+      bp.V[i] = rct::scalarmultKey(back.outPk[i].mask, rct::INV_EIGHT);
+  }
+  for (size_t i = 0; i < back.p.CLSAGs.size(); ++i)
+    back.p.CLSAGs[i].I = orig.p.CLSAGs[i].I;
+}
+
+static void roundtrip_type(int bp_version, uint8_t expect_type)
+{
+  rct::rctSig sig = make_sample_sig(bp_version, NIN, NOUT, RING);
+  CHECK_TRUE(sig.type == expect_type);
+
+  std::string blob;
+  CHECK_TRUE(bin_dump(sig, NIN, NOUT, MIXIN, blob));
+  CHECK_TRUE((uint8_t)blob[0] == expect_type);  // the type byte leads the wire encoding
+
+  // binary archive: parse back, re-dump, must be bit-identical; the parsed
+  // signature must still verify (mixRing/message restored the way the daemon
+  // reconstructs them)
+  {
+    rct::rctSig back{};
+    CHECK_TRUE(bin_parse(back, NIN, NOUT, MIXIN, blob));
+    std::string again;
+    CHECK_TRUE(bin_dump(back, NIN, NOUT, MIXIN, again));
+    CHECK_TRUE(again == blob);
+    if (expect_type >= rct::RCTTypeCLSAG)
+    {
+      expand_parsed(back, sig);
+      CHECK_TRUE(rct::verRctSemanticsSimple(back));
+      back.message = sig.message;
+      back.mixRing = sig.mixRing;
+      CHECK_TRUE(rct::verRctNonSemanticsSimple(back));
+    }
+  }
+
+  // boost archive (wallet cache / unsigned tx sets)
+  {
+    std::ostringstream oss;
+    boost::archive::portable_binary_oarchive oar(oss);
+    oar << sig;
+    std::istringstream iss(oss.str());
+    boost::archive::portable_binary_iarchive iar(iss);
+    rct::rctSig back{};
+    iar >> back;
+    std::string again;
+    CHECK_TRUE(bin_dump(back, NIN, NOUT, MIXIN, again));
+    CHECK_TRUE(again == blob);
+  }
+
+  // JSON, through a serialized string
+  {
+    rapidjson::Document doc;
+    doc.SetObject();
+    rapidjson::Value val;
+    cryptonote::json::toJsonValue(doc, sig, val);
+
+    rapidjson::StringBuffer buf;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+    val.Accept(writer);
+
+    rapidjson::Document doc2;
+    CHECK_FALSE(doc2.Parse(buf.GetString()).HasParseError());
+    rct::rctSig back{};
+    cryptonote::json::fromJsonValue(doc2, back);
+    std::string again;
+    CHECK_TRUE(bin_dump(back, NIN, NOUT, MIXIN, again));
+    CHECK_TRUE(again == blob);
+  }
+}
+
+static void type5_stays_5() { roundtrip_type(2, rct::RCTTypeBulletproof2); }
+static void type6_is_clsag() { roundtrip_type(3, rct::RCTTypeCLSAG); }
+static void type7_is_bp_plus() { roundtrip_type(4, rct::RCTTypeBulletproofPlus); }
+
+// The type byte is part of the signed message; a 6 relabeled as 7 must not
+// come back as a valid type-7 signature.
+static void type_byte_is_load_bearing()
+{
+  rct::rctSig sig = make_sample_sig(3, NIN, NOUT, RING);
+  std::string blob;
+  CHECK_TRUE(bin_dump(sig, NIN, NOUT, MIXIN, blob));
+  blob[0] = (char)rct::RCTTypeBulletproofPlus;
+  rct::rctSig back{};
+  const bool parsed = bin_parse(back, NIN, NOUT, MIXIN, blob);
+  if (parsed)
+    expand_parsed(back, sig);
+  CHECK_TRUE(!parsed || !rct::verRctSemanticsSimple(back));
+}
+
+// The point of the format change: same shape, smaller signature.
+static void type7_is_smaller_than_type5()
+{
+  rct::rctSig s5 = make_sample_sig(2, NIN, NOUT, RING);
+  rct::rctSig s7 = make_sample_sig(4, NIN, NOUT, RING);
+  std::string b5, b7;
+  CHECK_TRUE(bin_dump(s5, NIN, NOUT, MIXIN, b5));
+  CHECK_TRUE(bin_dump(s7, NIN, NOUT, MIXIN, b7));
+  std::printf("   type 5: %zu bytes, type 7: %zu bytes\n", b5.size(), b7.size());
+  CHECK_TRUE(b7.size() < b5.size());
+}
+
+int main()
+{
+  RUN(type5_stays_5);
+  RUN(type6_is_clsag);
+  RUN(type7_is_bp_plus);
+  RUN(type_byte_is_load_bearing);
+  RUN(type7_is_smaller_than_type5);
+  return check_summary("t_serialization");
+}

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -916,6 +916,20 @@ public:
    */
   virtual cryptonote::blobdata get_block_blob_from_height(const uint64_t& height) const = 0;
 
+  /**
+   * @brief bring any in-memory block cache up to the given height
+   *
+   * Hashing blocks ahead of the verifier on worker threads is only safe while
+   * the seed lookups are served from memory: a worker that had to reach the
+   * database would open its own read transaction and could not see blocks the
+   * caller has written but not committed. Callers warm the cache on the thread
+   * that owns the transaction first. A backend with no such cache does nothing
+   * and callers must then keep the work on one thread.
+   *
+   * @param height the height to cache up to
+   */
+  virtual void warm_block_cache(uint64_t height) {}
+
   virtual void get_cna_v2_data(crypto::cn_random_values_t *rv, uint64_t height, uint32_t seed) = 0;
   virtual void get_cna_v3_data(char *out, uint64_t height, uint32_t seed) = 0;
   virtual void get_cna_v4_data(char *out, uint64_t height, uint32_t seed)  = 0;

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -448,6 +448,8 @@ private:
 
   virtual void build_block_cache(uint64_t height);
 
+  virtual void warm_block_cache(uint64_t height) { build_block_cache(height); }
+
   // Hard fork
   virtual void set_hard_fork_version(uint64_t height, uint8_t version);
   virtual uint8_t get_hard_fork_version(uint64_t height) const;

--- a/src/crypto/cna-vm.c
+++ b/src/crypto/cna-vm.c
@@ -29,6 +29,7 @@
 #include "cna-vm.h"
 #include "hc128.h"
 #include "hash-ops.h"
+#include "int-util.h"
 
 #include <string.h>
 #include <stdint.h>
@@ -208,4 +209,153 @@ void cn_vm_execute(cn_vm_program_t *prog, uint8_t *scratchpad, uint64_t regs[CN_
 
         pc = next_pc;
     }
+}
+
+// ---------------------------------------------------------------------------
+// cn_vm_execute_v7 (HF14)
+//
+// Same program, different memory binding: each pass is CN_V7_SEGMENTS
+// repetitions of [tight serial chase over the per-nonce buffer, then a slice
+// of the program]. Every hop's address needs the previous hop's value, so
+// exactly one load is in flight on any hardware; a small in-order core walks
+// the buffer as fast as a big out-of-order one, which is where the per-core
+// parity comes from. Each chase segment is gated on a register the previous
+// program slice just mutated, so the walk cannot be advanced without
+// executing the per-nonce random program between segments.
+//
+// Instruction semantics match cn_vm_execute except the two memory ops:
+// SP_READ consumes the chased values in order instead of reading the pad,
+// and SP_WRITE keeps its v6 behaviour against the small v14 pad.
+// ---------------------------------------------------------------------------
+
+// A program slice runs CN_PROGRAM_SIZE/CN_V7_SEGMENTS steps and each step
+// consumes at most one chased value, while the chase segment before it
+// supplied CN_V7_HOPS/CN_V7_SEGMENTS of them, so consumption never outruns
+// the filled prefix of vals[] as long as a pass supplies at least as many
+// values as it can consume. A retune that breaks this would make SP_READ
+// read uninitialised stack and fork the chain, so pin it at compile time.
+_Static_assert(CN_V7_HOPS >= CN_PROGRAM_SIZE,
+               "CN_V7_HOPS must stay >= CN_PROGRAM_SIZE or SP_READ consumes uninitialised values");
+_Static_assert((CN_V7_HOPS % CN_V7_SEGMENTS) == 0 && (CN_PROGRAM_SIZE % CN_V7_SEGMENTS) == 0,
+               "CN_V7_SEGMENTS must divide both the hop count and the program size");
+_Static_assert((CN_V7_HOPS & (CN_V7_HOPS - 1)) == 0,
+               "CN_V7_HOPS must be a power of 2, SP_READ wraps vals[] with a bitmask");
+
+void cn_vm_execute_v7(cn_vm_program_t *prog, uint8_t *buffer, uint64_t buffer_qwords,
+                      uint8_t *pad, uint64_t regs[CN_REG_COUNT], uint64_t *chain_state)
+{
+    // CN_SCRATCHPAD_MEMORY_V14 is a power of two; the mask keeps pad writes
+    // 8-byte aligned inside it, exactly like cn_vm_execute's sp_mask.
+    const size_t sp_mask   = (size_t)(CN_SCRATCHPAD_MEMORY_V14 - 1) & ~(size_t)7;
+    const int    pc_mask   = CN_PROGRAM_SIZE - 1;
+    const int    seg_hops  = CN_V7_HOPS / CN_V7_SEGMENTS;
+    const int    seg_steps = CN_PROGRAM_SIZE / CN_V7_SEGMENTS;
+
+    int pc = 0;                       // persists across the pass's segments
+    unsigned consume = 0;
+    uint64_t wchain = 0;
+    uint64_t chain = *chain_state;
+    uint64_t vals[CN_V7_HOPS];
+
+    for (int seg = 0; seg < CN_V7_SEGMENTS; seg++)
+    {
+        // Chase segment. Gating on a register couples the walk to the
+        // program slice that just executed.
+        chain ^= regs[seg & (CN_REG_COUNT - 1)];
+        for (int h = 0; h < seg_hops; h++)
+        {
+            // Map chain into [0, buffer_qwords) as the high 64 bits of
+            // chain * buffer_qwords: uniform, no divide, any buffer length
+            // (no power-of-two requirement).
+            uint64_t idx;
+            mul128(chain, buffer_qwords, &idx);
+            uint64_t v;
+            memcpy(&v, buffer + idx * sizeof(uint64_t), sizeof(uint64_t));
+            // Write the cell back XORed with the live chain. The stored value
+            // now depends on the whole walk history, so a revisit reads
+            // something no fill-checkpoint can reproduce: the buffer must be
+            // kept resident, which is the per-nonce capacity brake.
+            uint64_t mut = v ^ chain;
+            memcpy(buffer + idx * sizeof(uint64_t), &mut, sizeof(uint64_t));
+            // +h so a repeated value cannot close a short cycle inside the pass
+            chain = v + (uint64_t)h;
+            vals[seg * seg_hops + h] = v;
+        }
+
+        for (int step = 0; step < seg_steps; step++)
+        {
+            const cn_vm_instruction_t *ins = &prog->instructions[pc & pc_mask];
+            int next_pc = pc + 1;
+
+            const uint8_t dst = ins->dst;
+            const uint8_t src = ins->src;
+
+            switch ((cn_vm_opcode_t)ins->op)
+            {
+            case CN_OP_IADD_RS:
+                regs[dst] += regs[src] << (ins->shift & 3);
+                break;
+
+            case CN_OP_ISUB:
+                regs[dst] -= regs[src];
+                break;
+
+            case CN_OP_IMUL:
+                regs[dst] *= regs[src];
+                break;
+
+            case CN_OP_IXOR:
+                regs[dst] ^= regs[src];
+                break;
+
+            case CN_OP_IROR:
+                regs[dst] = ror64(regs[dst], (uint32_t)(regs[src] & 63));
+                break;
+
+            case CN_OP_CBRANCH:
+                if (regs[dst] & ((uint64_t)ins->imm | 1))
+                {
+                    int target = (pc + (int)((int8_t)ins->shift) + CN_PROGRAM_SIZE) & pc_mask;
+                    next_pc = target;
+                }
+                break;
+
+            case CN_OP_SP_READ:
+                // Consume the chased values in order; imm keeps each
+                // consuming instruction distinct. Branch loops can revisit
+                // an SP_READ, but a pass executes at most CN_PROGRAM_SIZE
+                // steps while the chase supplies CN_V7_HOPS values, so
+                // consume stays inside the filled prefix (asserts above).
+                regs[dst] ^= vals[consume & (CN_V7_HOPS - 1)] + (uint64_t)ins->imm;
+                consume++;
+                break;
+
+            case CN_OP_SP_WRITE:
+            {
+                // v6 semantics against the small v14 pad: write-hardness.
+                size_t addr = ((size_t)((uint64_t)regs[dst] + (uint64_t)ins->imm + wchain)) & sp_mask;
+                uint64_t tmp;
+                memcpy(&tmp, &pad[addr], sizeof(uint64_t));
+                tmp ^= regs[src];
+                memcpy(&pad[addr], &tmp, sizeof(uint64_t));
+                wchain += tmp;
+                break;
+            }
+
+            case CN_OP_MIX:
+                regs[dst] = mix64(regs[dst] ^ regs[src], ins->imm);
+                break;
+
+            default:
+                // Unknown opcode: treat as NOP to stay deterministic.
+                break;
+            }
+
+            pc = next_pc;
+        }
+    }
+
+    *chain_state = chain;
+    // fold the write chain back so pad writes stay load-bearing too
+    regs[0] ^= wchain;
 }

--- a/src/crypto/cna-vm.c
+++ b/src/crypto/cna-vm.c
@@ -303,7 +303,13 @@ void cn_vm_execute_v7(cn_vm_program_t *prog, uint8_t *buffer, uint64_t buffer_qw
             // file and a per-nonce, value-dependent walk through the program
             // rather than a fixed formula a hardwired pipeline could bake in.
             const cn_vm_instruction_t *hop = &prog->instructions[walk_pc & pc_mask];
-            const uint64_t addr_material = regs[hop->src] + (uint64_t)hop->imm + chain;
+            // The register index steps with the hop, so regs[..] + imm is not a
+            // fixed 512-entry table for the whole segment: precomputing it needs
+            // one entry per (instruction, hop position) pair instead, and the
+            // register file stays in the address path per hop rather than per
+            // segment. Costs an add and a mask.
+            const uint8_t hop_reg = (uint8_t)((hop->src + (unsigned)h) & (CN_REG_COUNT - 1));
+            const uint64_t addr_material = regs[hop_reg] + (uint64_t)hop->imm + chain;
             // Map into [0, buffer_qwords) as the high 64 bits of
             // addr_material * buffer_qwords: uniform, no divide, any buffer
             // length (no power-of-two requirement).

--- a/src/crypto/cna-vm.c
+++ b/src/crypto/cna-vm.c
@@ -84,6 +84,31 @@ void cn_vm_generate_program(cn_vm_program_t *prog, const uint8_t seed[32])
         uint32_t hi = HC128_U32(&rng, &key_idx, 0x10000);
         ins->imm = (hi << 16) | lo;
     }
+
+    // Chase segment lengths, from the same keystream. Start uniform and move
+    // hops between segments: the sum stays exactly CN_V7_HOPS by construction,
+    // so every nonce issues the same number of accesses and none is cheaper to
+    // hash, while the per-nonce rhythm is what a GPU warp and an ASIC sequencer
+    // have to follow. The bounds keep every segment in
+    // [CN_V7_SEG_MIN, CN_V7_HOPS - (CN_V7_SEGMENTS-1)*CN_V7_SEG_MIN].
+    for (int i = 0; i < CN_V7_SEGMENTS; i++)
+        prog->seg_hops[i] = (uint16_t)(CN_V7_HOPS / CN_V7_SEGMENTS);
+
+    const uint16_t seg_cap = (uint16_t)(CN_V7_HOPS - (CN_V7_SEGMENTS - 1) * CN_V7_SEG_MIN);
+    for (int k = 0; k < 24; k++)
+    {
+        const int a = (int)HC128_U32(&rng, &key_idx, CN_V7_SEGMENTS);
+        const int b = (int)HC128_U32(&rng, &key_idx, CN_V7_SEGMENTS);
+        uint16_t amt = (uint16_t)HC128_U32(&rng, &key_idx, 32U);
+        if (a == b)
+            continue;
+        if (prog->seg_hops[a] < (uint16_t)(CN_V7_SEG_MIN + amt))
+            amt = (uint16_t)(prog->seg_hops[a] - CN_V7_SEG_MIN);
+        if ((uint16_t)(prog->seg_hops[b] + amt) > seg_cap)
+            amt = (uint16_t)(seg_cap - prog->seg_hops[b]);
+        prog->seg_hops[a] = (uint16_t)(prog->seg_hops[a] - amt);
+        prog->seg_hops[b] = (uint16_t)(prog->seg_hops[b] + amt);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -229,17 +254,24 @@ void cn_vm_execute(cn_vm_program_t *prog, uint8_t *scratchpad, uint64_t regs[CN_
 // ---------------------------------------------------------------------------
 
 // A program slice runs CN_PROGRAM_SIZE/CN_V7_SEGMENTS steps and each step
-// consumes at most one chased value, while the chase segment before it
-// supplied CN_V7_HOPS/CN_V7_SEGMENTS of them, so consumption never outruns
-// the filled prefix of vals[] as long as a pass supplies at least as many
-// values as it can consume. A retune that breaks this would make SP_READ
-// read uninitialised stack and fork the chain, so pin it at compile time.
+// consumes at most one chased value. Segment lengths now vary per nonce, so the
+// guarantee rests on the floor instead of a uniform split: after segment i the
+// chase has supplied at least CN_V7_SEG_MIN*(i+1) values while the slices can
+// have consumed at most (CN_PROGRAM_SIZE/CN_V7_SEGMENTS)*(i+1), so the floor has
+// to be the larger of the two. A retune that breaks this would make SP_READ read
+// uninitialised stack and fork the chain, so pin it at compile time.
+_Static_assert(CN_V7_SEG_MIN > CN_PROGRAM_SIZE / CN_V7_SEGMENTS,
+               "CN_V7_SEG_MIN must exceed the per-slice step count or SP_READ consumes uninitialised values");
+_Static_assert(CN_V7_SEG_MIN * CN_V7_SEGMENTS <= CN_V7_HOPS,
+               "CN_V7_SEG_MIN * CN_V7_SEGMENTS must fit in CN_V7_HOPS or the segment lengths cannot sum");
 _Static_assert(CN_V7_HOPS >= CN_PROGRAM_SIZE,
                "CN_V7_HOPS must stay >= CN_PROGRAM_SIZE or SP_READ consumes uninitialised values");
-_Static_assert((CN_V7_HOPS % CN_V7_SEGMENTS) == 0 && (CN_PROGRAM_SIZE % CN_V7_SEGMENTS) == 0,
-               "CN_V7_SEGMENTS must divide both the hop count and the program size");
+_Static_assert((CN_PROGRAM_SIZE % CN_V7_SEGMENTS) == 0,
+               "CN_V7_SEGMENTS must divide the program size");
 _Static_assert((CN_V7_HOPS & (CN_V7_HOPS - 1)) == 0,
                "CN_V7_HOPS must be a power of 2, SP_READ wraps vals[] with a bitmask");
+_Static_assert((CN_PROGRAM_SIZE & (CN_PROGRAM_SIZE - 1)) == 0,
+               "CN_PROGRAM_SIZE must be a power of 2, the hop operand walk wraps with pc_mask");
 
 void cn_vm_execute_v7(cn_vm_program_t *prog, uint8_t *buffer, uint64_t buffer_qwords,
                       uint8_t *pad, uint64_t regs[CN_REG_COUNT], uint64_t *chain_state)
@@ -248,38 +280,47 @@ void cn_vm_execute_v7(cn_vm_program_t *prog, uint8_t *buffer, uint64_t buffer_qw
     // 8-byte aligned inside it, exactly like cn_vm_execute's sp_mask.
     const size_t sp_mask   = (size_t)(CN_SCRATCHPAD_MEMORY_V14 - 1) & ~(size_t)7;
     const int    pc_mask   = CN_PROGRAM_SIZE - 1;
-    const int    seg_hops  = CN_V7_HOPS / CN_V7_SEGMENTS;
     const int    seg_steps = CN_PROGRAM_SIZE / CN_V7_SEGMENTS;
 
     int pc = 0;                       // persists across the pass's segments
     unsigned consume = 0;
+    unsigned filled = 0;              // chased values available to SP_READ
+    unsigned walk_pc = 0;             // operand source for the hops
     uint64_t wchain = 0;
     uint64_t chain = *chain_state;
     uint64_t vals[CN_V7_HOPS];
 
     for (int seg = 0; seg < CN_V7_SEGMENTS; seg++)
     {
-        // Chase segment. Gating on a register couples the walk to the
-        // program slice that just executed.
-        chain ^= regs[seg & (CN_REG_COUNT - 1)];
-        for (int h = 0; h < seg_hops; h++)
+        // Chase segment. Its length comes from the seed, so the rhythm is
+        // per-nonce while the total stays CN_V7_HOPS.
+        const int hops = (int)prog->seg_hops[seg];
+        for (int h = 0; h < hops; h++)
         {
-            // Map chain into [0, buffer_qwords) as the high 64 bits of
-            // chain * buffer_qwords: uniform, no divide, any buffer length
-            // (no power-of-two requirement).
+            // Address operands come from the program, the way v6's SP_READ
+            // built its address, and walk_pc advances by a stride taken from
+            // the value just loaded. So the address path needs the register
+            // file and a per-nonce, value-dependent walk through the program
+            // rather than a fixed formula a hardwired pipeline could bake in.
+            const cn_vm_instruction_t *hop = &prog->instructions[walk_pc & pc_mask];
+            const uint64_t addr_material = regs[hop->src] + (uint64_t)hop->imm + chain;
+            // Map into [0, buffer_qwords) as the high 64 bits of
+            // addr_material * buffer_qwords: uniform, no divide, any buffer
+            // length (no power-of-two requirement).
             uint64_t idx;
-            mul128(chain, buffer_qwords, &idx);
+            mul128(addr_material, buffer_qwords, &idx);
             uint64_t v;
             memcpy(&v, buffer + idx * sizeof(uint64_t), sizeof(uint64_t));
-            // Write the cell back XORed with the live chain. The stored value
-            // now depends on the whole walk history, so a revisit reads
+            // Write the cell back XORed with the address material. The stored
+            // value now depends on the whole walk history, so a revisit reads
             // something no fill-checkpoint can reproduce: the buffer must be
             // kept resident, which is the per-nonce capacity brake.
-            uint64_t mut = v ^ chain;
+            uint64_t mut = v ^ addr_material;
             memcpy(buffer + idx * sizeof(uint64_t), &mut, sizeof(uint64_t));
             // +h so a repeated value cannot close a short cycle inside the pass
             chain = v + (uint64_t)h;
-            vals[seg * seg_hops + h] = v;
+            walk_pc += 1u + (unsigned)(v & 3u);
+            vals[filled++] = v;
         }
 
         for (int step = 0; step < seg_steps; step++)

--- a/src/crypto/cna-vm.h
+++ b/src/crypto/cna-vm.h
@@ -44,6 +44,32 @@
 #define CN_REG_COUNT       8
 #define CN_VM_ITERATIONS   2048
 
+// CNA v7 (HF14): the memory-hard work is a strictly serial chase over a
+// per-nonce buffer that the walk writes back to as it goes. The buffer is
+// filled cheaply from the per-nonce seed, and the chase covers ~63% of it and
+// mutates every cell it touches, so touched cells diverge from the fill and
+// the buffer cannot be regenerated on the fly: a miner is forced to keep the
+// whole thing resident. That caps how many nonces a GPU/ASIC can hold at once
+// (one buffer each), the way v6's 8 MB pad did, while the chase itself stays
+// DRAM-latency-bound so a small board keeps pace with a desktop: one box ~ one
+// vote. Per pass, CN_V7_SEGMENTS segments of [CN_V7_HOPS / CN_V7_SEGMENTS
+// serial hops, then a program slice], each segment gated on a register the
+// program just mutated so the walk cannot advance without executing the
+// per-nonce random program (the GPU/ASIC barrier, same class as v6). All
+// values consensus-critical.
+#define CN_V7_HOPS           1024
+#define CN_V7_SEGMENTS       8
+// Per-nonce chase buffer: 24 MB. Big enough to spill any commodity L3 (so the
+// chase is DRAM-latency-bound, not cache/clock-bound) and to starve a GPU of
+// parallel nonces (VRAM / 24 MB), small enough to keep block verify ~0.3-0.5 s.
+#define CN_V7_BUFFER         (24 * 1024 * 1024)
+// v14 pass count = buffer qwords / hops-per-pass, so the chase touches ~63% of
+// the buffer. That coverage is what forces full residency: below it a
+// checkpoint attacker could store the buffer sparsely and recompute the rest.
+// Verify lands ~0.3-0.5 s/hash, roughly equal on every box since the chase is
+// DRAM-latency-bound. v13 keeps CN_VM_ITERATIONS.
+#define CN_VM_ITERATIONS_V14 (CN_V7_BUFFER / (8 * CN_V7_HOPS))
+
 // Instruction opcodes — kept small so the opcode byte fits in uint8_t.
 typedef enum {
     CN_OP_IADD_RS   = 0,  // r[dst] += r[src] << (shift & 3)
@@ -80,3 +106,16 @@ void cn_vm_generate_program(cn_vm_program_t *prog, const uint8_t seed[32]);
 // loops possible).  Call CN_VM_ITERATIONS times with the same prog and
 // evolving regs to accumulate scratchpad mutations.
 void cn_vm_execute(cn_vm_program_t *prog, uint8_t *scratchpad, uint64_t regs[CN_REG_COUNT]);
+
+// Execute one HF14 pass: CN_V7_SEGMENTS repetitions of [serial chase over
+// the per-nonce buffer, then a slice of prog].  Each hop reads a buffer cell
+// then writes it back (buffer[idx] ^= chain), so touched cells diverge from
+// the fill and the buffer cannot be regenerated on the fly.  buffer_qwords is
+// its length in 64-bit words (>= 1, any length: addressing maps the chain
+// value through a mul128 high word, no power-of-two requirement).  SP_READ
+// consumes the chased values, SP_WRITE mutates the small pad
+// (CN_SCRATCHPAD_MEMORY_V14 bytes, write-hardness only).  *chain_state
+// carries the walk position across passes so the chase stays sequential for
+// the whole hash and cannot be precomputed.  Call CN_VM_ITERATIONS_V14 times.
+void cn_vm_execute_v7(cn_vm_program_t *prog, uint8_t *buffer, uint64_t buffer_qwords,
+                      uint8_t *pad, uint64_t regs[CN_REG_COUNT], uint64_t *chain_state);

--- a/src/crypto/cna-vm.h
+++ b/src/crypto/cna-vm.h
@@ -57,8 +57,21 @@
 // program just mutated so the walk cannot advance without executing the
 // per-nonce random program (the GPU/ASIC barrier, same class as v6). All
 // values consensus-critical.
+//
+// The hop itself takes its address operands from the program (regs[src] + imm +
+// chain, as v6 did) and steps through the operand source by a stride derived
+// from the value just loaded, so the sequence of operands is per-nonce and
+// value-dependent rather than a fixed formula. Segment lengths are per-nonce
+// too. Measured against a fixed-loop chase on one GPU: 1.76x a CPU box instead
+// of 3.07x.
 #define CN_V7_HOPS           1024
 #define CN_V7_SEGMENTS       8
+// Per-segment hop counts come from the seed and sum to CN_V7_HOPS, so the
+// access count per pass is fixed while the rhythm differs per nonce. The floor
+// keeps the chased prefix ahead of what the following program slices can
+// consume: slice i consumes at most (CN_PROGRAM_SIZE / CN_V7_SEGMENTS) * (i+1)
+// values, and CN_V7_SEG_MIN * (i+1) is larger.
+#define CN_V7_SEG_MIN        80
 // Per-nonce chase buffer: 24 MB. Big enough to spill any commodity L3 (so the
 // chase is DRAM-latency-bound, not cache/clock-bound) and to starve a GPU of
 // parallel nonces (VRAM / 24 MB), small enough to keep block verify ~0.3-0.5 s.
@@ -94,6 +107,10 @@ typedef struct {
 
 typedef struct {
     cn_vm_instruction_t instructions[CN_PROGRAM_SIZE];
+    // Chase segment lengths for the HF14 pass, from the same seed. They sum to
+    // CN_V7_HOPS, so the access count per pass is identical for every nonce and
+    // no seed yields a cheaper hash; only the rhythm differs.
+    uint16_t seg_hops[CN_V7_SEGMENTS];
 } cn_vm_program_t;
 
 // Generate a deterministic random program from a 32-byte seed.

--- a/src/crypto/cna-vm.h
+++ b/src/crypto/cna-vm.h
@@ -61,7 +61,9 @@
 // The hop itself takes its address operands from the program (regs[src] + imm +
 // chain, as v6 did) and steps through the operand source by a stride derived
 // from the value just loaded, so the sequence of operands is per-nonce and
-// value-dependent rather than a fixed formula. Segment lengths are per-nonce
+// value-dependent rather than a fixed formula. The register index also steps
+// with the hop, so the operand sum cannot be reduced to one precomputed table
+// per segment. Segment lengths are per-nonce
 // too. Measured against a fixed-loop chase on one GPU: 1.76x a CPU box instead
 // of 3.07x.
 #define CN_V7_HOPS           1024

--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -1280,6 +1280,106 @@ void ge_double_scalarmult_base_vartime_p3(ge_p3 *r3, const unsigned char *a, con
   }
 }
 
+/* CLSAG (HF14) triple scalar multiplications, ported verbatim from Monero. */
+
+void ge_triple_scalarmult_base_vartime(ge_p2 *r, const unsigned char *a, const unsigned char *b, const ge_dsmp Bi, const unsigned char *c, const ge_dsmp Ci) {
+  signed char aslide[256];
+  signed char bslide[256];
+  signed char cslide[256];
+  ge_p1p1 t;
+  ge_p3 u;
+  int i;
+
+  slide(aslide, a);
+  slide(bslide, b);
+  slide(cslide, c);
+
+  ge_p2_0(r);
+
+  for (i = 255; i >= 0; --i) {
+    if (aslide[i] || bslide[i] || cslide[i]) break;
+  }
+
+  for (; i >= 0; --i) {
+    ge_p2_dbl(&t, r);
+
+    if (aslide[i] > 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_madd(&t, &u, &ge_Bi[aslide[i]/2]);
+    } else if (aslide[i] < 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_msub(&t, &u, &ge_Bi[(-aslide[i])/2]);
+    }
+
+    if (bslide[i] > 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_add(&t, &u, &Bi[bslide[i]/2]);
+    } else if (bslide[i] < 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_sub(&t, &u, &Bi[(-bslide[i])/2]);
+    }
+
+    if (cslide[i] > 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_add(&t, &u, &Ci[cslide[i]/2]);
+    } else if (cslide[i] < 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_sub(&t, &u, &Ci[(-cslide[i])/2]);
+    }
+
+    ge_p1p1_to_p2(r, &t);
+  }
+}
+
+void ge_triple_scalarmult_precomp_vartime(ge_p2 *r, const unsigned char *a, const ge_dsmp Ai, const unsigned char *b, const ge_dsmp Bi, const unsigned char *c, const ge_dsmp Ci) {
+  signed char aslide[256];
+  signed char bslide[256];
+  signed char cslide[256];
+  ge_p1p1 t;
+  ge_p3 u;
+  int i;
+
+  slide(aslide, a);
+  slide(bslide, b);
+  slide(cslide, c);
+
+  ge_p2_0(r);
+
+  for (i = 255; i >= 0; --i) {
+    if (aslide[i] || bslide[i] || cslide[i]) break;
+  }
+
+  for (; i >= 0; --i) {
+    ge_p2_dbl(&t, r);
+
+    if (aslide[i] > 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_add(&t, &u, &Ai[aslide[i]/2]);
+    } else if (aslide[i] < 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_sub(&t, &u, &Ai[(-aslide[i])/2]);
+    }
+
+    if (bslide[i] > 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_add(&t, &u, &Bi[bslide[i]/2]);
+    } else if (bslide[i] < 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_sub(&t, &u, &Bi[(-bslide[i])/2]);
+    }
+
+    if (cslide[i] > 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_add(&t, &u, &Ci[cslide[i]/2]);
+    } else if (cslide[i] < 0) {
+      ge_p1p1_to_p3(&u, &t);
+      ge_sub(&t, &u, &Ci[(-cslide[i])/2]);
+    }
+
+    ge_p1p1_to_p2(r, &t);
+  }
+}
+
 /* From ge_frombytes.c, modified */
 
 int ge_frombytes_vartime(ge_p3 *h, const unsigned char *s) {
@@ -3712,6 +3812,15 @@ static int64_t signum(int64_t a) {
   return a > 0 ? 1 : a < 0 ? -1 : 0;
 }
 
+//! @brief arithmetic left shift for signed operands
+static int64_t signed_lshift(const int64_t a, const int b) {
+#ifdef __GNUC__
+  return a << b; // well-defined in GCC
+#else
+  return a * ((int64_t)1 << b);
+#endif
+}
+
 int sc_check(const unsigned char *s) {
   int64_t s0 = load_4(s);
   int64_t s1 = load_4(s + 4);
@@ -3721,7 +3830,16 @@ int sc_check(const unsigned char *s) {
   int64_t s5 = load_4(s + 20);
   int64_t s6 = load_4(s + 24);
   int64_t s7 = load_4(s + 28);
-  return (signum(1559614444 - s0) + (signum(1477600026 - s1) << 1) + (signum(2734136534 - s2) << 2) + (signum(350157278 - s3) << 3) + (signum(-s4) << 4) + (signum(-s5) << 5) + (signum(-s6) << 6) + (signum(268435456 - s7) << 7)) >> 8;
+  return -(0 >
+    (                 signum(1559614444 - s0)
+      + signed_lshift(signum(1477600026 - s1), 1)
+      + signed_lshift(signum(2734136534 - s2), 2)
+      + signed_lshift(signum(350157278  - s3), 3)
+      + signed_lshift(signum(           - s4), 4)
+      + signed_lshift(signum(           - s5), 5)
+      + signed_lshift(signum(           - s6), 6)
+      + signed_lshift(signum(268435456  - s7), 7)
+    ));
 }
 
 int sc_isnonzero(const unsigned char *s) {

--- a/src/crypto/crypto-ops.h
+++ b/src/crypto/crypto-ops.h
@@ -81,6 +81,10 @@ extern const ge_precomp ge_Bi[8];
 void ge_dsm_precomp(ge_dsmp r, const ge_p3 *s);
 void ge_double_scalarmult_base_vartime(ge_p2 *, const unsigned char *, const ge_p3 *, const unsigned char *);
 void ge_double_scalarmult_base_vartime_p3(ge_p3 *, const unsigned char *, const ge_p3 *, const unsigned char *);
+/* aG + bB + cC where G is the basepoint; B, C via ge_dsm_precomp. CLSAG (HF14), from Monero. */
+void ge_triple_scalarmult_base_vartime(ge_p2 *, const unsigned char *, const unsigned char *, const ge_dsmp, const unsigned char *, const ge_dsmp);
+/* aA + bB + cC, all three via ge_dsm_precomp. CLSAG (HF14), from Monero. */
+void ge_triple_scalarmult_precomp_vartime(ge_p2 *, const unsigned char *, const ge_dsmp, const unsigned char *, const ge_dsmp, const unsigned char *, const ge_dsmp);
 
 /* From ge_frombytes.c, modified */
 

--- a/src/crypto/hash-ops.h
+++ b/src/crypto/hash-ops.h
@@ -91,6 +91,10 @@ void cn_fast_hash(const void *data, size_t length, char *hash);
 #define CN_SCRATCHPAD_MEMORY    1048576         // 1 MB — used by v9–v12
 #define CN_SCRATCHPAD_MEMORY_V13 (8*1024*1024)  // 8 MB — v13: a bigger pad keeps hashing memory-bound
                                                 // (1 CPU = 1 vote) and costlier to put on an ASIC
+#define CN_SCRATCHPAD_MEMORY_V14 (256*1024)     // 256 KB, v14: the pad is write-hardness only; the
+                                                // memory binding moved to the per-nonce 24 MB chase
+                                                // buffer. Small enough to fit every cache, so the v13
+                                                // per-nonce refill stops amplifying fast cores. Power of 2.
 #define CN_SALT_MEMORY 262144
 #define CNA_V6_WINDOW_BLOCKS     100000U        // recent-block window for sliding reads (~5.6 MB)
 #define CNA_V6_FULL_HISTORY_ODDS 13U            // out of 256 (~5%) go to full history
@@ -135,6 +139,8 @@ typedef struct cn_hash_context
   int scratchpad_is_mapped;
   uint8_t *cna_scratchpad;   // 8 MB  — v13 (CryptoNight-Adaptive v6)
   int cna_scratchpad_is_mapped;
+  uint8_t *cna_v7_buffer;    // 24 MB, v14 (CNA v7) per-nonce chase buffer
+  int cna_v7_buffer_is_mapped;
   char *salt;
   int salt_is_mapped;
   cn_random_values_t random_values;
@@ -161,6 +167,9 @@ int cn_slow_hash_self_test(void);
 void cn_slow_hash(cn_hash_context_t *context, const void *data, size_t length, char *hash, int variant, int prehashed, size_t iters);
 void cn_slow_hash_v11(cn_hash_context_t *context, const void *data, size_t length, char *hash, size_t iters, uint8_t init_size_blk, uint16_t xx, uint16_t yy);
 void cn_slow_hash_v13(cn_hash_context_t *context, const void *data, size_t length, char *hash, const uint8_t *seed);
+/* v14 (CNA v7): fills a 24 MB per-nonce chase buffer (context->cna_v7_buffer)
+ * from the seed and walks it, mutating as it goes. No external dataset. */
+void cn_slow_hash_v14(cn_hash_context_t *context, const void *data, size_t length, char *hash, const uint8_t *seed);
 void cn_slow_hash_v10(cn_hash_context_t *context, const void *data, size_t length, char *hash, size_t iters, uint8_t init_size_blk, uint16_t xx, uint16_t yy, uint16_t zz, uint16_t ww);
 void cn_slow_hash_v9(cn_hash_context_t *context, const void *data, size_t length, char *hash, size_t iters);
 void cn_slow_hash_v7_8(cn_hash_context_t *context, const void *data, size_t length, char *hash, size_t iters);

--- a/src/crypto/hash-ops.h
+++ b/src/crypto/hash-ops.h
@@ -130,6 +130,10 @@ typedef struct cn_random_values
 /* Human-readable name for a CN_PAGES_* tier (miner logs / status). */
 const char *cn_page_tier_name(int tier);
 
+/* The tier a mapping actually ended up on, which on Linux can be worse than the
+ * one that was asked for. Call it after the pages have been faulted in. */
+int cn_page_tier_actual(const void *p, size_t size, int requested_tier);
+
 typedef struct cn_hash_context
 {
   /* Software-AES path always has its context allocated so the runtime
@@ -146,6 +150,10 @@ typedef struct cn_hash_context
   cn_random_values_t random_values;
   uint64_t cached_height;
 } cn_hash_context_t;
+
+/* The actual tier of the buffer that carries the hashrate at a fork version,
+ * as the kernel backed it rather than as it was requested. */
+int cn_page_tier_for_version(const cn_hash_context_t *ctx, uint8_t major_version);
 
 cn_hash_context_t *cn_hash_context_create(void);
 void cn_hash_context_free(cn_hash_context_t *context);

--- a/src/crypto/hc128.h
+++ b/src/crypto/hc128.h
@@ -31,6 +31,7 @@
 #define _HC128_H_
 
 #include <stdint.h>
+#include <stddef.h>   /* size_t, used by HC128_U32 below */
 
 typedef unsigned char hc_byte;
 
@@ -55,7 +56,9 @@ void HC128_Init(HC128_State *state, hc_byte *key, hc_byte *iv);
 void HC128_NextKeys(HC128_State *state);
 
 /* Generate a random number in the range [0, max) */
-inline uint32_t HC128_U32(HC128_State *state, size_t *key_idx, uint32_t max)
+/* static: a plain C99 `inline` in a header emits no external definition, so
+ * any C TU built without inlining (-O0) fails to link */
+static inline uint32_t HC128_U32(HC128_State *state, size_t *key_idx, uint32_t max)
 {
     uint32_t mask = (uint32_t)0xFFFFFFFFU;
     --max;

--- a/src/crypto/oaes_lib.c
+++ b/src/crypto/oaes_lib.c
@@ -471,16 +471,24 @@ OAES_RET oaes_sprintf(
 	return OAES_RET_SUCCESS;
 }
 
+/* thread safe gmtime: the reentrant form is spelled differently on Windows */
+#if defined(_WIN32) || defined(_MSC_VER)
+#define OAES_GMTIME(t, buf) (gmtime_s((buf), (t)) == 0 ? (buf) : NULL)
+#else
+#define OAES_GMTIME(t, buf) gmtime_r((t), (buf))
+#endif
+
 #ifdef OAES_HAVE_ISAAC
 static void oaes_get_seed( char buf[RANDSIZ + 1] )
 {
         #if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
 	struct timeb timer;
+	struct tm tm_buf;
 	struct tm *gmTimer;
 	char * _test = NULL;
 	
 	ftime (&timer);
-	gmTimer = gmtime( &timer.time );
+	gmTimer = OAES_GMTIME( &timer.time, &tm_buf );
 	_test = (char *) calloc( sizeof( char ), timer.millitm );
 	sprintf( buf, "%04d%02d%02d%02d%02d%02d%03d%p%d",
 		gmTimer->tm_year + 1900, gmTimer->tm_mon + 1, gmTimer->tm_mday,
@@ -488,11 +496,12 @@ static void oaes_get_seed( char buf[RANDSIZ + 1] )
 		_test + timer.millitm, GETPID() );
 	#else
 	struct timeval timer;
+	struct tm tm_buf;
 	struct tm *gmTimer;
 	char * _test = NULL;
 	
 	gettimeofday(&timer, NULL);
-	gmTimer = gmtime( &timer.tv_sec );
+	gmTimer = OAES_GMTIME( &timer.tv_sec, &tm_buf );
 	_test = (char *) calloc( sizeof( char ), timer.tv_usec/1000 );
 	sprintf( buf, "%04d%02d%02d%02d%02d%02d%03d%p%d",
 		gmTimer->tm_year + 1900, gmTimer->tm_mon + 1, gmTimer->tm_mday,
@@ -508,24 +517,29 @@ static uint32_t oaes_get_seed(void)
 {
         #if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__ANDROID__) && !defined(__NetBSD__)
 	struct timeb timer;
+	struct tm tm_buf;
 	struct tm *gmTimer;
 	char * _test = NULL;
 	uint32_t _ret = 0;
 	
 	ftime (&timer);
-	gmTimer = gmtime( &timer.time );
+	/* gmtime hands back a pointer to one shared static, so two threads seeding
+	 * at once corrupt each other's reading. Every mining thread builds its own
+	 * hash context, so this really does happen. Give each caller its own. */
+	gmTimer = OAES_GMTIME( &timer.time, &tm_buf );
 	_test = (char *) calloc( sizeof( char ), timer.millitm );
 	_ret = gmTimer->tm_year + 1900 + gmTimer->tm_mon + 1 + gmTimer->tm_mday +
 			gmTimer->tm_hour + gmTimer->tm_min + gmTimer->tm_sec + timer.millitm +
 			(uintptr_t) ( _test + timer.millitm ) + GETPID();
 	#else
 	struct timeval timer;
+	struct tm tm_buf;
 	struct tm *gmTimer;
 	char * _test = NULL;
 	uint32_t _ret = 0;
 	
 	gettimeofday(&timer, NULL);
-	gmTimer = gmtime( &timer.tv_sec );
+	gmTimer = OAES_GMTIME( &timer.tv_sec, &tm_buf );
 	_test = (char *) calloc( sizeof( char ), timer.tv_usec/1000 );
 	_ret = gmTimer->tm_year + 1900 + gmTimer->tm_mon + 1 + gmTimer->tm_mday +
 			gmTimer->tm_hour + gmTimer->tm_min + gmTimer->tm_sec + timer.tv_usec/1000 +

--- a/src/crypto/slow-hash-hw.c
+++ b/src/crypto/slow-hash-hw.c
@@ -39,6 +39,7 @@
 #define cn_slow_hash_v10   cn_slow_hash_v10_hw
 #define cn_slow_hash_v11   cn_slow_hash_v11_hw
 #define cn_slow_hash_v13   cn_slow_hash_v13_hw
+#define cn_slow_hash_v14   cn_slow_hash_v14_hw
 
 #include "slow-hash.h"
 #include "slow-hash-impl.h"

--- a/src/crypto/slow-hash-impl.h
+++ b/src/crypto/slow-hash-impl.h
@@ -334,6 +334,141 @@ void cn_slow_hash_v13(cn_hash_context_t *context, const void *data, size_t lengt
     free(text);
 }
 
+// CNA v7 (HF14): same Keccak/AES framing as v13, but the memory-hard middle is
+// a serial chase over a 24 MB per-nonce buffer that the walk writes back to
+// (cn_vm_execute_v7), not v13's VM over the pad. The pad shrinks to
+// CN_SCRATCHPAD_MEMORY_V14 and carries write-hardness only (v13's 8 MB refill
+// was a clock-bound fast-core amplifier; 256 KB fits every cache, so it costs
+// everyone alike). The pad reuses the first 256 KB of cna_scratchpad, whose
+// 8 MB stays allocated for historical v13 validation anyway. chain_state
+// threads through every pass and folds into a register at the end, so the
+// whole walk is load-bearing.
+void cn_slow_hash_v14(cn_hash_context_t *context, const void *data, size_t length, char *hash,
+                      const uint8_t *seed)
+{
+    uint8_t * const hp_state = context->cna_scratchpad;
+    char * const salt = context->salt;
+    const uint8_t init_size_blk = INIT_SIZE_BLK;
+    const uint32_t init_size_byte = (uint32_t)(init_size_blk * AES_BLOCK_SIZE);
+
+    RDATA_ALIGN16 uint8_t expandedKey[240];
+    uint8_t *text = (uint8_t *)malloc(init_size_byte);
+    union cn_slow_hash_state state;
+    size_t i;
+
+    static void (*const extra_hashes[4])(const void *, size_t, char *) = {
+        hash_extra_blake, hash_extra_groestl, hash_extra_jh, hash_extra_skein};
+
+    hash_process(&state.hs, data, length);
+    memcpy(text, state.init, init_size_byte);
+    aes_expand_key((OAES_CTX *)context->oaes_ctx, state.hs.b, expandedKey);
+    for (i = 0; i < CN_SCRATCHPAD_MEMORY_V14 / init_size_byte; i++)
+    {
+        aes_pseudo_round(text, text, expandedKey, init_size_blk);
+        memcpy(&hp_state[i * init_size_byte], text, init_size_byte);
+    }
+
+    {
+        uint32_t s_off = 0;
+        uint32_t si;
+        for (si = 0; si < CN_SCRATCHPAD_MEMORY_V14; si += 4)
+        {
+            uint32_t sv, sp;
+            memcpy(&sv, (const uint8_t *)salt + s_off, 4);
+            memcpy(&sp, hp_state + si, 4);
+            sp ^= sv;
+            memcpy(hp_state + si, &sp, 4);
+            s_off += 4;
+            if (s_off >= (uint32_t)CN_SALT_MEMORY)
+                s_off = 0;
+        }
+    }
+
+    {
+        // the caller generated random_values against CN_SCRATCHPAD_MEMORY_V14,
+        // so every index lands inside the 256 KB pad
+        const cn_random_values_t rv = context->random_values;
+        int ri;
+        for (ri = 0; ri < CN_RANDOM_VALUES; ri++)
+        {
+            switch (rv.operators[ri])
+            {
+            case ADD:  hp_state[rv.indices[ri]] += (uint8_t)rv.values[ri]; break;
+            case SUB:  hp_state[rv.indices[ri]] -= (uint8_t)rv.values[ri]; break;
+            case XOR:  hp_state[rv.indices[ri]] ^= (uint8_t)rv.values[ri]; break;
+            case OR:   hp_state[rv.indices[ri]] |= (uint8_t)rv.values[ri]; break;
+            case AND:  hp_state[rv.indices[ri]] &= (uint8_t)rv.values[ri]; break;
+            case COMP: hp_state[rv.indices[ri]] = ~(uint8_t)rv.values[ri]; break;
+            case EQ:   hp_state[rv.indices[ri]] =  (uint8_t)rv.values[ri]; break;
+            default: break;
+            }
+        }
+    }
+
+    uint64_t regs[CN_REG_COUNT];
+    {
+        int r;
+        for (r = 0; r < CN_REG_COUNT; r++)
+            memcpy(&regs[r], &state.k[r * sizeof(uint64_t)], sizeof(uint64_t));
+    }
+
+    // per-nonce start of the buffer walk, from the Keccak state
+    uint64_t chain_state;
+    memcpy(&chain_state, state.init + 64, sizeof(uint64_t));
+
+    cn_vm_program_t prog;
+    cn_vm_generate_program(&prog, seed);
+
+    // Fill the 24 MB per-nonce buffer from the seed (light work). The chase
+    // then mutates ~63% of it as it walks, so its cells can't be regenerated
+    // from the fill and the whole buffer has to stay resident. That residency
+    // is the capacity brake: a GPU/ASIC runs only as many nonces as it has
+    // buffers for. Below that coverage the buffer could be stored sparsely and
+    // recomputed, so the pass count is tied to the buffer size.
+    uint8_t * const buffer = context->cna_v7_buffer;
+    const uint64_t buffer_qwords = CN_V7_BUFFER / sizeof(uint64_t);
+    {
+        uint64_t fx;
+        memcpy(&fx, seed, sizeof(uint64_t));
+        uint64_t *bw = (uint64_t *)buffer;
+        uint64_t bi;
+        for (bi = 0; bi < buffer_qwords; bi++)
+        {
+            fx = (fx ^ (fx >> 29)) * UINT64_C(0xbf58476d1ce4e5b9);
+            bw[bi] = fx;
+        }
+    }
+
+    {
+        int iter;
+        for (iter = 0; iter < CN_VM_ITERATIONS_V14; iter++)
+            cn_vm_execute_v7(&prog, buffer, buffer_qwords, hp_state, regs, &chain_state);
+    }
+
+    regs[0] ^= chain_state;   // the walk's final position feeds the result
+
+    {
+        int r;
+        for (r = 0; r < CN_REG_COUNT; r++)
+        {
+            uint64_t tmp;
+            memcpy(&tmp, &state.k[r * sizeof(uint64_t)], sizeof(uint64_t));
+            tmp ^= regs[r];
+            memcpy(&state.k[r * sizeof(uint64_t)], &tmp, sizeof(uint64_t));
+        }
+    }
+
+    memcpy(text, state.init, init_size_byte);
+    aes_expand_key((OAES_CTX *)context->oaes_ctx, &state.hs.b[32], expandedKey);
+    for (i = 0; i < CN_SCRATCHPAD_MEMORY_V14 / init_size_byte; i++)
+        aes_pseudo_round_xor(text, text, expandedKey, &hp_state[i * init_size_byte], init_size_blk);
+    memcpy(state.init, text, init_size_byte);
+    hash_permutation(&state.hs);
+    extra_hashes[state.hs.b[0] & 3](&state, 200, hash);
+
+    free(text);
+}
+
 #else /* CN_USE_SOFTWARE_AES */
 
 void cn_slow_hash_v11(cn_hash_context_t *context, const void *data, size_t length, char *hash, size_t iters, uint8_t init_size_blk, uint16_t xx, uint16_t yy)
@@ -596,6 +731,145 @@ void cn_slow_hash_v13(cn_hash_context_t *context, const void *data, size_t lengt
     memcpy(text, state.init, init_size_byte);
     oaes_key_import_data(aes_ctx, &state.hs.b[32], AES_KEY_SIZE);
     for (i = 0; i < CN_SCRATCHPAD_MEMORY_V13 / init_size_byte; i++)
+    {
+        for (j = 0; j < init_size_blk; j++)
+        {
+            xor_blocks(&text[j * AES_BLOCK_SIZE], &hp_state[i * init_size_byte + j * AES_BLOCK_SIZE]);
+            aesb_pseudo_round(&text[AES_BLOCK_SIZE * j], &text[AES_BLOCK_SIZE * j], aes_ctx->key->exp_data);
+        }
+    }
+    memcpy(state.init, text, init_size_byte);
+    hash_permutation(&state.hs);
+    extra_hashes[state.hs.b[0] & 3](&state, 200, hash);
+
+    free(text);
+}
+
+// Software-AES twin of the HW cn_slow_hash_v14: v13's software path with the
+// same v14 changes (256 KB pad, 24 MB per-nonce buffer chase). Must produce
+// bit-identical hashes to the HW path; cn_slow_hash_self_test compares them at
+// startup.
+void cn_slow_hash_v14(cn_hash_context_t *context, const void *data, size_t length, char *hash,
+                      const uint8_t *seed)
+{
+    uint8_t * const hp_state = context->cna_scratchpad;
+    char * const salt = context->salt;
+    const uint8_t init_size_blk = INIT_SIZE_BLK;
+    const uint32_t init_size_byte = (uint32_t)(init_size_blk * AES_BLOCK_SIZE);
+
+    uint8_t *text = (uint8_t *)malloc(init_size_byte);
+    union cn_slow_hash_state state;
+    uint8_t aes_key[AES_KEY_SIZE];
+    oaes_ctx * const aes_ctx = (oaes_ctx *)context->oaes_ctx;
+    size_t i, j;
+
+    static void (*const extra_hashes[4])(const void *, size_t, char *) = {
+        hash_extra_blake, hash_extra_groestl, hash_extra_jh, hash_extra_skein};
+
+    hash_process(&state.hs, data, length);
+    memcpy(text, state.init, init_size_byte);
+    memcpy(aes_key, state.hs.b, AES_KEY_SIZE);
+    oaes_key_import_data(aes_ctx, aes_key, AES_KEY_SIZE);
+    for (i = 0; i < CN_SCRATCHPAD_MEMORY_V14 / init_size_byte; i++)
+    {
+        for (j = 0; j < init_size_blk; j++)
+            aesb_pseudo_round(&text[AES_BLOCK_SIZE * j], &text[AES_BLOCK_SIZE * j], aes_ctx->key->exp_data);
+        memcpy(&hp_state[i * init_size_byte], text, init_size_byte);
+    }
+
+    {
+        uint32_t s_off = 0;
+        uint32_t si;
+        for (si = 0; si < CN_SCRATCHPAD_MEMORY_V14; si += 4)
+        {
+            uint32_t sv, sp;
+            memcpy(&sv, (const uint8_t *)salt + s_off, 4);
+            memcpy(&sp, hp_state + si, 4);
+            sp ^= sv;
+            memcpy(hp_state + si, &sp, 4);
+            s_off += 4;
+            if (s_off >= (uint32_t)CN_SALT_MEMORY)
+                s_off = 0;
+        }
+    }
+
+    {
+        // the caller generated random_values against CN_SCRATCHPAD_MEMORY_V14,
+        // so every index lands inside the 256 KB pad
+        const cn_random_values_t rv = context->random_values;
+        int ri;
+        for (ri = 0; ri < CN_RANDOM_VALUES; ri++)
+        {
+            switch (rv.operators[ri])
+            {
+            case ADD:  hp_state[rv.indices[ri]] += (uint8_t)rv.values[ri]; break;
+            case SUB:  hp_state[rv.indices[ri]] -= (uint8_t)rv.values[ri]; break;
+            case XOR:  hp_state[rv.indices[ri]] ^= (uint8_t)rv.values[ri]; break;
+            case OR:   hp_state[rv.indices[ri]] |= (uint8_t)rv.values[ri]; break;
+            case AND:  hp_state[rv.indices[ri]] &= (uint8_t)rv.values[ri]; break;
+            case COMP: hp_state[rv.indices[ri]] = ~(uint8_t)rv.values[ri]; break;
+            case EQ:   hp_state[rv.indices[ri]] =  (uint8_t)rv.values[ri]; break;
+            default: break;
+            }
+        }
+    }
+
+    uint64_t regs[CN_REG_COUNT];
+    {
+        int r;
+        for (r = 0; r < CN_REG_COUNT; r++)
+            memcpy(&regs[r], &state.k[r * sizeof(uint64_t)], sizeof(uint64_t));
+    }
+
+    // per-nonce start of the buffer walk, from the Keccak state
+    uint64_t chain_state;
+    memcpy(&chain_state, state.init + 64, sizeof(uint64_t));
+
+    cn_vm_program_t prog;
+    cn_vm_generate_program(&prog, seed);
+
+    // Fill the 24 MB per-nonce buffer from the seed (light work). The chase
+    // then mutates ~63% of it as it walks, so its cells can't be regenerated
+    // from the fill and the whole buffer has to stay resident. That residency
+    // is the capacity brake: a GPU/ASIC runs only as many nonces as it has
+    // buffers for. Below that coverage the buffer could be stored sparsely and
+    // recomputed, so the pass count is tied to the buffer size.
+    uint8_t * const buffer = context->cna_v7_buffer;
+    const uint64_t buffer_qwords = CN_V7_BUFFER / sizeof(uint64_t);
+    {
+        uint64_t fx;
+        memcpy(&fx, seed, sizeof(uint64_t));
+        uint64_t *bw = (uint64_t *)buffer;
+        uint64_t bi;
+        for (bi = 0; bi < buffer_qwords; bi++)
+        {
+            fx = (fx ^ (fx >> 29)) * UINT64_C(0xbf58476d1ce4e5b9);
+            bw[bi] = fx;
+        }
+    }
+
+    {
+        int iter;
+        for (iter = 0; iter < CN_VM_ITERATIONS_V14; iter++)
+            cn_vm_execute_v7(&prog, buffer, buffer_qwords, hp_state, regs, &chain_state);
+    }
+
+    regs[0] ^= chain_state;   // the walk's final position feeds the result
+
+    {
+        int r;
+        for (r = 0; r < CN_REG_COUNT; r++)
+        {
+            uint64_t tmp;
+            memcpy(&tmp, &state.k[r * sizeof(uint64_t)], sizeof(uint64_t));
+            tmp ^= regs[r];
+            memcpy(&state.k[r * sizeof(uint64_t)], &tmp, sizeof(uint64_t));
+        }
+    }
+
+    memcpy(text, state.init, init_size_byte);
+    oaes_key_import_data(aes_ctx, &state.hs.b[32], AES_KEY_SIZE);
+    for (i = 0; i < CN_SCRATCHPAD_MEMORY_V14 / init_size_byte; i++)
     {
         for (j = 0; j < init_size_blk; j++)
         {

--- a/src/crypto/slow-hash-impl.h
+++ b/src/crypto/slow-hash-impl.h
@@ -428,8 +428,22 @@ void cn_slow_hash_v14(cn_hash_context_t *context, const void *data, size_t lengt
     uint8_t * const buffer = context->cna_v7_buffer;
     const uint64_t buffer_qwords = CN_V7_BUFFER / sizeof(uint64_t);
     {
-        uint64_t fx;
-        memcpy(&fx, seed, sizeof(uint64_t));
+        // Fold all 32 seed bytes into the fill seed. Deriving it from just the
+        // first 8 made buffer collisions findable at ~2^32 (a cached fill could
+        // be reused across colliding nonces), and a zero prefix zeroed the
+        // whole buffer: zero is the fill map's only fixed point, so a non-zero
+        // start can never reach it, but a zero start never leaves it.
+        uint64_t fx = UINT64_C(0x9e3779b97f4a7c15);
+        uint64_t sq;
+        int sj;
+        for (sj = 0; sj < 4; sj++)
+        {
+            memcpy(&sq, seed + sj * sizeof(uint64_t), sizeof(uint64_t));
+            fx = (fx ^ sq) * UINT64_C(0xbf58476d1ce4e5b9);
+            fx ^= fx >> 29;
+        }
+        if (fx == 0)  // 2^-64 by chance; grinding for it buys one degenerate fill
+            fx = UINT64_C(0x9e3779b97f4a7c15);
         uint64_t *bw = (uint64_t *)buffer;
         uint64_t bi;
         for (bi = 0; bi < buffer_qwords; bi++)
@@ -837,8 +851,22 @@ void cn_slow_hash_v14(cn_hash_context_t *context, const void *data, size_t lengt
     uint8_t * const buffer = context->cna_v7_buffer;
     const uint64_t buffer_qwords = CN_V7_BUFFER / sizeof(uint64_t);
     {
-        uint64_t fx;
-        memcpy(&fx, seed, sizeof(uint64_t));
+        // Fold all 32 seed bytes into the fill seed. Deriving it from just the
+        // first 8 made buffer collisions findable at ~2^32 (a cached fill could
+        // be reused across colliding nonces), and a zero prefix zeroed the
+        // whole buffer: zero is the fill map's only fixed point, so a non-zero
+        // start can never reach it, but a zero start never leaves it.
+        uint64_t fx = UINT64_C(0x9e3779b97f4a7c15);
+        uint64_t sq;
+        int sj;
+        for (sj = 0; sj < 4; sj++)
+        {
+            memcpy(&sq, seed + sj * sizeof(uint64_t), sizeof(uint64_t));
+            fx = (fx ^ sq) * UINT64_C(0xbf58476d1ce4e5b9);
+            fx ^= fx >> 29;
+        }
+        if (fx == 0)  // 2^-64 by chance; grinding for it buys one degenerate fill
+            fx = UINT64_C(0x9e3779b97f4a7c15);
         uint64_t *bw = (uint64_t *)buffer;
         uint64_t bi;
         for (bi = 0; bi < buffer_qwords; bi++)

--- a/src/crypto/slow-hash-impl.h
+++ b/src/crypto/slow-hash-impl.h
@@ -346,7 +346,7 @@ void cn_slow_hash_v13(cn_hash_context_t *context, const void *data, size_t lengt
 void cn_slow_hash_v14(cn_hash_context_t *context, const void *data, size_t length, char *hash,
                       const uint8_t *seed)
 {
-    uint8_t * const hp_state = context->cna_scratchpad;
+    uint8_t * const hp_state = context->scratchpad;
     char * const salt = context->salt;
     const uint8_t init_size_blk = INIT_SIZE_BLK;
     const uint32_t init_size_byte = (uint32_t)(init_size_blk * AES_BLOCK_SIZE);
@@ -766,7 +766,7 @@ void cn_slow_hash_v13(cn_hash_context_t *context, const void *data, size_t lengt
 void cn_slow_hash_v14(cn_hash_context_t *context, const void *data, size_t length, char *hash,
                       const uint8_t *seed)
 {
-    uint8_t * const hp_state = context->cna_scratchpad;
+    uint8_t * const hp_state = context->scratchpad;
     char * const salt = context->salt;
     const uint8_t init_size_blk = INIT_SIZE_BLK;
     const uint32_t init_size_byte = (uint32_t)(init_size_blk * AES_BLOCK_SIZE);

--- a/src/crypto/slow-hash-sw.c
+++ b/src/crypto/slow-hash-sw.c
@@ -40,6 +40,7 @@
 #define cn_slow_hash_v10   cn_slow_hash_v10_sw
 #define cn_slow_hash_v11   cn_slow_hash_v11_sw
 #define cn_slow_hash_v13   cn_slow_hash_v13_sw
+#define cn_slow_hash_v14   cn_slow_hash_v14_sw
 
 #include "slow-hash.h"
 #include "slow-hash-impl.h"

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -60,6 +60,7 @@ extern void cn_slow_hash_v9_hw(cn_hash_context_t *context, const void *data, siz
 extern void cn_slow_hash_v10_hw(cn_hash_context_t *context, const void *data, size_t length, char *hash, size_t iters, uint8_t init_size_blk, uint16_t xx, uint16_t yy, uint16_t zz, uint16_t ww);
 extern void cn_slow_hash_v11_hw(cn_hash_context_t *context, const void *data, size_t length, char *hash, size_t iters, uint8_t init_size_blk, uint16_t xx, uint16_t yy);
 extern void cn_slow_hash_v13_hw(cn_hash_context_t *context, const void *data, size_t length, char *hash, const uint8_t *seed);
+extern void cn_slow_hash_v14_hw(cn_hash_context_t *context, const void *data, size_t length, char *hash, const uint8_t *seed);
 #endif
 
 extern void cn_slow_hash_sw(cn_hash_context_t *context, const void *data, size_t length, char *hash, int variant, int prehashed, size_t iters);
@@ -68,6 +69,7 @@ extern void cn_slow_hash_v9_sw(cn_hash_context_t *context, const void *data, siz
 extern void cn_slow_hash_v10_sw(cn_hash_context_t *context, const void *data, size_t length, char *hash, size_t iters, uint8_t init_size_blk, uint16_t xx, uint16_t yy, uint16_t zz, uint16_t ww);
 extern void cn_slow_hash_v11_sw(cn_hash_context_t *context, const void *data, size_t length, char *hash, size_t iters, uint8_t init_size_blk, uint16_t xx, uint16_t yy);
 extern void cn_slow_hash_v13_sw(cn_hash_context_t *context, const void *data, size_t length, char *hash, const uint8_t *seed);
+extern void cn_slow_hash_v14_sw(cn_hash_context_t *context, const void *data, size_t length, char *hash, const uint8_t *seed);
 
 /* Runtime CPU detection. Cached in a function-static so the per-hash overhead
  * is one branch on a hot variable. Override with NERVA_FORCE_SOFTWARE_AES=1 to
@@ -149,6 +151,12 @@ void cn_slow_hash_v13(cn_hash_context_t *ctx, const void *data, size_t length, c
 {
     CN_DISPATCH(cn_slow_hash_v13_hw(ctx, data, length, hash, seed),
                 cn_slow_hash_v13_sw(ctx, data, length, hash, seed));
+}
+
+void cn_slow_hash_v14(cn_hash_context_t *ctx, const void *data, size_t length, char *hash, const uint8_t *seed)
+{
+    CN_DISPATCH(cn_slow_hash_v14_hw(ctx, data, length, hash, seed),
+                cn_slow_hash_v14_sw(ctx, data, length, hash, seed));
 }
 
 const char *cn_page_tier_name(int tier)
@@ -345,6 +353,11 @@ cn_hash_context_t *cn_hash_context_create(void)
         cn_hash_context_free(ctx);
         return NULL;
     }
+    ctx->cna_v7_buffer_is_mapped = allocate_hugepage(CN_V7_BUFFER, (void **)&(ctx->cna_v7_buffer));
+    if (ctx->cna_v7_buffer == NULL) {
+        cn_hash_context_free(ctx);
+        return NULL;
+    }
     ctx->salt_is_mapped = allocate_hugepage(CN_SALT_MEMORY, (void **)&(ctx->salt));
     if (ctx->salt == NULL) {
         cn_hash_context_free(ctx);
@@ -371,6 +384,11 @@ void cn_hash_context_free(cn_hash_context_t *context)
     if (context->cna_scratchpad != NULL) {
         free_hugepage(context->cna_scratchpad, CN_SCRATCHPAD_MEMORY_V13, context->cna_scratchpad_is_mapped);
         context->cna_scratchpad = NULL;
+    }
+
+    if (context->cna_v7_buffer != NULL) {
+        free_hugepage(context->cna_v7_buffer, CN_V7_BUFFER, context->cna_v7_buffer_is_mapped);
+        context->cna_v7_buffer = NULL;
     }
 
     if (context->salt != NULL) {
@@ -444,6 +462,20 @@ int cn_slow_hash_self_test(void)
         memset(&ctx->random_values, 0, sizeof(ctx->random_values));
         memset(ctx->salt, 0, CN_SALT_MEMORY);
         cn_slow_hash_v13_sw(ctx, input, sizeof(input) - 1, sw, seed);
+        if (memcmp(hw, sw, HASH_SIZE) != 0) ok = 0;
+    }
+
+    /* v14: 256 KB pad + a 24 MB per-nonce buffer the hash fills from the seed
+     * and walks (mutating as it goes). Both paths mutate the pad; resetting
+     * salt/random_values before each call keeps the inputs identical. */
+    {
+        static const uint8_t seed[32] = {0};
+        memset(&ctx->random_values, 0, sizeof(ctx->random_values));
+        memset(ctx->salt, 0, CN_SALT_MEMORY);
+        cn_slow_hash_v14_hw(ctx, input, sizeof(input) - 1, hw, seed);
+        memset(&ctx->random_values, 0, sizeof(ctx->random_values));
+        memset(ctx->salt, 0, CN_SALT_MEMORY);
+        cn_slow_hash_v14_sw(ctx, input, sizeof(input) - 1, sw, seed);
         if (memcmp(hw, sw, HASH_SIZE) != 0) ok = 0;
     }
 

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -153,8 +153,17 @@ void cn_slow_hash_v13(cn_hash_context_t *ctx, const void *data, size_t length, c
                 cn_slow_hash_v13_sw(ctx, data, length, hash, seed));
 }
 
+static int cn_v7_buffer_ensure(cn_hash_context_t *ctx);
+
 void cn_slow_hash_v14(cn_hash_context_t *ctx, const void *data, size_t length, char *hash, const uint8_t *seed)
 {
+    if (!cn_v7_buffer_ensure(ctx)) {
+        /* PoW cannot proceed without the buffer, and a wrong hash would be
+         * worse than a crash; a 24 MB malloc failing means the process is
+         * out of memory anyway. */
+        fprintf(stderr, "failed to allocate the CNA v7 chase buffer (24 MB)\n");
+        abort();
+    }
     CN_DISPATCH(cn_slow_hash_v14_hw(ctx, data, length, hash, seed),
                 cn_slow_hash_v14_sw(ctx, data, length, hash, seed));
 }
@@ -330,6 +339,16 @@ static void free_hugepage(void *hp, size_t size, int page_tier)
     }
 }
 
+/* Allocate the 24 MB v7 chase buffer on first use. The context is
+ * per-thread, so there is no race to guard. Failure leaves the pointer
+ * NULL and returns 0; the caller decides how loudly to die. */
+static int cn_v7_buffer_ensure(cn_hash_context_t *ctx)
+{
+    if (ctx->cna_v7_buffer == NULL)
+        ctx->cna_v7_buffer_is_mapped = allocate_hugepage(CN_V7_BUFFER, (void **)&(ctx->cna_v7_buffer));
+    return ctx->cna_v7_buffer != NULL;
+}
+
 cn_hash_context_t *cn_hash_context_create(void)
 {
     // calloc so pointer fields start NULL; a failed alloc can't leave
@@ -353,11 +372,10 @@ cn_hash_context_t *cn_hash_context_create(void)
         cn_hash_context_free(ctx);
         return NULL;
     }
-    ctx->cna_v7_buffer_is_mapped = allocate_hugepage(CN_V7_BUFFER, (void **)&(ctx->cna_v7_buffer));
-    if (ctx->cna_v7_buffer == NULL) {
-        cn_hash_context_free(ctx);
-        return NULL;
-    }
+    /* cna_v7_buffer is allocated lazily on first v14 use (cn_v7_buffer_ensure):
+     * contexts are also created for non-PoW work like the wallet KDF, which
+     * would otherwise carry an unused 24 MB each, and until HF14 activates
+     * nothing needs it at all. calloc above leaves the pointer NULL. */
     ctx->salt_is_mapped = allocate_hugepage(CN_SALT_MEMORY, (void **)&(ctx->salt));
     if (ctx->salt == NULL) {
         cn_hash_context_free(ctx);
@@ -467,12 +485,36 @@ int cn_slow_hash_self_test(void)
 
     /* v14: 256 KB pad + a 24 MB per-nonce buffer the hash fills from the seed
      * and walks (mutating as it goes). Both paths mutate the pad; resetting
-     * salt/random_values before each call keeps the inputs identical. */
+     * salt/random_values before each call keeps the inputs identical. The
+     * seed must be varied: with an all-zero seed the old fill zeroed the
+     * whole buffer and the chase collapsed onto the low indices, so the test
+     * exercised under 1% of the buffer while this is the only guard against
+     * an AES-NI / software-AES split on the v14 path. */
     {
-        static const uint8_t seed[32] = {0};
+        uint8_t seed[32];
+        uint32_t si;
+        for (si = 0; si < sizeof(seed); si++)
+            seed[si] = (uint8_t)(si * 47u + 11u);
+        /* this block calls the _hw/_sw entry points directly, so the lazy
+         * buffer allocation in cn_slow_hash_v14 doesn't run for it */
+        if (!cn_v7_buffer_ensure(ctx)) {
+            cn_hash_context_free(ctx);
+            return 0;
+        }
         memset(&ctx->random_values, 0, sizeof(ctx->random_values));
         memset(ctx->salt, 0, CN_SALT_MEMORY);
         cn_slow_hash_v14_hw(ctx, input, sizeof(input) - 1, hw, seed);
+        /* the fill must actually populate the buffer, or the comparison
+         * below is vacuous again; OR-sample it across its whole length */
+        {
+            const uint64_t *bw = (const uint64_t *)ctx->cna_v7_buffer;
+            const uint32_t stride = (uint32_t)(CN_V7_BUFFER / sizeof(uint64_t) / 4096);
+            uint64_t acc = 0;
+            uint32_t bi;
+            for (bi = 0; bi < 4096; bi++)
+                acc |= bw[bi * stride];
+            if (acc == 0) ok = 0;
+        }
         memset(&ctx->random_values, 0, sizeof(ctx->random_values));
         memset(ctx->salt, 0, CN_SALT_MEMORY);
         cn_slow_hash_v14_sw(ctx, input, sizeof(input) - 1, sw, seed);

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -117,53 +117,54 @@ int cn_hardware_aes_supported(void)
 #define CN_DISPATCH(call_hw, call_sw) do { call_sw; } while (0)
 #endif
 
+/* defined below, next to the allocator it uses */
+static void cn_pads_require(cn_hash_context_t *ctx, int legacy, int v6, int v7);
+
 void cn_slow_hash(cn_hash_context_t *ctx, const void *data, size_t length, char *hash, int variant, int prehashed, size_t iters)
 {
+    cn_pads_require(ctx, 1, 0, 0);
     CN_DISPATCH(cn_slow_hash_hw(ctx, data, length, hash, variant, prehashed, iters),
                 cn_slow_hash_sw(ctx, data, length, hash, variant, prehashed, iters));
 }
 
 void cn_slow_hash_v7_8(cn_hash_context_t *ctx, const void *data, size_t length, char *hash, size_t iters)
 {
+    cn_pads_require(ctx, 1, 0, 0);
     CN_DISPATCH(cn_slow_hash_v7_8_hw(ctx, data, length, hash, iters),
                 cn_slow_hash_v7_8_sw(ctx, data, length, hash, iters));
 }
 
 void cn_slow_hash_v9(cn_hash_context_t *ctx, const void *data, size_t length, char *hash, size_t iters)
 {
+    cn_pads_require(ctx, 1, 0, 0);
     CN_DISPATCH(cn_slow_hash_v9_hw(ctx, data, length, hash, iters),
                 cn_slow_hash_v9_sw(ctx, data, length, hash, iters));
 }
 
 void cn_slow_hash_v10(cn_hash_context_t *ctx, const void *data, size_t length, char *hash, size_t iters, uint8_t init_size_blk, uint16_t xx, uint16_t yy, uint16_t zz, uint16_t ww)
 {
+    cn_pads_require(ctx, 1, 0, 0);
     CN_DISPATCH(cn_slow_hash_v10_hw(ctx, data, length, hash, iters, init_size_blk, xx, yy, zz, ww),
                 cn_slow_hash_v10_sw(ctx, data, length, hash, iters, init_size_blk, xx, yy, zz, ww));
 }
 
 void cn_slow_hash_v11(cn_hash_context_t *ctx, const void *data, size_t length, char *hash, size_t iters, uint8_t init_size_blk, uint16_t xx, uint16_t yy)
 {
+    cn_pads_require(ctx, 1, 0, 0);
     CN_DISPATCH(cn_slow_hash_v11_hw(ctx, data, length, hash, iters, init_size_blk, xx, yy),
                 cn_slow_hash_v11_sw(ctx, data, length, hash, iters, init_size_blk, xx, yy));
 }
 
 void cn_slow_hash_v13(cn_hash_context_t *ctx, const void *data, size_t length, char *hash, const uint8_t *seed)
 {
+    cn_pads_require(ctx, 0, 1, 0);
     CN_DISPATCH(cn_slow_hash_v13_hw(ctx, data, length, hash, seed),
                 cn_slow_hash_v13_sw(ctx, data, length, hash, seed));
 }
 
-static int cn_v7_buffer_ensure(cn_hash_context_t *ctx);
-
 void cn_slow_hash_v14(cn_hash_context_t *ctx, const void *data, size_t length, char *hash, const uint8_t *seed)
 {
-    if (!cn_v7_buffer_ensure(ctx)) {
-        /* PoW cannot proceed without the buffer, and a wrong hash would be
-         * worse than a crash; a 24 MB malloc failing means the process is
-         * out of memory anyway. */
-        fprintf(stderr, "failed to allocate the CNA v7 chase buffer (24 MB)\n");
-        abort();
-    }
+    cn_pads_require(ctx, 1, 0, 1);   /* 256 KB pad lives in the legacy buffer */
     CN_DISPATCH(cn_slow_hash_v14_hw(ctx, data, length, hash, seed),
                 cn_slow_hash_v14_sw(ctx, data, length, hash, seed));
 }
@@ -339,14 +340,37 @@ static void free_hugepage(void *hp, size_t size, int page_tier)
     }
 }
 
-/* Allocate the 24 MB v7 chase buffer on first use. The context is
- * per-thread, so there is no race to guard. Failure leaves the pointer
- * NULL and returns 0; the caller decides how loudly to die. */
-static int cn_v7_buffer_ensure(cn_hash_context_t *ctx)
+/* Allocate a PoW buffer on first use. Contexts are also created for work that
+ * never hashes a block (the wallet KDF, key encryption) and a node past HF14
+ * never touches the v6 pad, so none of these are worth carrying up front. The
+ * context is per-thread, so there is no race to guard. Failure leaves the
+ * pointer NULL and returns 0; the caller decides how loudly to die. */
+static int cn_buffer_ensure(uint8_t **buf, int *tier, size_t size)
 {
-    if (ctx->cna_v7_buffer == NULL)
-        ctx->cna_v7_buffer_is_mapped = allocate_hugepage(CN_V7_BUFFER, (void **)&(ctx->cna_v7_buffer));
-    return ctx->cna_v7_buffer != NULL;
+    if (*buf == NULL)
+        *tier = allocate_hugepage(size, (void **)buf);
+    return *buf != NULL;
+}
+
+static int cn_pads_ensure(cn_hash_context_t *ctx, int legacy, int v6, int v7)
+{
+    if (legacy && !cn_buffer_ensure(&ctx->scratchpad, &ctx->scratchpad_is_mapped, CN_SCRATCHPAD_MEMORY))
+        return 0;
+    if (v6 && !cn_buffer_ensure(&ctx->cna_scratchpad, &ctx->cna_scratchpad_is_mapped, CN_SCRATCHPAD_MEMORY_V13))
+        return 0;
+    if (v7 && !cn_buffer_ensure(&ctx->cna_v7_buffer, &ctx->cna_v7_buffer_is_mapped, CN_V7_BUFFER))
+        return 0;
+    return 1;
+}
+
+static void cn_pads_require(cn_hash_context_t *ctx, int legacy, int v6, int v7)
+{
+    if (!cn_pads_ensure(ctx, legacy, v6, v7)) {
+        /* hashing cannot proceed, and a wrong hash would be worse than a
+         * crash; a failed pad allocation means the process is out of memory */
+        fprintf(stderr, "failed to allocate a CryptoNight scratchpad\n");
+        abort();
+    }
 }
 
 cn_hash_context_t *cn_hash_context_create(void)
@@ -362,20 +386,9 @@ cn_hash_context_t *cn_hash_context_create(void)
         free(ctx);
         return NULL;
     }
-    ctx->scratchpad_is_mapped = allocate_hugepage(CN_SCRATCHPAD_MEMORY, (void **)&(ctx->scratchpad));
-    if (ctx->scratchpad == NULL) {
-        cn_hash_context_free(ctx);
-        return NULL;
-    }
-    ctx->cna_scratchpad_is_mapped = allocate_hugepage(CN_SCRATCHPAD_MEMORY_V13, (void **)&(ctx->cna_scratchpad));
-    if (ctx->cna_scratchpad == NULL) {
-        cn_hash_context_free(ctx);
-        return NULL;
-    }
-    /* cna_v7_buffer is allocated lazily on first v14 use (cn_v7_buffer_ensure):
-     * contexts are also created for non-PoW work like the wallet KDF, which
-     * would otherwise carry an unused 24 MB each, and until HF14 activates
-     * nothing needs it at all. calloc above leaves the pointer NULL. */
+    /* the PoW pads are allocated on first use (cn_pads_ensure); calloc above
+     * leaves their pointers NULL. Only the salt is carried up front, because
+     * the block-hash callers fill it before they call in. */
     ctx->salt_is_mapped = allocate_hugepage(CN_SALT_MEMORY, (void **)&(ctx->salt));
     if (ctx->salt == NULL) {
         cn_hash_context_free(ctx);
@@ -428,6 +441,13 @@ int cn_slow_hash_self_test(void)
     cn_hash_context_t *ctx = cn_hash_context_create();
     if (ctx == NULL)
         return 1;
+
+    /* every case below calls the _hw/_sw entry points directly, so the lazy
+     * allocation in the dispatchers does not run for them */
+    if (!cn_pads_ensure(ctx, 1, 1, 1)) {
+        cn_hash_context_free(ctx);
+        return 0;
+    }
 
     static const char input[] = "nerva-cn-slow-hash-hw-vs-sw-self-test";
     char hw[HASH_SIZE];
@@ -495,12 +515,6 @@ int cn_slow_hash_self_test(void)
         uint32_t si;
         for (si = 0; si < sizeof(seed); si++)
             seed[si] = (uint8_t)(si * 47u + 11u);
-        /* this block calls the _hw/_sw entry points directly, so the lazy
-         * buffer allocation in cn_slow_hash_v14 doesn't run for it */
-        if (!cn_v7_buffer_ensure(ctx)) {
-            cn_hash_context_free(ctx);
-            return 0;
-        }
         memset(&ctx->random_values, 0, sizeof(ctx->random_values));
         memset(ctx->salt, 0, CN_SALT_MEMORY);
         cn_slow_hash_v14_hw(ctx, input, sizeof(input) - 1, hw, seed);

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -169,6 +169,65 @@ void cn_slow_hash_v14(cn_hash_context_t *ctx, const void *data, size_t length, c
                 cn_slow_hash_v14_sw(ctx, data, length, hash, seed));
 }
 
+/* mmap + MADV_HUGEPAGE on Linux is best effort: the kernel can back the mapping
+ * with base pages anyway, and it decides that as the pages are faulted in, well
+ * after the allocation returns. So the tier allocate_hugepage recorded is what
+ * we asked for, not what we got, and printing it claims huge pages that may not
+ * exist. Ask the kernel what actually happened. Only Linux needs this: Windows
+ * large pages either come back from VirtualAlloc or they do not, and FreeBSD
+ * superpages are transparent with nothing to query. */
+int cn_page_tier_actual(const void *p, size_t size, int requested_tier)
+{
+#if defined(__linux__) && !defined(__ANDROID__)
+    if (requested_tier != CN_PAGES_THP || p == NULL)
+        return requested_tier;
+
+    FILE *f = fopen("/proc/self/smaps", "r");
+    if (f == NULL)
+        return requested_tier;   /* cannot tell, do not invent an answer */
+
+    const unsigned long target = (unsigned long)(uintptr_t)p;
+    char line[512];
+    int in_mapping = 0;
+    long huge_kb = -1;
+    while (fgets(line, sizeof(line), f) != NULL) {
+        unsigned long from, to;
+        if (sscanf(line, "%lx-%lx", &from, &to) == 2)
+            in_mapping = (target >= from && target < to);
+        else if (in_mapping && strncmp(line, "AnonHugePages:", 14) == 0) {
+            sscanf(line + 14, "%ld", &huge_kb);
+            break;
+        }
+    }
+    fclose(f);
+
+    if (huge_kb < 0)
+        return requested_tier;   /* kernel did not report the field */
+    /* most of the mapping has to be huge-page backed to call it that */
+    if ((size_t)huge_kb * 1024u < size / 2u)
+        return CN_PAGES_PLAIN_MMAP;
+    return requested_tier;
+#else
+    (void)p; (void)size;
+    return requested_tier;
+#endif
+}
+
+/* The page tier of whichever buffer carries the hashrate at this fork version,
+ * as the kernel actually backed it: the 24 MB chase buffer from v14, the 8 MB
+ * v6 pad at v13, the 1 MB legacy pad before that. Call it after a hash of that
+ * version has run, or the buffer will not be allocated yet. */
+int cn_page_tier_for_version(const cn_hash_context_t *ctx, uint8_t major_version)
+{
+    if (ctx == NULL)
+        return CN_PAGES_MALLOC;
+    if (major_version >= 14)
+        return cn_page_tier_actual(ctx->cna_v7_buffer, CN_V7_BUFFER, ctx->cna_v7_buffer_is_mapped);
+    if (major_version == 13)
+        return cn_page_tier_actual(ctx->cna_scratchpad, CN_SCRATCHPAD_MEMORY_V13, ctx->cna_scratchpad_is_mapped);
+    return cn_page_tier_actual(ctx->scratchpad, CN_SCRATCHPAD_MEMORY, ctx->scratchpad_is_mapped);
+}
+
 const char *cn_page_tier_name(int tier)
 {
     switch (tier)

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -510,7 +510,10 @@ int cn_slow_hash_self_test(void)
         return 1;
     }
 
-    static const char input[] = "nerva-cn-slow-hash-hw-vs-sw-self-test";
+    /* variant 1 reads a tweak at data+35 as a 64 bit word, so anything
+     * shorter than 43 bytes reads past the end of it. Monero refuses short
+     * input outright; here the fixed test vector just has to be long enough. */
+    static const char input[] = "nerva-cn-slow-hash hardware versus software self test vector";
     char hw[HASH_SIZE];
     char sw[HASH_SIZE];
     int ok = 1;

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -443,10 +443,12 @@ int cn_slow_hash_self_test(void)
         return 1;
 
     /* every case below calls the _hw/_sw entry points directly, so the lazy
-     * allocation in the dispatchers does not run for them */
+     * allocation in the dispatchers does not run for them. A failed allocation
+     * says nothing about HW versus SW agreement, so skip the test the same way
+     * a failed context allocation does above rather than refusing to start. */
     if (!cn_pads_ensure(ctx, 1, 1, 1)) {
         cn_hash_context_free(ctx);
-        return 0;
+        return 1;
     }
 
     static const char input[] = "nerva-cn-slow-hash-hw-vs-sw-self-test";

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -240,6 +240,15 @@ namespace boost
   }
 
   template <class Archive>
+  inline void serialize(Archive &a, rct::clsag &x, const boost::serialization::version_type ver)
+  {
+    a & x.s;
+    a & x.c1;
+    // a & x.I; // not serialized, we can recover it from the tx vin
+    a & x.D;
+  }
+
+  template <class Archive>
   inline void serialize(Archive &a, rct::ecdhTuple &x, const boost::serialization::version_type ver)
   {
     a & x.mask;
@@ -289,9 +298,9 @@ namespace boost
     a & x.type;
     if (x.type == rct::RCTTypeNull)
       return;
-    if (x.type != rct::RCTTypeFull && x.type != rct::RCTTypeSimple && 
-        x.type != rct::RCTTypeBulletproof1Full && x.type != rct::RCTTypeBulletproof1Simple && 
-        x.type != rct::RCTTypeBulletproof2)
+    if (x.type != rct::RCTTypeFull && x.type != rct::RCTTypeSimple &&
+        x.type != rct::RCTTypeBulletproof1Full && x.type != rct::RCTTypeBulletproof1Simple &&
+        x.type != rct::RCTTypeBulletproof2 && x.type != rct::RCTTypeCLSAG)
       throw boost::archive::archive_exception(boost::archive::archive_exception::other_exception, "Unsupported rct type");
     // a & x.message; message is not serialized, as it can be reconstructed from the tx data
     // a & x.mixRing; mixRing is not serialized, as it can be reconstructed from the offsets
@@ -309,6 +318,8 @@ namespace boost
     if (x.rangeSigs.empty())
       a & x.bulletproofs;
     a & x.MGs;
+    if (ver >= 1u)
+      a & x.CLSAGs;
     if (x.rangeSigs.empty())
       a & x.pseudoOuts;
   }
@@ -319,9 +330,9 @@ namespace boost
     a & x.type;
     if (x.type == rct::RCTTypeNull)
       return;
-    if (x.type != rct::RCTTypeFull && x.type != rct::RCTTypeSimple && 
-        x.type != rct::RCTTypeBulletproof1Full && x.type != rct::RCTTypeBulletproof1Simple && 
-        x.type != rct::RCTTypeBulletproof2)
+    if (x.type != rct::RCTTypeFull && x.type != rct::RCTTypeSimple &&
+        x.type != rct::RCTTypeBulletproof1Full && x.type != rct::RCTTypeBulletproof1Simple &&
+        x.type != rct::RCTTypeBulletproof2 && x.type != rct::RCTTypeCLSAG)
       throw boost::archive::archive_exception(boost::archive::archive_exception::other_exception, "Unsupported rct type");
     // a & x.message; message is not serialized, as it can be reconstructed from the tx data
     // a & x.mixRing; mixRing is not serialized, as it can be reconstructed from the offsets
@@ -335,8 +346,11 @@ namespace boost
     if (x.p.rangeSigs.empty())
       a & x.p.bulletproofs;
     a & x.p.MGs;
+    if (ver >= 1u)
+      a & x.p.CLSAGs;
     if (x.type == rct::RCTTypeBulletproof1Simple ||
-        x.type == rct::RCTTypeBulletproof2)
+        x.type == rct::RCTTypeBulletproof2 ||
+        x.type == rct::RCTTypeCLSAG)
       a & x.p.pseudoOuts;
   }
 
@@ -377,3 +391,7 @@ namespace boost
 }
 }
 
+// Class version gates the HF14 CLSAGs field so wallet caches written by
+// older code still load, as Monero master.
+BOOST_CLASS_VERSION(rct::rctSigPrunable, 1)
+BOOST_CLASS_VERSION(rct::rctSig, 1)

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -224,6 +224,20 @@ namespace boost
   }
 
   template <class Archive>
+  inline void serialize(Archive &a, rct::BulletproofPlus &x, const boost::serialization::version_type ver)
+  {
+    a & x.V;
+    a & x.A;
+    a & x.A1;
+    a & x.B;
+    a & x.r1;
+    a & x.s1;
+    a & x.d1;
+    a & x.L;
+    a & x.R;
+  }
+
+  template <class Archive>
   inline void serialize(Archive &a, rct::boroSig &x, const boost::serialization::version_type ver)
   {
     a & x.s0;
@@ -300,7 +314,8 @@ namespace boost
       return;
     if (x.type != rct::RCTTypeFull && x.type != rct::RCTTypeSimple &&
         x.type != rct::RCTTypeBulletproof1Full && x.type != rct::RCTTypeBulletproof1Simple &&
-        x.type != rct::RCTTypeBulletproof2 && x.type != rct::RCTTypeCLSAG)
+        x.type != rct::RCTTypeBulletproof2 && x.type != rct::RCTTypeCLSAG &&
+        x.type != rct::RCTTypeBulletproofPlus)
       throw boost::archive::archive_exception(boost::archive::archive_exception::other_exception, "Unsupported rct type");
     // a & x.message; message is not serialized, as it can be reconstructed from the tx data
     // a & x.mixRing; mixRing is not serialized, as it can be reconstructed from the offsets
@@ -316,7 +331,11 @@ namespace boost
   {
     a & x.rangeSigs;
     if (x.rangeSigs.empty())
+    {
       a & x.bulletproofs;
+      if (ver >= 2u)
+        a & x.bulletproofs_plus;
+    }
     a & x.MGs;
     if (ver >= 1u)
       a & x.CLSAGs;
@@ -332,7 +351,8 @@ namespace boost
       return;
     if (x.type != rct::RCTTypeFull && x.type != rct::RCTTypeSimple &&
         x.type != rct::RCTTypeBulletproof1Full && x.type != rct::RCTTypeBulletproof1Simple &&
-        x.type != rct::RCTTypeBulletproof2 && x.type != rct::RCTTypeCLSAG)
+        x.type != rct::RCTTypeBulletproof2 && x.type != rct::RCTTypeCLSAG &&
+        x.type != rct::RCTTypeBulletproofPlus)
       throw boost::archive::archive_exception(boost::archive::archive_exception::other_exception, "Unsupported rct type");
     // a & x.message; message is not serialized, as it can be reconstructed from the tx data
     // a & x.mixRing; mixRing is not serialized, as it can be reconstructed from the offsets
@@ -344,13 +364,18 @@ namespace boost
     //--------------
     a & x.p.rangeSigs;
     if (x.p.rangeSigs.empty())
+    {
       a & x.p.bulletproofs;
+      if (ver >= 2u)
+        a & x.p.bulletproofs_plus;
+    }
     a & x.p.MGs;
     if (ver >= 1u)
       a & x.p.CLSAGs;
     if (x.type == rct::RCTTypeBulletproof1Simple ||
         x.type == rct::RCTTypeBulletproof2 ||
-        x.type == rct::RCTTypeCLSAG)
+        x.type == rct::RCTTypeCLSAG ||
+        x.type == rct::RCTTypeBulletproofPlus)
       a & x.p.pseudoOuts;
   }
 
@@ -391,7 +416,7 @@ namespace boost
 }
 }
 
-// Class version gates the HF14 CLSAGs field so wallet caches written by
-// older code still load, as Monero master.
-BOOST_CLASS_VERSION(rct::rctSigPrunable, 1)
-BOOST_CLASS_VERSION(rct::rctSig, 1)
+// Class versions gate the HF14 fields (CLSAGs at 1, bulletproofs_plus at 2)
+// so wallet caches written by older code still load, as Monero master.
+BOOST_CLASS_VERSION(rct::rctSigPrunable, 2)
+BOOST_CLASS_VERSION(rct::rctSig, 2)

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -383,7 +383,16 @@ namespace boost
   inline void serialize(Archive &a, rct::RCTConfig &x, const boost::serialization::version_type ver)
   {
     a & x.range_proof_type;
-    a & x.is_v2;
+    if (ver < 1)
+    {
+      // pre-HF14 archives stored the old bool is_v2; map it onto bp_version
+      bool is_v2 = x.bp_version >= 2;
+      a & is_v2;
+      if (Archive::is_loading::value)
+        x.bp_version = is_v2 ? 2 : 1;
+      return;
+    }
+    a & x.bp_version;
   }
 
   template <class Archive>
@@ -420,3 +429,4 @@ namespace boost
 // so wallet caches written by older code still load, as Monero master.
 BOOST_CLASS_VERSION(rct::rctSigPrunable, 2)
 BOOST_CLASS_VERSION(rct::rctSig, 2)
+BOOST_CLASS_VERSION(rct::RCTConfig, 1)

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -385,8 +385,11 @@ namespace boost
     a & x.range_proof_type;
     if (ver < 1)
     {
-      // pre-HF14 archives stored the old bool is_v2; map it onto bp_version
-      bool is_v2 = x.bp_version >= 2;
+      // pre-HF14 archives stored the old bool is_v2; map it onto bp_version.
+      // Only read bp_version when saving: loading an old archive lands here
+      // with the field still uninitialised, and the archive overwrites is_v2
+      // before it is used anyway.
+      bool is_v2 = Archive::is_saving::value && x.bp_version >= 2;
       a & is_v2;
       if (Archive::is_loading::value)
         x.bp_version = is_v2 ? 2 : 1;

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -108,7 +108,8 @@ namespace cryptonote
   uint64_t get_transaction_weight_clawback(const transaction &tx, size_t n_padded_outputs)
   {
     const rct::rctSig &rv = tx.rct_signatures;
-    const uint64_t bp_base = 368;
+    const bool plus = rv.type == rct::RCTTypeBulletproofPlus;
+    const uint64_t bp_base = (32 * ((plus ? 6 : 9) + 7 * 2)) / 2; // notional size of a 2 output proof, normalized to 1 proof (ie, divided by 2)
     const size_t n_outputs = tx.vout.size();
     if (n_padded_outputs <= 2)
       return 0;
@@ -116,7 +117,7 @@ namespace cryptonote
     while ((1u << nlr) < n_padded_outputs)
       ++nlr;
     nlr += 6;
-    const size_t bp_size = 32 * (9 + 2 * nlr);
+    const size_t bp_size = 32 * ((plus ? 6 : 9) + 2 * nlr);
     CHECK_AND_ASSERT_THROW_MES_L1(n_outputs <= BULLETPROOF_MAX_OUTPUTS, "maximum number of outputs is " + std::to_string(BULLETPROOF_MAX_OUTPUTS) + " per transaction");
     CHECK_AND_ASSERT_THROW_MES_L1(bp_base * n_padded_outputs >= bp_size, "Invalid bulletproof clawback: bp_base " + std::to_string(bp_base) + ", n_padded_outputs "
         + std::to_string(n_padded_outputs) + ", bp_size " + std::to_string(bp_size));
@@ -187,7 +188,7 @@ namespace cryptonote
             bp.V[0] = rv.outPk[i].mask;
           }
         }
-        else if (rv.type == rct::RCTTypeBulletproof2)
+        else if (rv.type == rct::RCTTypeBulletproof2 || rv.type == rct::RCTTypeCLSAG)
         {
           if (rv.p.bulletproofs.size() != 1)
           {
@@ -205,6 +206,31 @@ namespace cryptonote
           if (max_outputs < n_outputs)
           {
             LOG_PRINT_L1("Failed to parse transaction from blob, bad bulletproofs max outputs in tx " << get_transaction_hash(tx));
+            return false;
+          }
+          CHECK_AND_ASSERT_MES(n_outputs == rv.outPk.size(), false, "Internal error filling out V");
+          bp.V.resize(n_outputs);
+          for (size_t i = 0; i < n_outputs; ++i)
+            bp.V[i] = rct::scalarmultKey(rv.outPk[i].mask, rct::INV_EIGHT);
+        }
+        else if (rv.type == rct::RCTTypeBulletproofPlus)
+        {
+          if (rv.p.bulletproofs_plus.size() != 1)
+          {
+            LOG_PRINT_L1("Failed to parse transaction from blob, bad bulletproofs_plus size in tx " << get_transaction_hash(tx));
+            return false;
+          }
+          rct::BulletproofPlus &bp = rv.p.bulletproofs_plus[0];
+          if (bp.L.size() < 6)
+          {
+            LOG_PRINT_L1("Failed to parse transaction from blob, bad bulletproofs_plus L size in tx " << get_transaction_hash(tx));
+            return false;
+          }
+          const size_t max_outputs = rct::n_bulletproof_plus_max_amounts(bp);
+          const size_t n_outputs = tx.vout.size();
+          if (max_outputs < n_outputs)
+          {
+            LOG_PRINT_L1("Failed to parse transaction from blob, bad bulletproofs_plus max outputs in tx " << get_transaction_hash(tx));
             return false;
           }
           CHECK_AND_ASSERT_MES(n_outputs == rv.outPk.size(), false, "Internal error filling out V");
@@ -432,9 +458,11 @@ namespace cryptonote
     if (tx.version < 2)
       return blob_size;
     const rct::rctSig &rv = tx.rct_signatures;
-    if (!rct::is_rct_bulletproof(rv.type))
+    const bool bulletproof = rct::is_rct_bulletproof(rv.type);
+    const bool bulletproof_plus = rct::is_rct_bulletproof_plus(rv.type);
+    if (!bulletproof && !bulletproof_plus)
       return blob_size;
-    const size_t n_padded_outputs = rct::n_bulletproof_max_amounts(rv.p.bulletproofs);
+    const size_t n_padded_outputs = bulletproof_plus ? rct::n_bulletproof_plus_max_amounts(rv.p.bulletproofs_plus) : rct::n_bulletproof_max_amounts(rv.p.bulletproofs);
     uint64_t bp_clawback = get_transaction_weight_clawback(tx, n_padded_outputs);
     CHECK_AND_ASSERT_THROW_MES_L1(bp_clawback <= std::numeric_limits<uint64_t>::max() - blob_size, "Weight overflow");
     return blob_size + bp_clawback;
@@ -444,7 +472,7 @@ namespace cryptonote
   {
     CHECK_AND_ASSERT_MES(tx.pruned, std::numeric_limits<uint64_t>::max(), "get_pruned_transaction_weight does not support non pruned txes");
     CHECK_AND_ASSERT_MES(tx.version >= 2, std::numeric_limits<uint64_t>::max(), "get_pruned_transaction_weight does not support v1 txes");
-    CHECK_AND_ASSERT_MES(tx.rct_signatures.type >= rct::RCTTypeBulletproof2,
+    CHECK_AND_ASSERT_MES(tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG || tx.rct_signatures.type == rct::RCTTypeBulletproofPlus,
         std::numeric_limits<uint64_t>::max(), "get_pruned_transaction_weight does not support older range proof types");
     CHECK_AND_ASSERT_MES(!tx.vin.empty(), std::numeric_limits<uint64_t>::max(), "empty vin");
     CHECK_AND_ASSERT_MES(tx.vin[0].type() == typeid(cryptonote::txin_to_key), std::numeric_limits<uint64_t>::max(), "empty vin");
@@ -463,12 +491,15 @@ namespace cryptonote
     while ((n_padded_outputs = (1u << nrl)) < tx.vout.size())
       ++nrl;
     nrl += 6;
-    extra = 32 * (9 + 2 * nrl) + 2;
+    extra = 32 * ((rct::is_rct_bulletproof_plus(tx.rct_signatures.type) ? 6 : 9) + 2 * nrl) + 2;
     weight += extra;
 
-    // calculate deterministic MLSAG data size
+    // calculate deterministic CLSAG/MLSAG data size
     const size_t ring_size = boost::get<cryptonote::txin_to_key>(tx.vin[0]).key_offsets.size();
-    extra = tx.vin.size() * (ring_size * (1 + 1) * 32 + 32 /* cc */);
+    if (rct::is_rct_clsag(tx.rct_signatures.type))
+      extra = tx.vin.size() * (ring_size + 2) * 32;
+    else
+      extra = tx.vin.size() * (ring_size * (1 + 1) * 32 + 32 /* cc */);
     weight += extra;
 
     // calculate deterministic pseudoOuts size

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -118,7 +118,8 @@ namespace cryptonote
       ++nlr;
     nlr += 6;
     const size_t bp_size = 32 * ((plus ? 6 : 9) + 2 * nlr);
-    CHECK_AND_ASSERT_THROW_MES_L1(n_outputs <= BULLETPROOF_MAX_OUTPUTS, "maximum number of outputs is " + std::to_string(BULLETPROOF_MAX_OUTPUTS) + " per transaction");
+    const size_t max_outputs = plus ? BULLETPROOF_PLUS_MAX_OUTPUTS : BULLETPROOF_MAX_OUTPUTS;
+    CHECK_AND_ASSERT_THROW_MES_L1(n_outputs <= max_outputs, "maximum number of outputs is " + std::to_string(max_outputs) + " per transaction");
     CHECK_AND_ASSERT_THROW_MES_L1(bp_base * n_padded_outputs >= bp_size, "Invalid bulletproof clawback: bp_base " + std::to_string(bp_base) + ", n_padded_outputs "
         + std::to_string(n_padded_outputs) + ", bp_size " + std::to_string(bp_size));
     const uint64_t bp_clawback = (bp_base * n_padded_outputs - bp_size) * 4 / 5;

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -834,8 +834,10 @@ namespace cryptonote
 #else
       const int good_tier = CN_PAGES_THP;
 #endif
-      // the 8 MB pad only matters once CNA v6 (v13) is what we mine, no point
-      // nagging pre-fork miners about it
+      // no point nagging pre-v13 miners, but from v13 on the page tier is
+      // real hashrate: the v13 8 MB pad, and even more the v14 24 MB
+      // per-nonce chase, where every hop on 4 KB pages likely eats a TLB
+      // miss and a page walk on top of the DRAM load
       uint8_t template_version = 0;
       CRITICAL_REGION_BEGIN(m_template_lock);
       template_version = m_template.major_version;

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -819,35 +819,11 @@ namespace cryptonote
       MERROR("Unable to allocate hash context, terminating miner thread");
       return false;
     }
-    // Report which pages the v13 scratchpad landed on. The allocation used to
-    // fall back to normal pages silently and mining just looked slow until the
-    // next reboot, with nothing in the log explaining why.
-    {
-      const int tier = hash_context->cna_scratchpad_is_mapped;
-      // one INFO line for the session; per-thread detail stays at debug since
-      // tiers can differ per thread when the reserved pages run out mid-spawn
-      if (th_local_index == 0)
-        MGINFO("Mining scratchpads on " << crypto::cn_page_tier_name(tier));
-      MDEBUG("Miner thread [" << th_local_index << "] scratchpad on " << crypto::cn_page_tier_name(tier));
-#if defined(__APPLE__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
-      const int good_tier = CN_PAGES_PLAIN_MMAP; // best this platform offers, nothing to warn about
-#else
-      const int good_tier = CN_PAGES_THP;
-#endif
-      // no point nagging pre-v13 miners, but from v13 on the page tier is
-      // real hashrate: the v13 8 MB pad, and even more the v14 24 MB
-      // per-nonce chase, where every hop on 4 KB pages likely eats a TLB
-      // miss and a page walk on top of the DRAM load
-      uint8_t template_version = 0;
-      CRITICAL_REGION_BEGIN(m_template_lock);
-      template_version = m_template.major_version;
-      CRITICAL_REGION_END();
-      if (tier < good_tier && template_version >= 13 && !m_slow_pages_warned.exchange(true))
-        MGUSER_YELLOW("Mining is running on normal memory pages, hashrate will be lower. "
-            "Windows: run 'nervad --setup-large-pages' once as administrator, then log out and back in. "
-            "Linux: set vm.nr_hugepages or leave transparent hugepages enabled. "
-            "Freeing memory or rebooting, then restarting mining, retries the allocation.");
-    }
+    // The page tier is reported after the first hash, not here: the buffers are
+    // allocated on first use, so every *_is_mapped field is still zero at this
+    // point and reading one would report the worst tier no matter what the
+    // allocation actually got.
+    bool tier_reported = false;
     block b;
     ++m_threads_active;
     while(!m_stop)
@@ -892,6 +868,39 @@ namespace cryptonote
       b.nonce = nonce;
       crypto::hash h;
       get_block_longhash(hash_context, m_pbc, b, h, height);
+
+      // Report which pages the mining buffers landed on. The allocation used to
+      // fall back to normal pages silently and mining just looked slow until
+      // the next reboot, with nothing in the log explaining why. Read the
+      // buffer that actually carries the hashrate for this fork version: from
+      // v14 that is the 24 MB chase buffer, at v13 the 8 MB pad, before that
+      // the 1 MB one.
+      if (!tier_reported)
+      {
+        tier_reported = true;
+        const int tier = b.major_version >= 14 ? hash_context->cna_v7_buffer_is_mapped
+                       : b.major_version == 13 ? hash_context->cna_scratchpad_is_mapped
+                                               : hash_context->scratchpad_is_mapped;
+        // one INFO line for the session; per-thread detail stays at debug since
+        // tiers can differ per thread when the reserved pages run out mid-spawn
+        if (th_local_index == 0)
+          MGINFO("Mining scratchpads on " << crypto::cn_page_tier_name(tier));
+        MDEBUG("Miner thread [" << th_local_index << "] scratchpad on " << crypto::cn_page_tier_name(tier));
+#if defined(__APPLE__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
+        const int good_tier = CN_PAGES_PLAIN_MMAP; // best this platform offers, nothing to warn about
+#else
+        const int good_tier = CN_PAGES_THP;
+#endif
+        // no point nagging pre-v13 miners, but from v13 on the page tier is
+        // real hashrate: the v13 8 MB pad, and even more the v14 24 MB
+        // per-nonce chase, where every hop on 4 KB pages likely eats a TLB
+        // miss and a page walk on top of the DRAM load
+        if (tier < good_tier && b.major_version >= 13 && !m_slow_pages_warned.exchange(true))
+          MGUSER_YELLOW("Mining is running on normal memory pages, hashrate will be lower. "
+              "Windows: run 'nervad --setup-large-pages' once as administrator, then log out and back in. "
+              "Linux: set vm.nr_hugepages or leave transparent hugepages enabled. "
+              "Freeing memory or rebooting, then restarting mining, retries the allocation.");
+      }
 
       if(check_hash(h, local_diff))
       {

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -881,9 +881,9 @@ namespace cryptonote
       if (tier_reported_version != b.major_version)
       {
         tier_reported_version = b.major_version;
-        const int tier = b.major_version >= 14 ? hash_context->cna_v7_buffer_is_mapped
-                       : b.major_version == 13 ? hash_context->cna_scratchpad_is_mapped
-                                               : hash_context->scratchpad_is_mapped;
+        // the tier recorded at allocation is only what was asked for; on Linux
+        // the kernel may have used base pages anyway, so ask what it actually did
+        const int tier = crypto::cn_page_tier_for_version(hash_context, b.major_version);
         // one INFO line for the session; per-thread detail stays at debug since
         // tiers can differ per thread when the reserved pages run out mid-spawn
         if (th_local_index == 0)

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -823,7 +823,7 @@ namespace cryptonote
     // allocated on first use, so every *_is_mapped field is still zero at this
     // point and reading one would report the worst tier no matter what the
     // allocation actually got.
-    bool tier_reported = false;
+    uint8_t tier_reported_version = 0;   // 0 = nothing reported yet
     block b;
     ++m_threads_active;
     while(!m_stop)
@@ -875,9 +875,12 @@ namespace cryptonote
       // buffer that actually carries the hashrate for this fork version: from
       // v14 that is the 24 MB chase buffer, at v13 the 8 MB pad, before that
       // the 1 MB one.
-      if (!tier_reported)
+      // re-report when the fork version moves: a miner that started before the
+      // fork reported a different buffer, and the one that carries the hashrate
+      // from v14 on is the 24 MB chase buffer
+      if (tier_reported_version != b.major_version)
       {
-        tier_reported = true;
+        tier_reported_version = b.major_version;
         const int tier = b.major_version >= 14 ? hash_context->cna_v7_buffer_is_mapped
                        : b.major_version == 13 ? hash_context->cna_scratchpad_is_mapped
                                                : hash_context->scratchpad_is_mapped;

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -244,6 +244,10 @@ namespace config
         {11, 500000},
         {12, 930000},
         {13, 4320000}   // CryptoNight-Adaptive v6: 8 MB scratchpad + random VM program
+        // {14, TBD}    // CLSAG + Bulletproofs+ (type 7 only) and CryptoNight-Adaptive
+                        // v7 (per-nonce mutable-buffer chase, one box ~ one vote).
+                        // Mainnet height is set only after the validation gates pass:
+                        // reference-pair run, testnet fork, GPU port test.
     };
 
     namespace testnet
@@ -272,7 +276,7 @@ namespace config
             {11, 590},
             {12, 2000},
             {13, 2100}
-            // {14, TBD}  // CLSAG + Bulletproofs+ (type 7 only)
+            // {14, TBD}  // CLSAG + Bulletproofs+ (type 7 only) + CryptoNight-Adaptive v7
         };
     }
 
@@ -297,7 +301,7 @@ namespace config
             {11, 590},
             {12, 700},
             {13, 800}
-            // {14, TBD}  // CLSAG + Bulletproofs+ (type 7 only)
+            // {14, TBD}  // CLSAG + Bulletproofs+ (type 7 only) + CryptoNight-Adaptive v7
         };
     }
 }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -173,6 +173,10 @@
 #define HF_VERSION_MIN_2_OUTPUTS                                        13
 #define HF_VERSION_ENFORCE_MIN_AGE                                      13
 #define HF_VERSION_TX_KEY_VALIDATION                                    13
+// Monero forks these separately (v13 and v15); Nerva does both at HF14 and
+// only ever creates type 7 (CLSAG with Bulletproofs+)
+#define HF_VERSION_CLSAG                                                14
+#define HF_VERSION_BULLETPROOF_PLUS                                     14
 #define CRYPTONOTE_SHORT_TERM_BLOCK_WEIGHT_SURGE_FACTOR                 50
 
 #define CRYPTONOTE_NOISE_MIN_EPOCH                                      5
@@ -268,6 +272,7 @@ namespace config
             {11, 590},
             {12, 2000},
             {13, 2100}
+            // {14, TBD}  // CLSAG + Bulletproofs+ (type 7 only)
         };
     }
 
@@ -292,6 +297,7 @@ namespace config
             {11, 590},
             {12, 700},
             {13, 800}
+            // {14, TBD}  // CLSAG + Bulletproofs+ (type 7 only)
         };
     }
 }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -53,6 +53,7 @@
 #define CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE                             10
 
 #define BULLETPROOF_MAX_OUTPUTS                                         16
+#define BULLETPROOF_PLUS_MAX_OUTPUTS                                    16
 #define BULLETPROOF_SIMPLE_FORK_HEIGHT                                  8
 #define BULLETPROOF_FULL_FORK_HEIGHT                                    11
 
@@ -221,6 +222,9 @@ namespace config
     const unsigned char HASH_KEY_CLSAG_ROUND[] = "CLSAG_round";
     const unsigned char HASH_KEY_CLSAG_AGG_0[] = "CLSAG_agg_0";
     const unsigned char HASH_KEY_CLSAG_AGG_1[] = "CLSAG_agg_1";
+    // Bulletproofs+ (HF14) domain separators, byte-identical to Monero's
+    const char HASH_KEY_BULLETPROOF_PLUS_EXPONENT[] = "bulletproof_plus";
+    const char HASH_KEY_BULLETPROOF_PLUS_TRANSCRIPT[] = "bulletproof_plus_transcript";
 
     static const hard_fork hard_forks[] = {
         { 1,      1},

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -243,10 +243,11 @@ namespace config
         {10, 341000},
         {11, 500000},
         {12, 930000},
-        {13, 4320000}   // CryptoNight-Adaptive v6: 8 MB scratchpad + random VM program
-        // {14, TBD}    // CLSAG + Bulletproofs+ (type 7 only) and CryptoNight-Adaptive
+        {13, 4320000},  // CryptoNight-Adaptive v6: 8 MB scratchpad + random VM program
+        {14, 4400000}   // CLSAG + Bulletproofs+ (type 7 only) and CryptoNight-Adaptive
                         // v7 (per-nonce mutable-buffer chase, one box ~ one vote).
-                        // Mainnet height is set only after the validation gates pass:
+                        // Placeholder, about six weeks of blocks past the tip it was
+                        // picked against. It moves if the validation gates slip:
                         // reference-pair run, testnet fork, GPU port test.
     };
 
@@ -262,6 +263,8 @@ namespace config
 
         uint64_t const ASSUME_VALID_HEIGHT = 0; // 0 = full PoW verification
 
+        // 12 and 13 sit where stagenet has them, which only holds for a testnet
+        // started fresh from genesis: on the retired chain they were 2000 and 2100.
         static const hard_fork hard_forks[] = {
             { 1,   1},
             { 2,   2},
@@ -274,9 +277,9 @@ namespace config
             { 9, 570},
             {10, 580},
             {11, 590},
-            {12, 2000},
-            {13, 2100}
-            // {14, TBD}  // CLSAG + Bulletproofs+ (type 7 only) + CryptoNight-Adaptive v7
+            {12, 700},
+            {13, 800},
+            {14, 1000}  // CLSAG + Bulletproofs+ (type 7 only) + CryptoNight-Adaptive v7
         };
     }
 
@@ -300,8 +303,8 @@ namespace config
             {10, 580},
             {11, 590},
             {12, 700},
-            {13, 800}
-            // {14, TBD}  // CLSAG + Bulletproofs+ (type 7 only) + CryptoNight-Adaptive v7
+            {13, 800},
+            {14, 1000}  // CLSAG + Bulletproofs+ (type 7 only) + CryptoNight-Adaptive v7
         };
     }
 }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -215,6 +215,13 @@ namespace config
     // Gated by --fast-block-sync; bump both each release. 0 = disable.
     uint64_t const ASSUME_VALID_HEIGHT = 4320000;
 
+    // CLSAG (HF14) hash domain separators. Byte-identical to Monero's so the
+    // signature scheme stays bit-compatible with the battle-tested upstream
+    // implementation; consensus-critical once HF14 activates.
+    const unsigned char HASH_KEY_CLSAG_ROUND[] = "CLSAG_round";
+    const unsigned char HASH_KEY_CLSAG_AGG_0[] = "CLSAG_agg_0";
+    const unsigned char HASH_KEY_CLSAG_AGG_1[] = "CLSAG_agg_1";
+
     static const hard_fork hard_forks[] = {
         { 1,      1},
         { 2,      2},

--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -31,6 +31,7 @@ set(cryptonote_core_sources
   blockchain.cpp
   cryptonote_core.cpp
   tx_pool.cpp
+  tx_verification_utils.cpp
   tx_sanity_check.cpp
   cryptonote_tx_utils.cpp)
 
@@ -41,6 +42,7 @@ set(cryptonote_core_private_headers
   blockchain.h
   cryptonote_core.h
   tx_pool.h
+  tx_verification_utils.h
   tx_sanity_check.h
   cryptonote_tx_utils.h)
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -38,6 +38,7 @@
 #include "include_base_utils.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "tx_pool.h"
+#include "cryptonote_core/tx_verification_utils.h"
 #include "blockchain.h"
 #include "blockchain_db/blockchain_db.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
@@ -2832,7 +2833,7 @@ bool Blockchain::have_tx_keyimges_as_spent(const transaction &tx) const
   }
   return false;
 }
-bool Blockchain::expand_transaction(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys) const
+bool Blockchain::expand_transaction(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys)
 {
   PERF_TIMER(expand_transaction);
 
@@ -3045,167 +3046,10 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         false, "Transaction spends at least one output which is too young");
   }
 
-  if (!expand_transaction(tx, tx_prefix_hash, pubkeys))
-  {
-    MERROR_VER("Failed to expand rct signatures!");
+  if (!ver_input_proofs_rings(tx, pubkeys))
     return false;
-  }
 
-  // check ringct signatures
-  // obviously, the original and simple rct APIs use a mixRing that's indexes
-  // in opposite orders, because it'd be too simple otherwise...
   const rct::rctSig &rv = tx.rct_signatures;
-  switch (rv.type)
-  {
-  case rct::RCTTypeNull: {
-    // we only accept no signatures for coinbase txes
-    MERROR_VER("Null rct signature on non-coinbase tx");
-    return false;
-  }
-  case rct::RCTTypeSimple:
-  case rct::RCTTypeBulletproof1Simple:
-  case rct::RCTTypeBulletproof2:
-  case rct::RCTTypeCLSAG:
-  case rct::RCTTypeBulletproofPlus:
-  {
-    // check all this, either reconstructed (so should really pass), or not
-    {
-      if (pubkeys.size() != rv.mixRing.size())
-      {
-        MERROR_VER("Failed to check ringct signatures: mismatched pubkeys/mixRing size");
-        return false;
-      }
-      for (size_t i = 0; i < pubkeys.size(); ++i)
-      {
-        if (pubkeys[i].size() != rv.mixRing[i].size())
-        {
-          MERROR_VER("Failed to check ringct signatures: mismatched pubkeys/mixRing size");
-          return false;
-        }
-      }
-
-      for (size_t n = 0; n < pubkeys.size(); ++n)
-      {
-        for (size_t m = 0; m < pubkeys[n].size(); ++m)
-        {
-          if (pubkeys[n][m].dest != rct::rct2pk(rv.mixRing[n][m].dest))
-          {
-            MERROR_VER("Failed to check ringct signatures: mismatched pubkey at vin " << n << ", index " << m);
-            return false;
-          }
-          if (pubkeys[n][m].mask != rct::rct2pk(rv.mixRing[n][m].mask))
-          {
-            MERROR_VER("Failed to check ringct signatures: mismatched commitment at vin " << n << ", index " << m);
-            return false;
-          }
-        }
-      }
-    }
-
-    if (rct::is_rct_clsag(rv.type))
-    {
-      if (rv.p.CLSAGs.size() != tx.vin.size())
-      {
-        MERROR_VER("Failed to check ringct signatures: mismatched CLSAGs/vin sizes");
-        return false;
-      }
-      for (size_t n = 0; n < tx.vin.size(); ++n)
-      {
-        if (memcmp(&boost::get<txin_to_key>(tx.vin[n]).k_image, &rv.p.CLSAGs[n].I, 32))
-        {
-          MERROR_VER("Failed to check ringct signatures: mismatched key image");
-          return false;
-        }
-      }
-    }
-    else
-    {
-      if (rv.p.MGs.size() != tx.vin.size())
-      {
-        MERROR_VER("Failed to check ringct signatures: mismatched MGs/vin sizes");
-        return false;
-      }
-      for (size_t n = 0; n < tx.vin.size(); ++n)
-      {
-        if (rv.p.MGs[n].II.empty() || memcmp(&boost::get<txin_to_key>(tx.vin[n]).k_image, &rv.p.MGs[n].II[0], 32))
-        {
-          MERROR_VER("Failed to check ringct signatures: mismatched key image");
-          return false;
-        }
-      }
-    }
-
-    if (!(rv.type == rct::RCTTypeSimple || rv.type == rct::RCTTypeBulletproof1Simple ? rct::verRctNonSemanticsSimple_v1(rv) : rct::verRctNonSemanticsSimple(rv)))
-    {
-      MERROR_VER("Failed to check ringct signatures!");
-      return false;
-    }
-    break;
-  }
-  case rct::RCTTypeFull:
-  case rct::RCTTypeBulletproof1Full:
-  {
-    // check all this, either reconstructed (so should really pass), or not
-    {
-      bool size_matches = true;
-      for (size_t i = 0; i < pubkeys.size(); ++i)
-        size_matches &= pubkeys[i].size() == rv.mixRing.size();
-      for (size_t i = 0; i < rv.mixRing.size(); ++i)
-        size_matches &= pubkeys.size() == rv.mixRing[i].size();
-      if (!size_matches)
-      {
-        MERROR_VER("Failed to check ringct signatures: mismatched pubkeys/mixRing size");
-        return false;
-      }
-
-      for (size_t n = 0; n < pubkeys.size(); ++n)
-      {
-        for (size_t m = 0; m < pubkeys[n].size(); ++m)
-        {
-          if (pubkeys[n][m].dest != rct::rct2pk(rv.mixRing[m][n].dest))
-          {
-            MERROR_VER("Failed to check ringct signatures: mismatched pubkey at vin " << n << ", index " << m);
-            return false;
-          }
-          if (pubkeys[n][m].mask != rct::rct2pk(rv.mixRing[m][n].mask))
-          {
-            MERROR_VER("Failed to check ringct signatures: mismatched commitment at vin " << n << ", index " << m);
-            return false;
-          }
-        }
-      }
-    }
-
-    if (rv.p.MGs.size() != 1)
-    {
-      MERROR_VER("Failed to check ringct signatures: Bad MGs size");
-      return false;
-    }
-    if (rv.p.MGs.empty() || rv.p.MGs[0].II.size() != tx.vin.size())
-    {
-      MERROR_VER("Failed to check ringct signatures: mismatched II/vin sizes");
-      return false;
-    }
-    for (size_t n = 0; n < tx.vin.size(); ++n)
-    {
-      if (memcmp(&boost::get<txin_to_key>(tx.vin[n]).k_image, &rv.p.MGs[0].II[n], 32))
-      {
-        MERROR_VER("Failed to check ringct signatures: mismatched II/vin sizes");
-        return false;
-      }
-    }
-
-    if (!rct::verRct(rv, false))
-    {
-      MERROR_VER("Failed to check ringct signatures!");
-      return false;
-    }
-    break;
-  }
-  default:
-    MERROR_VER("Unsupported rct type: " << rv.type);
-    return false;
-  }
 
   // for bulletproofs, check they're only multi-output after v8
   if (rct::is_rct_bulletproof(rv.type))

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2790,6 +2790,34 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
     return false;
   }
 
+  // from v14, allow CLSAGs and bulletproofs plus (Monero's HF_VERSION_CLSAG /
+  // HF_VERSION_BULLETPROOF_PLUS gates, folded into one fork here)
+  if (hf_version < HF_VERSION_CLSAG) {
+    if (tx.version >= 2) {
+      if (tx.rct_signatures.type == rct::RCTTypeCLSAG || tx.rct_signatures.type == rct::RCTTypeBulletproofPlus || !tx.rct_signatures.p.bulletproofs_plus.empty())
+      {
+        MERROR_VER("Ringct type " << (unsigned)tx.rct_signatures.type << " is not allowed before v" << HF_VERSION_CLSAG);
+        tvc.m_invalid_output = true;
+        return false;
+      }
+    }
+  }
+
+  // from v14, allow only bulletproofs plus: type 6 (CLSAG with Bulletproofs)
+  // is the verified stepping stone and is never activated, new transactions
+  // must be type 7. Stray legacy bulletproofs are rejected like stray
+  // bulletproofs_plus are before the fork.
+  if (hf_version >= HF_VERSION_BULLETPROOF_PLUS) {
+    if (tx.version >= 2) {
+      if (tx.rct_signatures.type != rct::RCTTypeBulletproofPlus || !tx.rct_signatures.p.bulletproofs.empty())
+      {
+        MERROR_VER("Ringct type " << (unsigned)tx.rct_signatures.type << " is not allowed from v" << HF_VERSION_BULLETPROOF_PLUS);
+        tvc.m_invalid_output = true;
+        return false;
+      }
+    }
+  }
+
   return true;
 }
 //------------------------------------------------------------------
@@ -2827,7 +2855,7 @@ bool Blockchain::expand_transaction(transaction &tx, const crypto::hash &tx_pref
         rv.mixRing[m].push_back(pubkeys[n][m]);
     }
   }
-  else if (rv.type == rct::RCTTypeSimple || rv.type == rct::RCTTypeBulletproof1Simple || rv.type == rct::RCTTypeBulletproof2)
+  else if (rv.type == rct::RCTTypeSimple || rv.type == rct::RCTTypeBulletproof1Simple || rv.type == rct::RCTTypeBulletproof2 || rv.type == rct::RCTTypeCLSAG || rv.type == rct::RCTTypeBulletproofPlus)
   {
     CHECK_AND_ASSERT_MES(!pubkeys.empty() && !pubkeys[0].empty(), false, "empty pubkeys");
     rv.mixRing.resize(pubkeys.size());
@@ -2865,6 +2893,17 @@ bool Blockchain::expand_transaction(transaction &tx, const crypto::hash &tx_pref
       {
         rv.p.MGs[n].II.resize(1);
         rv.p.MGs[n].II[0] = rct::ki2rct(boost::get<txin_to_key>(tx.vin[n]).k_image);
+      }
+    }
+  }
+  else if (rv.type == rct::RCTTypeCLSAG || rv.type == rct::RCTTypeBulletproofPlus)
+  {
+    if (!tx.pruned)
+    {
+      CHECK_AND_ASSERT_MES(rv.p.CLSAGs.size() == tx.vin.size(), false, "Bad CLSAGs size");
+      for (size_t n = 0; n < tx.vin.size(); ++n)
+      {
+        rv.p.CLSAGs[n].I = rct::ki2rct(boost::get<txin_to_key>(tx.vin[n]).k_image);
       }
     }
   }
@@ -3026,6 +3065,8 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
   case rct::RCTTypeSimple:
   case rct::RCTTypeBulletproof1Simple:
   case rct::RCTTypeBulletproof2:
+  case rct::RCTTypeCLSAG:
+  case rct::RCTTypeBulletproofPlus:
   {
     // check all this, either reconstructed (so should really pass), or not
     {
@@ -3061,21 +3102,40 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       }
     }
 
-    if (rv.p.MGs.size() != tx.vin.size())
+    if (rct::is_rct_clsag(rv.type))
     {
-      MERROR_VER("Failed to check ringct signatures: mismatched MGs/vin sizes");
-      return false;
-    }
-    for (size_t n = 0; n < tx.vin.size(); ++n)
-    {
-      if (rv.p.MGs[n].II.empty() || memcmp(&boost::get<txin_to_key>(tx.vin[n]).k_image, &rv.p.MGs[n].II[0], 32))
+      if (rv.p.CLSAGs.size() != tx.vin.size())
       {
-        MERROR_VER("Failed to check ringct signatures: mismatched key image");
+        MERROR_VER("Failed to check ringct signatures: mismatched CLSAGs/vin sizes");
         return false;
+      }
+      for (size_t n = 0; n < tx.vin.size(); ++n)
+      {
+        if (memcmp(&boost::get<txin_to_key>(tx.vin[n]).k_image, &rv.p.CLSAGs[n].I, 32))
+        {
+          MERROR_VER("Failed to check ringct signatures: mismatched key image");
+          return false;
+        }
+      }
+    }
+    else
+    {
+      if (rv.p.MGs.size() != tx.vin.size())
+      {
+        MERROR_VER("Failed to check ringct signatures: mismatched MGs/vin sizes");
+        return false;
+      }
+      for (size_t n = 0; n < tx.vin.size(); ++n)
+      {
+        if (rv.p.MGs[n].II.empty() || memcmp(&boost::get<txin_to_key>(tx.vin[n]).k_image, &rv.p.MGs[n].II[0], 32))
+        {
+          MERROR_VER("Failed to check ringct signatures: mismatched key image");
+          return false;
+        }
       }
     }
 
-    if (!(rv.type == rct::RCTTypeBulletproof2 ? rct::verRctNonSemanticsSimple(rv) : rct::verRctNonSemanticsSimple_v1(rv)))
+    if (!(rv.type == rct::RCTTypeSimple || rv.type == rct::RCTTypeBulletproof1Simple ? rct::verRctNonSemanticsSimple_v1(rv) : rct::verRctNonSemanticsSimple(rv)))
     {
       MERROR_VER("Failed to check ringct signatures!");
       return false;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2764,6 +2764,23 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
     }
   }
 
+  return check_tx_rct_type(tx, tvc);
+}
+//------------------------------------------------------------------
+// The range proof and ring signature type rules, split out of
+// check_tx_outputs. These are the only output rules that move at the HF14
+// boundary: the checks above it are either version independent or gated on
+// HF13, which is already behind us. That lets the pool re-check a candidate
+// against them at template time without paying the per-output subgroup
+// multiplication above on every build. A later fork that adds an output rule
+// which can invalidate a transaction already in the pool belongs here too.
+bool Blockchain::check_tx_rct_type(const transaction& tx, tx_verification_context &tvc) const
+{
+  LOG_PRINT_L3("Blockchain::" << __func__);
+  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+
+  const uint8_t hf_version = m_hardfork->get_current_version();
+
   if (hf_version < BULLETPROOF_SIMPLE_FORK_HEIGHT) {
     // pre-v8, disallow bulletproofs
     const bool bulletproof = rct::is_rct_bulletproof(tx.rct_signatures.type);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -87,7 +87,7 @@ DISABLE_VS_WARNINGS(4267)
 //------------------------------------------------------------------
 Blockchain::Blockchain(tx_memory_pool& tx_pool) :
   m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_hash_context(NULL), m_timestamps_and_difficulties_height(0), m_current_block_cumul_weight_limit(0), m_current_block_cumul_weight_median(0),
-  m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_db_sync_on_blocks(true), m_db_sync_threshold(1), m_db_sync_mode(db_async), m_db_default_sync(false), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0), m_bytes_to_sync(0), m_cancel(false),
+  m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_batch_longhash_base(0), m_prepare_blocks(NULL), m_prepare_nblocks(0), m_db_sync_on_blocks(true), m_db_sync_threshold(1), m_db_sync_mode(db_async), m_db_default_sync(false), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0), m_bytes_to_sync(0), m_cancel(false),
   m_long_term_block_weights_window(CRYPTONOTE_LONG_TERM_BLOCK_WEIGHT_WINDOW_SIZE),
   m_long_term_effective_median_block_weight(0),
   m_long_term_block_weights_cache_tip_height(0),
@@ -552,6 +552,8 @@ bool Blockchain::deinit()
 
   crypto::cn_hash_context_free(m_hash_context);
   m_hash_context = NULL;
+  // a batch may have been interrupted, so release any worker contexts too
+  free_longhash_contexts();
 
   return true;
 }
@@ -3524,28 +3526,37 @@ leave:
   crypto::hash proof_of_work;
   memset(proof_of_work.data, 0xff, sizeof(proof_of_work.data));
 
-  // Gated by --fast-block-sync; FAKECHAIN inherits the mainnet config but never
-  // reaches that height.
-  const uint64_t assume_valid_height = cryptonote::get_config(m_nettype).ASSUME_VALID_HEIGHT;
-  const bool assume_valid = m_fast_sync && m_nettype != FAKECHAIN && assume_valid_height != 0 && blockchain_height < assume_valid_height;
-
-  // Quicksync is trusted only up to the checkpoint height it was anchored against
-  // (m_quicksync_max_height, captured at set_quicksync before any DNS/JSON checkpoints);
-  // above that it is unanchored, so PoW is always required.
-  const bool quicksync_active = m_fast_sync && m_nettype != FAKECHAIN && blockchain_height <= m_quicksync_max_height;
-  bool quicksync_has_block = false;
-  const bool quicksync_match = m_quicksync.check_block(blockchain_height, id, quicksync_has_block);
-  const bool quicksync_verified = quicksync_active && quicksync_match;
-
-  // A present-but-mismatching entry could be a forged block or a wrong/corrupt file;
-  // let PoW decide rather than trusting the file or stalling the node on a bad file.
-  const bool quicksync_conflict = quicksync_active && quicksync_has_block && !quicksync_match;
-  if (quicksync_conflict)
-    MWARNING("Block with id: " << id << " at height " << blockchain_height << " does not match the quick sync hash; verifying PoW");
-
-  if ((!quicksync_verified && !assume_valid) || quicksync_conflict)
+  // A present-but-mismatching quicksync entry could be a forged block or a
+  // wrong/corrupt file; block_needs_pow lets PoW decide rather than trusting
+  // the file or stalling the node on a bad file. Warn so it is visible.
   {
-    get_block_longhash(m_hash_context, this, bl, proof_of_work, blockchain_height);
+    bool quicksync_has_block = false;
+    const bool quicksync_match = m_quicksync.check_block(blockchain_height, id, quicksync_has_block);
+    const bool quicksync_active = m_fast_sync && m_nettype != FAKECHAIN && blockchain_height <= m_quicksync_max_height;
+    if (quicksync_active && quicksync_has_block && !quicksync_match)
+      MWARNING("Block with id: " << id << " at height " << blockchain_height << " does not match the quick sync hash; verifying PoW");
+  }
+
+  if (block_needs_pow(blockchain_height, id))
+  {
+    // prepare_handle_incoming_blocks may already have hashed this one on
+    // another thread. The seed depends on the exact height, so the cached
+    // result counts only when the height matches as well as the id.
+    ensure_batch_longhashes(blockchain_height);
+
+    bool precomputed = false;
+    const uint64_t idx = blockchain_height - m_batch_longhash_base;
+    if (blockchain_height >= m_batch_longhash_base && idx < m_batch_longhashes.size())
+    {
+      const precomputed_pow &e = m_batch_longhashes[idx];
+      if (e.valid && e.id == id)
+      {
+        proof_of_work = e.pow;
+        precomputed = true;
+      }
+    }
+    if (!precomputed)
+      get_block_longhash(m_hash_context, this, bl, proof_of_work, blockchain_height);
 
     // validate proof_of_work versus difficulty target
     if(!check_hash(proof_of_work, current_diffic))
@@ -4084,6 +4095,13 @@ bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
   CRITICAL_REGION_BEGIN(m_blockchain_lock);
   TIME_MEASURE_START(t1);
 
+  // the precomputed proofs of work and the batch they came from end here;
+  // m_prepare_blocks points at the caller's vector and must not outlive it
+  m_batch_longhashes.clear();
+  m_prepare_blocks = NULL;
+  m_prepare_nblocks = 0;
+  free_longhash_contexts();
+
   try
   {
     if (m_batch_success)
@@ -4303,6 +4321,175 @@ bool Blockchain::has_block_weights(uint64_t height, uint64_t nblocks) const
 //    vs [k_image, output_keys] (m_scan_table). This is faster because it takes advantage of bulk queries
 //    and is threaded if possible. The table (m_scan_table) will be used later when querying output
 //    keys.
+//------------------------------------------------------------------
+bool Blockchain::block_needs_pow(uint64_t blockchain_height, const crypto::hash& id) const
+{
+  const uint64_t assume_valid_height = cryptonote::get_config(m_nettype).ASSUME_VALID_HEIGHT;
+  const bool assume_valid = m_fast_sync && m_nettype != FAKECHAIN && assume_valid_height != 0 && blockchain_height < assume_valid_height;
+
+  // Quicksync is trusted only up to the checkpoint height it was anchored
+  // against; above that it is unanchored, so PoW is always required.
+  const bool quicksync_active = m_fast_sync && m_nettype != FAKECHAIN && blockchain_height <= m_quicksync_max_height;
+  bool quicksync_has_block = false;
+  const bool quicksync_match = m_quicksync.check_block(blockchain_height, id, quicksync_has_block);
+  const bool quicksync_verified = quicksync_active && quicksync_match;
+
+  // A present-but-mismatching entry could be a forged block or a wrong/corrupt
+  // file; let PoW decide rather than trusting the file or stalling the node.
+  const bool quicksync_conflict = quicksync_active && quicksync_has_block && !quicksync_match;
+
+  return (!quicksync_verified && !assume_valid) || quicksync_conflict;
+}
+//------------------------------------------------------------------
+void Blockchain::free_longhash_contexts()
+{
+  for (crypto::cn_hash_context_t *c : m_longhash_contexts)
+    crypto::cn_hash_context_free(c);
+  m_longhash_contexts.clear();
+}
+//------------------------------------------------------------------
+void Blockchain::longhash_worker(crypto::cn_hash_context_t *ctx, const std::vector<block> *blocks,
+                                 size_t block_offset, uint64_t base_height,
+                                 const std::vector<size_t> *todo, size_t from, size_t to)
+{
+  for (size_t k = from; k < to && !m_cancel; k++)
+  {
+    const size_t i = (*todo)[k];
+    crypto::hash pow = crypto::null_hash;
+    try
+    {
+      if (get_block_longhash(ctx, this, (*blocks)[block_offset + i], pow, base_height + i))
+      {
+        m_batch_longhashes[i].pow = pow;
+        m_batch_longhashes[i].valid = true;
+      }
+    }
+    catch (const std::exception &e)
+    {
+      // hashing ahead of the verifier is an optimisation and nothing more, so
+      // a failure here leaves the entry invalid and the verifier hashes the
+      // block itself. It must never take the daemon down.
+      MWARNING("Could not hash block at height " << (base_height + i) << " ahead of time: " << e.what());
+      m_batch_longhashes[i].valid = false;
+    }
+  }
+}
+//------------------------------------------------------------------
+// Verification hashes one block at a time on one core, which is the worst way
+// to run a memory latency bound proof of work: the rest of the machine idles.
+// So when the verifier asks for the proof of work of a block, hash the next
+// few blocks of the same batch alongside it, one per thread.
+//
+// The chunk is deliberately exactly the thread count. That is what keeps a
+// peer from turning this into wasted work: the extra hashes run at the same
+// time as the one that was needed anyway, so a batch of rubbish costs the same
+// wall clock as it does today and only borrows cores that would have idled.
+// A window larger than the thread count would let one cheap message buy
+// arbitrarily much of our cpu.
+//
+// Two more bounds fall out for free:
+//  - the seed of a block reads chain data 256 blocks back and a chunk is never
+//    more than a handful of blocks ahead of the tip, so everything the workers
+//    read is already committed;
+//  - the thread count stays at m_max_prepare_blocks_threads, because sync
+//    speed that scales with core count would widen the gap between a big
+//    machine and a small one. Measured on a 14 core laptop against a 4 core
+//    board: capped the gap is 1.52x, uncapped it is 3.77x.
+void Blockchain::ensure_batch_longhashes(uint64_t blockchain_height)
+{
+  // first version whose seed lookups are served purely from the block cache
+  static const uint8_t CN_CACHE_ONLY_SEED_VERSION = 13;
+
+
+  // already covered by the current chunk
+  if (blockchain_height >= m_batch_longhash_base &&
+      blockchain_height - m_batch_longhash_base < m_batch_longhashes.size())
+    return;
+
+  // only meaningful while a prepared batch is being consumed
+  const std::vector<block> *batch = m_prepare_blocks;
+  if (batch == NULL || batch->empty() || blockchain_height < m_batch_start_height)
+    return;
+
+  const uint64_t offset = blockchain_height - m_batch_start_height;
+  if (offset >= batch->size())
+    return;
+
+  tools::threadpool& tpool = tools::threadpool::getInstance();
+  size_t threads = std::min<size_t>(tpool.get_max_concurrency(), m_max_prepare_blocks_threads);
+  threads = std::min<size_t>(threads, batch->size() - offset);
+  if (threads < 2)
+    return;   // nothing to win, leave it to the caller's serial path
+
+  m_batch_longhashes.clear();
+  m_batch_longhash_base = blockchain_height;
+  m_batch_longhashes.resize(threads);
+
+  std::vector<size_t> todo;
+  todo.reserve(threads);
+  for (size_t i = 0; i < threads; i++)
+  {
+    const block &b = (*batch)[offset + i];
+    m_batch_longhashes[i].id = get_block_hash(b);
+    m_batch_longhashes[i].valid = false;
+    // Only the v13 and v14 seeds are served purely from the in-memory block
+    // cache. The older versions reach for get_cna_v3/v4/v5_data and v7 looks
+    // only one block back rather than 256, so a worker could need chain data
+    // this thread has not committed yet, open its own read transaction and
+    // fail to find it. They stay on the serial path, where the caller's
+    // transaction can see the whole batch. They are also the cheap ones.
+    if (b.major_version < CN_CACHE_ONLY_SEED_VERSION)
+      continue;
+    // never hash a block the verifier would have waved through
+    if (block_needs_pow(blockchain_height + i, m_batch_longhashes[i].id))
+      todo.push_back(i);
+  }
+  if (todo.empty())
+    return;
+
+  // Warm the block cache here, on the thread that owns the batch transaction,
+  // as far as the chain goes. Once it is current every seed lookup a worker
+  // makes is served from memory under a reader lock, so no worker ever opens
+  // an lmdb cursor and the uncommitted batch never comes into it.
+  m_db->warm_block_cache(blockchain_height);
+
+  // The contexts live for the batch, not the chunk. Each carries a 24 MB
+  // buffer, and cn_hash_context_create is not thread safe (oaes seeds itself
+  // through gmtime), so building them once per batch beats hundreds of times.
+  while (m_longhash_contexts.size() < todo.size())
+  {
+    crypto::cn_hash_context_t *c = crypto::cn_hash_context_create();
+    if (c == NULL)
+    {
+      // no memory for another worker buffer: carry on with the ones we have
+      break;
+    }
+    m_longhash_contexts.push_back(c);
+  }
+  if (m_longhash_contexts.empty())
+  {
+    m_batch_longhashes.clear();
+    return;
+  }
+  if (todo.size() > m_longhash_contexts.size())
+    todo.resize(m_longhash_contexts.size());
+
+  TIME_MEASURE_START(longhash_chunk);
+  {
+    tools::threadpool::waiter waiter;
+    for (size_t t = 0; t < todo.size(); t++)
+      tpool.submit(&waiter, boost::bind(&Blockchain::longhash_worker, this, m_longhash_contexts[t],
+                                        batch, offset, m_batch_start_height + offset, &todo, t, t + 1), true);
+    waiter.wait(&tpool);
+  }
+  TIME_MEASURE_FINISH(longhash_chunk);
+
+  // MDEBUG here is invisible in practice: this file sets the log category to
+  // "blockchain", which the console filter drops below warning level.
+  if (m_show_time_stats)
+    MGINFO("Hashed " << todo.size() << " blocks on " << todo.size() << " threads in " << longhash_chunk << " ms");
+}
+//------------------------------------------------------------------
 bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete_entry> &blocks_entry, std::vector<block> &blocks)
 {
   MTRACE("Blockchain::" << __func__);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -86,7 +86,7 @@ DISABLE_VS_WARNINGS(4267)
 
 //------------------------------------------------------------------
 Blockchain::Blockchain(tx_memory_pool& tx_pool) :
-  m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_timestamps_and_difficulties_height(0), m_current_block_cumul_weight_limit(0), m_current_block_cumul_weight_median(0),
+  m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_hash_context(NULL), m_timestamps_and_difficulties_height(0), m_current_block_cumul_weight_limit(0), m_current_block_cumul_weight_median(0),
   m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_db_sync_on_blocks(true), m_db_sync_threshold(1), m_db_sync_mode(db_async), m_db_default_sync(false), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0), m_bytes_to_sync(0), m_cancel(false),
   m_long_term_block_weights_window(CRYPTONOTE_LONG_TERM_BLOCK_WEIGHT_WINDOW_SIZE),
   m_long_term_effective_median_block_weight(0),

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4387,18 +4387,20 @@ void Blockchain::longhash_worker(crypto::cn_hash_context_t *ctx, const std::vect
 // A window larger than the thread count would let one cheap message buy
 // arbitrarily much of our cpu.
 //
-// Two more bounds fall out for free:
-//  - the seed of a block reads chain data 256 blocks back and a chunk is never
-//    more than a handful of blocks ahead of the tip, so everything the workers
-//    read is already committed;
+// Two more bounds:
+//  - the seed of a block reads chain data 256 blocks back, so the chunk has to
+//    stay inside that depth or a worker would want a block the cache was not
+//    warmed for. The defaults leave a wide margin, but prep-blocks-threads is
+//    settable, so the chunk is clamped below rather than left to them;
 //  - the thread count stays at m_max_prepare_blocks_threads, because sync
 //    speed that scales with core count would widen the gap between a big
-//    machine and a small one. Measured on a 14 core laptop against a 4 core
-//    board: capped the gap is 1.52x, uncapped it is 3.77x.
+//    machine and a small one, which is the thing this fork is closing.
 void Blockchain::ensure_batch_longhashes(uint64_t blockchain_height)
 {
   // first version whose seed lookups are served purely from the block cache
   static const uint8_t CN_CACHE_ONLY_SEED_VERSION = 13;
+  // how far back of the chain those seeds read, see get_block_longhash_v13
+  static const size_t CN_SEED_LOOKBACK_BLOCKS = 256;
 
 
   // already covered by the current chunk
@@ -4418,6 +4420,12 @@ void Blockchain::ensure_batch_longhashes(uint64_t blockchain_height)
   tools::threadpool& tpool = tools::threadpool::getInstance();
   size_t threads = std::min<size_t>(tpool.get_max_concurrency(), m_max_prepare_blocks_threads);
   threads = std::min<size_t>(threads, batch->size() - offset);
+  // A worker at chunk index i hashes the block at blockchain_height + i, whose
+  // seed reads the chain CN_SEED_LOOKBACK_BLOCKS back. The cache below is warmed
+  // only as far as the committed chain, so a chunk that reached past that depth
+  // would send a worker to lmdb on the batch's own write transaction. Nothing
+  // else bounds this once prep-blocks-threads is raised, so bound it here.
+  threads = std::min<size_t>(threads, CN_SEED_LOOKBACK_BLOCKS - 1);
   if (threads < 2)
     return;   // nothing to win, leave it to the caller's serial path
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2718,6 +2718,47 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
 
+  if (!check_tx_outputs_except_subgroup(tx, tvc))
+    return false;
+
+  const uint8_t hf_version = m_hardfork->get_current_version();
+
+  // From HF13 only (gated so historical resync is unaffected). Split out from
+  // the rest because the subgroup multiplication costs about 490 us per output,
+  // which is the whole reason the pool re-checks candidates without it.
+  if (hf_version >= HF_VERSION_TX_KEY_VALIDATION) {
+    for (const auto &o: tx.vout) {
+      if (o.target.type() == typeid(txout_to_key)) {
+        const txout_to_key& out_to_key = boost::get<txout_to_key>(o.target);
+        if (!rct::isInMainSubgroup(rct::pk2rct(out_to_key.key)) || out_to_key.key == rct::rct2pk(rct::identity())) {
+          MERROR_VER("Output public key is identity or not in main subgroup");
+          tvc.m_invalid_output = true;
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+//------------------------------------------------------------------
+// Everything check_tx_outputs enforces apart from the per-output main-subgroup
+// multiplication. The pool re-checks block-template candidates against this,
+// because output rules can move under a transaction while it sits in the pool
+// and the miner must not be handed one every other node would reject, while the
+// subgroup check at ~490 us an output would cost ~200 ms per template build on
+// a 200 transaction pool, under the blockchain lock.
+//
+// The rules left out of the pool's re-check are therefore only the subgroup and
+// identity tests, which turn on at HF13. A transaction that could newly fail
+// them has to have been accepted before that fork and still be in the pool when
+// it activates, which costs one wasted block at one height on a chain that has
+// yet to cross HF13, and nothing on a chain past it.
+bool Blockchain::check_tx_outputs_except_subgroup(const transaction& tx, tx_verification_context &tvc) const
+{
+  LOG_PRINT_L3("Blockchain::" << __func__);
+  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+
   const uint8_t hf_version = m_hardfork->get_current_version();
 
   // From HF13, require at least two outputs so single-output txs can't leak the
@@ -2752,14 +2793,6 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
       if (!crypto::check_key(out_to_key.key)) {
         tvc.m_invalid_output = true;
         return false;
-      }
-      // From HF13 only (gated so historical resync is unaffected).
-      if (hf_version >= HF_VERSION_TX_KEY_VALIDATION) {
-        if (!rct::isInMainSubgroup(rct::pk2rct(out_to_key.key)) || out_to_key.key == rct::rct2pk(rct::identity())) {
-          MERROR_VER("Output public key is identity or not in main subgroup");
-          tvc.m_invalid_output = true;
-          return false;
-        }
       }
     }
   }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1002,6 +1002,15 @@ namespace cryptonote
      */
     bool has_block_weights(uint64_t height, uint64_t nblocks) const;
 
+    /**
+     * @brief expands transaction data from blockchain
+     *
+     * RingCT transactions do not transmit some of their data if it
+     * can be reconstituted by the receiver. This function expands
+     * that implicit data.
+     */
+    static bool expand_transaction(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys);
+
 #ifndef IN_UNIT_TESTS
   private:
 #endif
@@ -1460,14 +1469,6 @@ namespace cryptonote
     void check_ring_signature(const crypto::hash &tx_prefix_hash, const crypto::key_image &key_image,
         const std::vector<rct::ctkey> &pubkeys, const std::vector<crypto::signature> &sig, uint64_t &result) const;
 
-    /**
-     * @brief expands transaction data from blockchain
-     *
-     * RingCT transactions do not transmit some of their data if it
-     * can be reconstituted by the receiver. This function expands
-     * that implicit data.
-     */
-    bool expand_transaction(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys) const;
     
     /**
      * @brief invalidates any cached block template

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1050,6 +1050,24 @@ namespace cryptonote
 
     crypto::cn_hash_context_t *m_hash_context;
 
+    // Proof of work computed ahead of time for the batch being handled, indexed
+    // by height - m_batch_longhash_base. The id is kept so a result is only used
+    // for the block it was computed for.
+    struct precomputed_pow
+    {
+      crypto::hash id;
+      crypto::hash pow;
+      bool valid;
+    };
+    std::vector<precomputed_pow> m_batch_longhashes;
+    uint64_t m_batch_longhash_base;
+    // Worker hash contexts, made once per batch rather than once per chunk.
+    // Each carries a 24 MB buffer, so building them per chunk meant hundreds of
+    // allocations across a sync, and cn_hash_context_create is not thread safe
+    // (oaes seeds itself through gmtime), so fewer calls is also safer.
+    std::vector<crypto::cn_hash_context_t *> m_longhash_contexts;
+    void free_longhash_contexts();
+
     BlockchainDB* m_db;
 
     tx_memory_pool& m_tx_pool;
@@ -1248,6 +1266,39 @@ namespace cryptonote
      * @return true if the block was added successfully, otherwise false
      */
     bool handle_block_to_main_chain(const block& bl, const crypto::hash& id, block_verification_context& bvc);
+
+    /**
+     * @brief whether the proof of work of a block still has to be computed
+     *
+     * Quicksync and assume-valid let a block through without hashing it. This
+     * is the single place that decides, so the batch precompute never hashes a
+     * block the verifier would have skipped.
+     *
+     * @param blockchain_height the height the block would take
+     * @param id the hash of the block
+     *
+     * @return true if the proof of work has to be computed and checked
+     */
+    bool block_needs_pow(uint64_t blockchain_height, const crypto::hash& id) const;
+
+    /**
+     * @brief hash a chunk of the current batch, one block per thread
+     *
+     * Called when the verifier reaches a block whose proof of work is not in
+     * m_batch_longhashes. The chunk is the thread count, so the extra hashes
+     * ride along with the one that was needed and a rubbish batch cannot buy
+     * more of our cpu than a single block does today.
+     *
+     * @param blockchain_height the height of the block being verified
+     */
+    void ensure_batch_longhashes(uint64_t blockchain_height);
+
+    /**
+     * @brief hashes one slice of the batch, on one thread, with its own context
+     */
+    void longhash_worker(crypto::cn_hash_context_t *ctx, const std::vector<block> *blocks,
+                         size_t block_offset, uint64_t base_height,
+                         const std::vector<size_t> *todo, size_t from, size_t to);
 
     /**
      * @brief validate and add a new block to an alternate blockchain

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -643,8 +643,7 @@ namespace cryptonote
     /**
      * @brief checks only the range proof and ring signature type rules
      *
-     * The subset of check_tx_outputs that moves at a fork boundary, so a
-     * transaction sitting in the pool can be re-checked cheaply.
+     * The subset of check_tx_outputs that moves at the HF14 boundary.
      *
      * @param tx the transaction to check
      * @param tvc returned info about tx verification
@@ -652,6 +651,19 @@ namespace cryptonote
      * @return false if the type is not allowed at the current fork version
      */
     bool check_tx_rct_type(const transaction& tx, tx_verification_context &tvc) const;
+
+    /**
+     * @brief check_tx_outputs without the per-output main-subgroup multiplication
+     *
+     * What the pool re-checks block-template candidates against: every output
+     * rule except the one that costs ~490 us an output.
+     *
+     * @param tx the transaction to check
+     * @param tvc returned info about tx verification
+     *
+     * @return false if any of those rules rejects the transaction
+     */
+    bool check_tx_outputs_except_subgroup(const transaction& tx, tx_verification_context &tvc) const;
 
     /**
      * @brief gets the block weight limit based on recent blocks

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -643,7 +643,8 @@ namespace cryptonote
     /**
      * @brief checks only the range proof and ring signature type rules
      *
-     * The subset of check_tx_outputs that moves at the HF14 boundary.
+     * The subset of check_tx_outputs that moves at the HF14 boundary. Internal:
+     * callers want check_tx_outputs or check_tx_outputs_except_subgroup.
      *
      * @param tx the transaction to check
      * @param tvc returned info about tx verification

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -641,6 +641,19 @@ namespace cryptonote
     bool check_tx_outputs(const transaction& tx, tx_verification_context &tvc) const;
 
     /**
+     * @brief checks only the range proof and ring signature type rules
+     *
+     * The subset of check_tx_outputs that moves at a fork boundary, so a
+     * transaction sitting in the pool can be re-checked cheaply.
+     *
+     * @param tx the transaction to check
+     * @param tvc returned info about tx verification
+     *
+     * @return false if the type is not allowed at the current fork version
+     */
+    bool check_tx_rct_type(const transaction& tx, tx_verification_context &tvc) const;
+
+    /**
      * @brief gets the block weight limit based on recent blocks
      *
      * @return the limit

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -871,6 +871,16 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
+  static bool is_canonical_bulletproof_plus_layout(const std::vector<rct::BulletproofPlus> &proofs)
+  {
+    if (proofs.size() != 1)
+      return false;
+    const size_t sz = proofs[0].V.size();
+    if (sz == 0 || sz > BULLETPROOF_PLUS_MAX_OUTPUTS)
+      return false;
+    return true;
+  }
+  //-----------------------------------------------------------------------------------------------
   bool core::handle_incoming_tx_accumulated_batch(std::vector<tx_verification_batch_info> &tx_info, bool keeped_by_block)
   {
     bool ret = true;
@@ -917,9 +927,21 @@ namespace cryptonote
           }
           break;
         case rct::RCTTypeBulletproof2:
+        case rct::RCTTypeCLSAG:
           if (!is_canonical_bulletproof_layout(rv.p.bulletproofs))
           {
             MERROR_VER("Bulletproof does not have canonical form");
+            set_semantics_failed(tx_info[n].tx_hash);
+            tx_info[n].tvc.m_verifivation_failed = true;
+            tx_info[n].result = false;
+            break;
+          }
+          rvv.push_back(&rv); // delayed batch verification
+          break;
+        case rct::RCTTypeBulletproofPlus:
+          if (!is_canonical_bulletproof_plus_layout(rv.p.bulletproofs_plus))
+          {
+            MERROR_VER("Bulletproof_plus does not have canonical form");
             set_semantics_failed(tx_info[n].tx_hash);
             tx_info[n].tvc.m_verifivation_failed = true;
             tx_info[n].result = false;
@@ -944,7 +966,7 @@ namespace cryptonote
       {
         if (!tx_info[n].result)
           continue;
-        if (tx_info[n].tx->rct_signatures.type != rct::RCTTypeBulletproof2)
+        if (tx_info[n].tx->rct_signatures.type != rct::RCTTypeBulletproof2 && tx_info[n].tx->rct_signatures.type != rct::RCTTypeCLSAG && tx_info[n].tx->rct_signatures.type != rct::RCTTypeBulletproofPlus)
           continue;
         if (assumed_bad || !rct::verRctSemanticsSimple(tx_info[n].tx->rct_signatures))
         {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -37,6 +37,7 @@ using namespace epee;
 
 #include <unordered_set>
 #include "cryptonote_core.h"
+#include "cryptonote_core/tx_verification_utils.h"
 #include "common/command_line.h"
 #include "common/util.h"
 #include "common/updates.h"
@@ -859,26 +860,6 @@ namespace cryptonote
       bad_semantics_txes[0].clear();
     }
     bad_semantics_txes_lock.unlock();
-  }
-  //-----------------------------------------------------------------------------------------------
-  static bool is_canonical_bulletproof_layout(const std::vector<rct::Bulletproof> &proofs)
-  {
-    if (proofs.size() != 1)
-      return false;
-    const size_t sz = proofs[0].V.size();
-    if (sz == 0 || sz > BULLETPROOF_MAX_OUTPUTS)
-      return false;
-    return true;
-  }
-  //-----------------------------------------------------------------------------------------------
-  static bool is_canonical_bulletproof_plus_layout(const std::vector<rct::BulletproofPlus> &proofs)
-  {
-    if (proofs.size() != 1)
-      return false;
-    const size_t sz = proofs[0].V.size();
-    if (sz == 0 || sz > BULLETPROOF_PLUS_MAX_OUTPUTS)
-      return false;
-    return true;
   }
   //-----------------------------------------------------------------------------------------------
   bool core::handle_incoming_tx_accumulated_batch(std::vector<tx_verification_batch_info> &tx_info, bool keeped_by_block)

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -687,6 +687,49 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------
+  bool get_block_longhash_v14(crypto::cn_hash_context_t *context, BlockchainDB &db, const blobdata &blob, crypto::hash &res, uint64_t height)
+  {
+    // no fork table puts v14 this low; keep the guard hard because the
+    // assert is compiled out in release and the subtraction would wrap
+    if (height <= 257)
+      return false;
+    const uint64_t stable_height = height - 256;
+
+    // random_values must land inside the 256 KB v14 pad, so fetch them with
+    // the v14 bound on every call and never through context->cached_height.
+    // That cache is shared with the v13 path whose bound is 8 MB, and around
+    // the fork one context can hash both versions at the same height
+    // (competing chains): a stale v13-bounded set served here would index
+    // past the pad and fork the chain. Invalidate the cache too, so a v13
+    // hash following on this context refetches with its own bound. The
+    // fetch is five block-cache lookups, noise next to the hash itself.
+    db.get_cna_v2_data(&context->random_values, stable_height, CN_SCRATCHPAD_MEMORY_V14);
+    context->cached_height = (uint64_t)-1;
+
+    // Per-nonce program seed built exactly as v13: HC128 seeded from the blob
+    // hash fills the chain salt, and the seed is blob_hash XOR salt[0..32).
+    // Unique per (height, nonce) and requires the blockchain DB, so pool
+    // resistance is unchanged.
+    crypto::hash blob_hash;
+    get_blob_hash(blob, blob_hash);
+
+    HC128_State rng_state;
+    HC128_Init(&rng_state, (unsigned char *)blob_hash.data, (unsigned char *)blob_hash.data + 16);
+
+    db.get_cna_v6_data(context->salt, &rng_state, stable_height);
+
+    uint8_t seed[32];
+    const uint8_t *salt_bytes = reinterpret_cast<const uint8_t *>(context->salt);
+    const uint8_t *hash_bytes = reinterpret_cast<const uint8_t *>(blob_hash.data);
+    for (int i = 0; i < 32; i++)
+      seed[i] = hash_bytes[i] ^ salt_bytes[i];
+
+    // No external dataset: cn_slow_hash_v14 fills its own 24 MB per-nonce
+    // buffer from the seed and walks it (mutating as it goes).
+    cn_slow_hash_v14(context, blob.data(), blob.size(), res.data, seed);
+    return true;
+  }
+  //---------------------------------------------------------------
   bool get_block_longhash(crypto::cn_hash_context_t *context, BlockchainDB &db, const uint8_t major_version, const blobdata &blob, crypto::hash &res, const uint64_t height)
   {
     if (major_version < 7)
@@ -710,8 +753,11 @@ namespace cryptonote
       case 11:
       case 12:
         return get_block_longhash_v11(context, db, blob, res, height);
-      default:
+      case 13:
         return get_block_longhash_v13(context, db, blob, res, height);
+      default:
+        // >= 14: CNA v7, per-nonce mutable-buffer chase
+        return get_block_longhash_v14(context, db, blob, res, height);
     }
   }
   //---------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -656,7 +656,10 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool get_block_longhash_v13(crypto::cn_hash_context_t *context, BlockchainDB &db, const blobdata &blob, crypto::hash &res, uint64_t height)
   {
-    assert(height > 257);
+    // same hard guard as the v14 path: the assert is compiled out in release
+    // and the subtraction below would wrap
+    if (height <= 257)
+      return false;
     const uint64_t stable_height = height - 256;
 
     if (context->cached_height != height)

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -121,11 +121,11 @@ namespace cryptonote
   bool construct_tx_with_tx_key(const account_keys& sender_account_keys, const std::unordered_map<crypto::public_key, subaddress_index>& subaddresses, 
     std::vector<tx_source_entry>& sources, std::vector<tx_destination_entry>& destinations, const boost::optional<cryptonote::account_public_address>& change_addr, 
     const std::vector<uint8_t> &extra, transaction& tx, uint64_t unlock_time, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys, 
-    uint8_t current_tx_version, const rct::RCTConfig &rct_config = { rct::RangeProofBorromean, 0 }, rct::multisig_out *msout = NULL, bool shuffle_outs = true);
+    uint8_t current_tx_version, const rct::RCTConfig &rct_config = { rct::RangeProofBorromean, 1 }, rct::multisig_out *msout = NULL, bool shuffle_outs = true);
   bool construct_tx_and_get_tx_key(const account_keys& sender_account_keys, const std::unordered_map<crypto::public_key, subaddress_index>& subaddresses, std::vector<tx_source_entry>& sources, 
     std::vector<tx_destination_entry>& destinations, const boost::optional<cryptonote::account_public_address>& change_addr, const std::vector<uint8_t> &extra, transaction& tx, 
     uint64_t unlock_time, crypto::secret_key &tx_key, std::vector<crypto::secret_key> &additional_tx_keys, uint8_t current_tx_version,
-    const rct::RCTConfig &rct_config = { rct::RangeProofBorromean, 0 }, rct::multisig_out *msout = NULL);
+    const rct::RCTConfig &rct_config = { rct::RangeProofBorromean, 1 }, rct::multisig_out *msout = NULL);
   bool generate_output_ephemeral_keys(const size_t tx_version, const cryptonote::account_keys &sender_account_keys, const crypto::public_key &txkey_pub,  const crypto::secret_key &tx_key,
                                       const cryptonote::tx_destination_entry &dst_entr, const boost::optional<cryptonote::account_public_address> &change_addr, const size_t output_index,
                                       const bool &need_additional_txkeys, const std::vector<crypto::secret_key> &additional_tx_keys,

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include "tx_pool.h"
+#include "cryptonote_core/tx_verification_utils.h"
 #include "cryptonote_tx_utils.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
 #include "cryptonote_config.h"
@@ -79,11 +80,6 @@ namespace cryptonote
     uint64_t template_accept_threshold(uint64_t amount)
     {
       return amount * ACCEPT_THRESHOLD;
-    }
-
-    uint64_t get_transaction_weight_limit(uint8_t version)
-    {
-      return get_min_block_weight(version) - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE;
     }
 
     // This class is meant to create a batch when none currently exists.

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -186,7 +186,12 @@ namespace cryptonote
       }
     }
 
-    if (!m_blockchain.check_tx_outputs(tx, tvc))
+    // not for kept_by_block: the output rules follow the pool tip's fork
+    // version, but a tx carried by a block belongs to that block's height.
+    // An alternative chain crossing the HF14 boundary would fail here and
+    // drop the peer; block transactions get this check with the right
+    // hardfork state in handle_block_to_main_chain instead.
+    if (!kept_by_block && !m_blockchain.check_tx_outputs(tx, tvc))
     {
       LOG_PRINT_L1("Transaction with id= "<< id << " has at least one invalid output");
       tvc.m_verifivation_failed = true;
@@ -1093,6 +1098,12 @@ namespace cryptonote
         }
       }
     }
+    // the output rules can flip at the fork boundary while a tx sits in the
+    // pool (re-validation can leave one behind on a transient failure);
+    // never hand the miner a tx every other node would reject
+    tx_verification_context tvc_out{};
+    if(!m_blockchain.check_tx_outputs(lazy_tx(), tvc_out))
+      return false;
     //if we here, transaction seems valid, but, anyway, check for key_images collisions with blockchain, just to be sure
     if(m_blockchain.have_tx_keyimges_as_spent(lazy_tx()))
     {

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1094,14 +1094,13 @@ namespace cryptonote
         }
       }
     }
-    // the rct type rules flip at the fork boundary while a tx sits in the
-    // pool (re-validation can leave one behind on a transient failure);
-    // never hand the miner a tx every other node would reject. Only the type
-    // gate is re-checked: the rest of check_tx_outputs cannot start failing
-    // for a tx the pool already accepted, and its per-output subgroup
-    // multiplication would land on every candidate of every template build.
+    // output rules can move under a tx while it sits in the pool, and
+    // re-validation can leave one behind on a transient failure, so never hand
+    // the miner a tx every other node would reject. Everything except the
+    // per-output subgroup multiplication is re-checked here; that one costs
+    // ~490 us an output and would land on every candidate of every build.
     tx_verification_context tvc_out{};
-    if(!m_blockchain.check_tx_rct_type(lazy_tx(), tvc_out))
+    if(!m_blockchain.check_tx_outputs_except_subgroup(lazy_tx(), tvc_out))
       return false;
     //if we here, transaction seems valid, but, anyway, check for key_images collisions with blockchain, just to be sure
     if(m_blockchain.have_tx_keyimges_as_spent(lazy_tx()))

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1094,11 +1094,14 @@ namespace cryptonote
         }
       }
     }
-    // the output rules can flip at the fork boundary while a tx sits in the
+    // the rct type rules flip at the fork boundary while a tx sits in the
     // pool (re-validation can leave one behind on a transient failure);
-    // never hand the miner a tx every other node would reject
+    // never hand the miner a tx every other node would reject. Only the type
+    // gate is re-checked: the rest of check_tx_outputs cannot start failing
+    // for a tx the pool already accepted, and its per-output subgroup
+    // multiplication would land on every candidate of every template build.
     tx_verification_context tvc_out{};
-    if(!m_blockchain.check_tx_outputs(lazy_tx(), tvc_out))
+    if(!m_blockchain.check_tx_rct_type(lazy_tx(), tvc_out))
       return false;
     //if we here, transaction seems valid, but, anyway, check for key_images collisions with blockchain, just to be sure
     if(m_blockchain.have_tx_keyimges_as_spent(lazy_tx()))

--- a/src/cryptonote_core/tx_verification_utils.cpp
+++ b/src/cryptonote_core/tx_verification_utils.cpp
@@ -1,0 +1,268 @@
+// Copyright (c) 2018-2026, The Nerva Project
+// Copyright (c) 2023-2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "cryptonote_core/tx_verification_utils.h"
+
+#include <boost/variant/get.hpp>
+
+#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "cryptonote_core/blockchain.h"
+#include "ringct/rctSigs.h"
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "verify"
+
+#define MERROR_VER(x) MCERROR("verify", x)
+
+using namespace cryptonote;
+
+// Do RCT expansion, then post-expansion sanity checks, then full
+// non-semantics verification, for the simple types.
+static bool expand_tx_and_ver_rct_non_sem(transaction& tx, const std::vector<std::vector<rct::ctkey>>& pubkeys)
+{
+  const crypto::hash tx_prefix_hash = get_transaction_prefix_hash(tx);
+
+  if (!Blockchain::expand_transaction(tx, tx_prefix_hash, pubkeys))
+  {
+    MERROR_VER("Failed to expand rct signatures!");
+    return false;
+  }
+
+  const rct::rctSig &rv = tx.rct_signatures;
+
+  // check all this, either reconstructed (so should really pass), or not
+  {
+    if (pubkeys.size() != rv.mixRing.size())
+    {
+      MERROR_VER("Failed to check ringct signatures: mismatched pubkeys/mixRing size");
+      return false;
+    }
+    for (size_t i = 0; i < pubkeys.size(); ++i)
+    {
+      if (pubkeys[i].size() != rv.mixRing[i].size())
+      {
+        MERROR_VER("Failed to check ringct signatures: mismatched pubkeys/mixRing size");
+        return false;
+      }
+    }
+
+    for (size_t n = 0; n < pubkeys.size(); ++n)
+    {
+      for (size_t m = 0; m < pubkeys[n].size(); ++m)
+      {
+        if (pubkeys[n][m].dest != rct::rct2pk(rv.mixRing[n][m].dest))
+        {
+          MERROR_VER("Failed to check ringct signatures: mismatched pubkey at vin " << n << ", index " << m);
+          return false;
+        }
+        if (pubkeys[n][m].mask != rct::rct2pk(rv.mixRing[n][m].mask))
+        {
+          MERROR_VER("Failed to check ringct signatures: mismatched commitment at vin " << n << ", index " << m);
+          return false;
+        }
+      }
+    }
+  }
+
+  if (rct::is_rct_clsag(rv.type))
+  {
+    if (rv.p.CLSAGs.size() != tx.vin.size())
+    {
+      MERROR_VER("Failed to check ringct signatures: mismatched CLSAGs/vin sizes");
+      return false;
+    }
+    for (size_t n = 0; n < tx.vin.size(); ++n)
+    {
+      if (memcmp(&boost::get<txin_to_key>(tx.vin[n]).k_image, &rv.p.CLSAGs[n].I, 32))
+      {
+        MERROR_VER("Failed to check ringct signatures: mismatched key image");
+        return false;
+      }
+    }
+  }
+  else
+  {
+    if (rv.p.MGs.size() != tx.vin.size())
+    {
+      MERROR_VER("Failed to check ringct signatures: mismatched MGs/vin sizes");
+      return false;
+    }
+    for (size_t n = 0; n < tx.vin.size(); ++n)
+    {
+      if (rv.p.MGs[n].II.empty() || memcmp(&boost::get<txin_to_key>(tx.vin[n]).k_image, &rv.p.MGs[n].II[0], 32))
+      {
+        MERROR_VER("Failed to check ringct signatures: mismatched key image");
+        return false;
+      }
+    }
+  }
+
+  if (!(rv.type == rct::RCTTypeSimple || rv.type == rct::RCTTypeBulletproof1Simple ? rct::verRctNonSemanticsSimple_v1(rv) : rct::verRctNonSemanticsSimple(rv)))
+  {
+    MERROR_VER("Failed to check ringct signatures!");
+    return false;
+  }
+
+  return true;
+}
+
+// Same, but for the full types.
+static bool expand_tx_and_ver_full_rct_non_sem(transaction& tx, const std::vector<std::vector<rct::ctkey>>& pubkeys)
+{
+  const crypto::hash tx_prefix_hash = get_transaction_prefix_hash(tx);
+
+  if (!Blockchain::expand_transaction(tx, tx_prefix_hash, pubkeys))
+  {
+    MERROR_VER("Failed to expand rct signatures!");
+    return false;
+  }
+
+  const rct::rctSig &rv = tx.rct_signatures;
+
+  // check all this, either reconstructed (so should really pass), or not
+  {
+    bool size_matches = true;
+    for (size_t i = 0; i < pubkeys.size(); ++i)
+      size_matches &= pubkeys[i].size() == rv.mixRing.size();
+    for (size_t i = 0; i < rv.mixRing.size(); ++i)
+      size_matches &= pubkeys.size() == rv.mixRing[i].size();
+    if (!size_matches)
+    {
+      MERROR_VER("Failed to check ringct signatures: mismatched pubkeys/mixRing size");
+      return false;
+    }
+
+    for (size_t n = 0; n < pubkeys.size(); ++n)
+    {
+      for (size_t m = 0; m < pubkeys[n].size(); ++m)
+      {
+        if (pubkeys[n][m].dest != rct::rct2pk(rv.mixRing[m][n].dest))
+        {
+          MERROR_VER("Failed to check ringct signatures: mismatched pubkey at vin " << n << ", index " << m);
+          return false;
+        }
+        if (pubkeys[n][m].mask != rct::rct2pk(rv.mixRing[m][n].mask))
+        {
+          MERROR_VER("Failed to check ringct signatures: mismatched commitment at vin " << n << ", index " << m);
+          return false;
+        }
+      }
+    }
+  }
+
+  if (rv.p.MGs.size() != 1)
+  {
+    MERROR_VER("Failed to check ringct signatures: Bad MGs size");
+    return false;
+  }
+  if (rv.p.MGs.empty() || rv.p.MGs[0].II.size() != tx.vin.size())
+  {
+    MERROR_VER("Failed to check ringct signatures: mismatched II/vin sizes");
+    return false;
+  }
+  for (size_t n = 0; n < tx.vin.size(); ++n)
+  {
+    if (memcmp(&boost::get<txin_to_key>(tx.vin[n]).k_image, &rv.p.MGs[0].II[n], 32))
+    {
+      MERROR_VER("Failed to check ringct signatures: mismatched II/vin sizes");
+      return false;
+    }
+  }
+
+  if (!rct::verRct(rv, false))
+  {
+    MERROR_VER("Failed to check ringct signatures!");
+    return false;
+  }
+
+  return true;
+}
+
+namespace cryptonote
+{
+
+uint64_t get_transaction_weight_limit(const uint8_t hf_version)
+{
+  return get_min_block_weight(hf_version) - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE;
+}
+
+bool ver_input_proofs_rings(transaction& tx, const std::vector<std::vector<rct::ctkey>>& pubkeys)
+{
+  // Defensive: this dispatch (and any verification cache built on top of it
+  // later) must be revisited before a type newer than BulletproofPlus is
+  // allowed through.
+  const bool untested_tx = tx.version > 2 || tx.rct_signatures.type > rct::RCTTypeBulletproofPlus;
+  CHECK_AND_ASSERT_MES(!untested_tx, false, "Unknown TX type");
+
+  // check ringct signatures
+  // obviously, the original and simple rct APIs use a mixRing that's indexes
+  // in opposite orders, because it'd be too simple otherwise...
+  const rct::rctSig &rv = tx.rct_signatures;
+  switch (rv.type)
+  {
+  case rct::RCTTypeNull:
+    // we only accept no signatures for coinbase txes
+    MERROR_VER("Null rct signature on non-coinbase tx");
+    return false;
+  case rct::RCTTypeSimple:
+  case rct::RCTTypeBulletproof1Simple:
+  case rct::RCTTypeBulletproof2:
+  case rct::RCTTypeCLSAG:
+  case rct::RCTTypeBulletproofPlus:
+    return expand_tx_and_ver_rct_non_sem(tx, pubkeys);
+  case rct::RCTTypeFull:
+  case rct::RCTTypeBulletproof1Full:
+    return expand_tx_and_ver_full_rct_non_sem(tx, pubkeys);
+  default:
+    MERROR_VER("Unsupported rct type: " << rv.type);
+    return false;
+  }
+}
+
+bool is_canonical_bulletproof_layout(const std::vector<rct::Bulletproof> &proofs)
+{
+  if (proofs.size() != 1)
+    return false;
+  const size_t sz = proofs[0].V.size();
+  if (sz == 0 || sz > BULLETPROOF_MAX_OUTPUTS)
+    return false;
+  return true;
+}
+
+bool is_canonical_bulletproof_plus_layout(const std::vector<rct::BulletproofPlus> &proofs)
+{
+  if (proofs.size() != 1)
+    return false;
+  const size_t sz = proofs[0].V.size();
+  if (sz == 0 || sz > BULLETPROOF_PLUS_MAX_OUTPUTS)
+    return false;
+  return true;
+}
+
+}

--- a/src/cryptonote_core/tx_verification_utils.h
+++ b/src/cryptonote_core/tx_verification_utils.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2018-2026, The Nerva Project
+// Copyright (c) 2023-2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "cryptonote_basic/cryptonote_basic.h"
+#include "ringct/rctTypes.h"
+
+// Standalone transaction verification helpers, Monero master's
+// tx_verification_utils layout. The input-verification cache
+// (make_input_verification_id and the pool_supplement machinery around it)
+// is not adopted; verification here is stateless.
+
+namespace cryptonote
+{
+
+// The maximum weight of a single transaction accepted into the pool.
+uint64_t get_transaction_weight_limit(uint8_t hf_version);
+
+// Do RCT expansion, then post-expansion sanity checks, then full
+// non-semantics verification of the ring signatures. The mix ring is the
+// output keys fetched from the chain for each input, in the same layout
+// Blockchain::expand_transaction expects.
+bool ver_input_proofs_rings(transaction& tx, const std::vector<std::vector<rct::ctkey>>& pubkeys);
+
+// Canonical range proof layout for the aggregate proof types: exactly one
+// proof, with a sane number of commitments.
+bool is_canonical_bulletproof_layout(const std::vector<rct::Bulletproof> &proofs);
+bool is_canonical_bulletproof_plus_layout(const std::vector<rct::BulletproofPlus> &proofs);
+
+}

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -228,6 +228,11 @@ namespace hw {
         virtual bool  mlsag_hash(const rct::keyV &long_message, rct::key &c) = 0;
         virtual bool  mlsag_sign(const rct::key &c, const rct::keyV &xx, const rct::keyV &alpha, const size_t rows, const size_t dsRows, rct::keyV &ss) = 0;
 
+        // CLSAG (HF14), same hook pattern Monero added in v0.17
+        virtual bool  clsag_prepare(const rct::key &p, const rct::key &z, rct::key &I, rct::key &D, const rct::key &H, rct::key &a, rct::key &aG, rct::key &aH) = 0;
+        virtual bool  clsag_hash(const rct::keyV &data, rct::key &hash) = 0;
+        virtual bool  clsag_sign(const rct::key &c, const rct::key &a, const rct::key &p, const rct::key &z, const rct::key &mu_P, const rct::key &mu_C, rct::key &s) = 0;
+
         virtual bool  close_tx(void) = 0;
 
         virtual bool  has_ki_cold_sync(void) const { return false; }

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -401,6 +401,29 @@ namespace hw {
             return true;
         }
 
+        bool device_default::clsag_prepare(const rct::key &p, const rct::key &z, rct::key &I, rct::key &D, const rct::key &H, rct::key &a, rct::key &aG, rct::key &aH) {
+            rct::skpkGen(a,aG); // aG = a*G
+            rct::scalarmultKey(aH,H,a); // aH = a*H
+            rct::scalarmultKey(I,H,p); // I = p*H
+            rct::scalarmultKey(D,H,z); // D = z*H
+            return true;
+        }
+
+        bool device_default::clsag_hash(const rct::keyV &data, rct::key &hash) {
+            hash = rct::hash_to_scalar(data);
+            return true;
+        }
+
+        bool device_default::clsag_sign(const rct::key &c, const rct::key &a, const rct::key &p, const rct::key &z, const rct::key &mu_P, const rct::key &mu_C, rct::key &s) {
+            rct::key s0_p_mu_P;
+            sc_mul(s0_p_mu_P.bytes,mu_P.bytes,p.bytes);
+            rct::key s0_add_z_mu_C;
+            sc_muladd(s0_add_z_mu_C.bytes,mu_C.bytes,z.bytes,s0_p_mu_P.bytes);
+            sc_mulsub(s.bytes,c.bytes,s0_add_z_mu_C.bytes,a.bytes);
+
+            return true;
+        }
+
         bool device_default::close_tx() {
             return true;
         }

--- a/src/device/device_default.hpp
+++ b/src/device/device_default.hpp
@@ -134,6 +134,10 @@ namespace hw {
             bool  mlsag_hash(const rct::keyV &long_message, rct::key &c) override;
             bool  mlsag_sign(const rct::key &c, const rct::keyV &xx, const rct::keyV &alpha, const size_t rows, const size_t dsRows, rct::keyV &ss) override;
 
+            bool  clsag_prepare(const rct::key &p, const rct::key &z, rct::key &I, rct::key &D, const rct::key &H, rct::key &a, rct::key &aG, rct::key &aH) override;
+            bool  clsag_hash(const rct::keyV &data, rct::key &hash) override;
+            bool  clsag_sign(const rct::key &c, const rct::key &a, const rct::key &p, const rct::key &z, const rct::key &mu_P, const rct::key &mu_C, rct::key &s) override;
+
             bool  close_tx(void) override;
         };
 

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -1972,6 +1972,25 @@ namespace hw {
         return true;
     }
 
+    // CLSAG (HF14): signing on a Ledger needs the post-CLSAG app protocol
+    // (new INS commands, added in Monero v0.17's ledger integration); this
+    // implementation still speaks the pre-CLSAG protocol. Refuse by throwing
+    // instead of producing something wrong: CLSAG_Gen ignores the bool
+    // returns, so returning false would let it sign with uninitialized keys.
+    // Verification is unaffected since nodes verify in software. Porting the
+    // protocol update needs a device to test against.
+    bool device_ledger::clsag_prepare(const rct::key &p, const rct::key &z, rct::key &I, rct::key &D, const rct::key &H, rct::key &a, rct::key &aG, rct::key &aH) {
+        ASSERT_MES_AND_THROW("CLSAG signing is not supported on this Ledger integration yet");
+    }
+
+    bool device_ledger::clsag_hash(const rct::keyV &data, rct::key &hash) {
+        ASSERT_MES_AND_THROW("CLSAG signing is not supported on this Ledger integration yet");
+    }
+
+    bool device_ledger::clsag_sign(const rct::key &c, const rct::key &a, const rct::key &p, const rct::key &z, const rct::key &mu_P, const rct::key &mu_C, rct::key &s) {
+        ASSERT_MES_AND_THROW("CLSAG signing is not supported on this Ledger integration yet");
+    }
+
     bool device_ledger::close_tx() {
         AUTO_LOCK_CMD();
         send_simple(INS_CLOSE_TX);

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -253,6 +253,12 @@ namespace hw {
         bool  mlsag_hash(const rct::keyV &long_message, rct::key &c) override;
         bool  mlsag_sign( const rct::key &c, const rct::keyV &xx, const rct::keyV &alpha, const size_t rows, const size_t dsRows, rct::keyV &ss) override;
 
+        // CLSAG signing needs the post-CLSAG Ledger app protocol, which this
+        // (pre-CLSAG) implementation does not speak; see device_ledger.cpp
+        bool  clsag_prepare(const rct::key &p, const rct::key &z, rct::key &I, rct::key &D, const rct::key &H, rct::key &a, rct::key &aG, rct::key &aH) override;
+        bool  clsag_hash(const rct::keyV &data, rct::key &hash) override;
+        bool  clsag_sign(const rct::key &c, const rct::key &a, const rct::key &p, const rct::key &z, const rct::key &mu_P, const rct::key &mu_C, rct::key &s) override;
+
         bool  close_tx(void) override;
 
     };

--- a/src/ringct/CMakeLists.txt
+++ b/src/ringct/CMakeLists.txt
@@ -32,13 +32,15 @@ set(ringct_basic_sources
   rctTypes.cpp
   rctCryptoOps.c
   multiexp.cc
-  bulletproofs.cc)
+  bulletproofs.cc
+  bulletproofs_plus.cc)
 
 set(ringct_basic_private_headers
   rctOps.h
   rctTypes.h
   multiexp.h
-  bulletproofs.h)
+  bulletproofs.h
+  bulletproofs_plus.h)
 
 monero_private_headers(ringct_basic
   ${crypto_private_headers})

--- a/src/ringct/bulletproofs_plus.cc
+++ b/src/ringct/bulletproofs_plus.cc
@@ -1,0 +1,1121 @@
+// Copyright (c) 2017-2024, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Implements the Bulletproofs+ prover and verifier algorithms
+//
+// Preprint: https://eprint.iacr.org/2020/735, version 17 Jun 2020
+//
+// NOTE ON NOTATION:
+//  In the signature constructions used in Monero, commitments to zero are treated as
+//      public keys against the curve group generator `G`. This means that amount
+//      commitments must use another generator `H` for values in order to show balance.
+//  The result is that the roles of `g` and `h` in the preprint are effectively swapped
+//      in this code, taking on the roles of `H` and `G`, respectively. Read carefully!
+
+#include <stdlib.h>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/lock_guard.hpp>
+#include "misc_log_ex.h"
+#include "span.h"
+#include "cryptonote_config.h"
+extern "C"
+{
+#include "crypto/crypto-ops.h"
+}
+#include "rctOps.h"
+#include "multiexp.h"
+#include "bulletproofs_plus.h"
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "bulletproof_plus"
+
+#define STRAUS_SIZE_LIMIT 232
+#define PIPPENGER_SIZE_LIMIT 0
+
+namespace rct
+{
+    // Vector functions
+    static rct::key vector_exponent(const rct::keyV &a, const rct::keyV &b);
+    static rct::keyV vector_of_scalar_powers(const rct::key &x, size_t n);
+
+    // Proof bounds
+    static constexpr size_t maxN = 64; // maximum number of bits in range
+    static constexpr size_t maxM = BULLETPROOF_PLUS_MAX_OUTPUTS; // maximum number of outputs to aggregate into a single proof
+
+    // Cached public generators
+    static ge_p3 Hi_p3[maxN*maxM], Gi_p3[maxN*maxM];
+    static std::shared_ptr<straus_cached_data> straus_HiGi_cache;
+    static std::shared_ptr<pippenger_cached_data> pippenger_HiGi_cache;
+
+    // Useful scalar constants
+    static const constexpr rct::key ZERO = { {0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00  } }; // 0
+    static const constexpr rct::key ONE = { {0x01, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00  } }; // 1
+    static const constexpr rct::key TWO = { {0x02, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00 , 0x00, 0x00, 0x00,0x00  } }; // 2
+    static const constexpr rct::key MINUS_ONE = { { 0xec, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10 } }; // -1
+    static const constexpr rct::key MINUS_INV_EIGHT = { { 0x74, 0xa4, 0x19, 0x7a, 0xf0, 0x7d, 0x0b, 0xf7, 0x05, 0xc2, 0xda, 0x25, 0x2b, 0x5c, 0x0b, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0a } }; // -(8**(-1))
+    static rct::key TWO_SIXTY_FOUR_MINUS_ONE; // 2**64 - 1
+
+    // Initial transcript hash
+    static rct::key initial_transcript;
+
+    static boost::mutex init_mutex;
+
+    // Use the generator caches to compute a multiscalar multiplication
+    static inline rct::key multiexp(const std::vector<MultiexpData> &data, size_t HiGi_size)
+    {
+        if (HiGi_size > 0)
+        {
+            static_assert(232 <= STRAUS_SIZE_LIMIT, "Straus in precalc mode can only be calculated till STRAUS_SIZE_LIMIT");
+            return HiGi_size <= 232 && data.size() == HiGi_size ? straus(data, straus_HiGi_cache, 0) : pippenger(data, pippenger_HiGi_cache, HiGi_size, get_pippenger_c(data.size()));
+        }
+        else
+        {
+            return data.size() <= 95 ? straus(data, NULL, 0) : pippenger(data, NULL, 0, get_pippenger_c(data.size()));
+        }
+    }
+
+    // Confirm that a scalar is properly reduced
+    static inline bool is_reduced(const rct::key &scalar)
+    {
+        return sc_check(scalar.bytes) == 0;
+    }
+
+    // Use hashed values to produce indexed public generators
+    static ge_p3 get_exponent(const rct::key &base, size_t idx)
+    {
+        std::string hashed = std::string((const char*)base.bytes, sizeof(base)) + config::HASH_KEY_BULLETPROOF_PLUS_EXPONENT + tools::get_varint_data(idx);
+        rct::key generator;
+        ge_p3 generator_p3;
+        rct::hash_to_p3(generator_p3, rct::hash2rct(crypto::cn_fast_hash(hashed.data(), hashed.size())));
+        ge_p3_tobytes(generator.bytes, &generator_p3);
+        CHECK_AND_ASSERT_THROW_MES(!(generator == rct::identity()), "Exponent is point at infinity");
+        return generator_p3;
+    }
+
+    // Construct public generators
+    static void init_exponents()
+    {
+        boost::lock_guard<boost::mutex> lock(init_mutex);
+
+        // Only needs to be done once
+        static bool init_done = false;
+        if (init_done)
+            return;
+
+        std::vector<MultiexpData> data;
+        data.reserve(maxN*maxM*2);
+        for (size_t i = 0; i < maxN*maxM; ++i)
+        {
+            Hi_p3[i] = get_exponent(rct::H, i * 2);
+            Gi_p3[i] = get_exponent(rct::H, i * 2 + 1);
+
+            data.push_back({rct::zero(), Gi_p3[i]});
+            data.push_back({rct::zero(), Hi_p3[i]});
+        }
+
+        straus_HiGi_cache = straus_init_cache(data, STRAUS_SIZE_LIMIT);
+        pippenger_HiGi_cache = pippenger_init_cache(data, 0, PIPPENGER_SIZE_LIMIT);
+
+        // Compute 2**64 - 1 for later use in simplifying verification
+        TWO_SIXTY_FOUR_MINUS_ONE = TWO;
+        for (size_t i = 0; i < 6; i++)
+        {
+            sc_mul(TWO_SIXTY_FOUR_MINUS_ONE.bytes, TWO_SIXTY_FOUR_MINUS_ONE.bytes, TWO_SIXTY_FOUR_MINUS_ONE.bytes);
+        }
+        sc_sub(TWO_SIXTY_FOUR_MINUS_ONE.bytes, TWO_SIXTY_FOUR_MINUS_ONE.bytes, ONE.bytes);
+
+        // Generate the initial Fiat-Shamir transcript hash, which is constant across all proofs
+        const std::string domain_separator(config::HASH_KEY_BULLETPROOF_PLUS_TRANSCRIPT);
+        ge_p3 initial_transcript_p3;
+        rct::hash_to_p3(initial_transcript_p3, rct::hash2rct(crypto::cn_fast_hash(domain_separator.data(), domain_separator.size())));
+        ge_p3_tobytes(initial_transcript.bytes, &initial_transcript_p3);
+
+        init_done = true;
+    }
+
+    // Given two scalar arrays, construct a vector pre-commitment:
+    //
+    // a = (a_0, ..., a_{n-1})
+    // b = (b_0, ..., b_{n-1})
+    //
+    // Outputs a_0*Gi_0 + ... + a_{n-1}*Gi_{n-1} +
+    //         b_0*Hi_0 + ... + b_{n-1}*Hi_{n-1}
+    static rct::key vector_exponent(const rct::keyV &a, const rct::keyV &b)
+    {
+        CHECK_AND_ASSERT_THROW_MES(a.size() == b.size(), "Incompatible sizes of a and b");
+        CHECK_AND_ASSERT_THROW_MES(a.size() <= maxN*maxM, "Incompatible sizes of a and maxN");
+
+        std::vector<MultiexpData> multiexp_data;
+        multiexp_data.reserve(a.size()*2);
+        for (size_t i = 0; i < a.size(); ++i)
+        {
+            multiexp_data.emplace_back(a[i], Gi_p3[i]);
+            multiexp_data.emplace_back(b[i], Hi_p3[i]);
+        }
+        return multiexp(multiexp_data, 2 * a.size());
+    }
+
+    // Helper function used to compute the L and R terms used in the inner-product round function
+    static rct::key compute_LR(size_t size, const rct::key &y, const std::vector<ge_p3> &G, size_t G0, const std::vector<ge_p3> &H, size_t H0, const rct::keyV &a, size_t a0, const rct::keyV &b, size_t b0, const rct::key &c, const rct::key &d)
+    {
+        CHECK_AND_ASSERT_THROW_MES(size + G0 <= G.size(), "Incompatible size for G");
+        CHECK_AND_ASSERT_THROW_MES(size + H0 <= H.size(), "Incompatible size for H");
+        CHECK_AND_ASSERT_THROW_MES(size + a0 <= a.size(), "Incompatible size for a");
+        CHECK_AND_ASSERT_THROW_MES(size + b0 <= b.size(), "Incompatible size for b");
+        CHECK_AND_ASSERT_THROW_MES(size <= maxN*maxM, "size is too large");
+
+        std::vector<MultiexpData> multiexp_data;
+        multiexp_data.resize(size*2 + 2);
+        rct::key temp;
+        for (size_t i = 0; i < size; ++i)
+        {
+            sc_mul(temp.bytes, a[a0+i].bytes, y.bytes);
+            sc_mul(multiexp_data[i*2].scalar.bytes, temp.bytes, INV_EIGHT.bytes);
+            multiexp_data[i*2].point = G[G0+i];
+
+            sc_mul(multiexp_data[i*2+1].scalar.bytes, b[b0+i].bytes, INV_EIGHT.bytes);
+            multiexp_data[i*2+1].point = H[H0+i];
+        }
+
+        sc_mul(multiexp_data[2*size].scalar.bytes, c.bytes, INV_EIGHT.bytes);
+        ge_p3 H_p3;
+        ge_frombytes_vartime(&H_p3, rct::H.bytes);
+        multiexp_data[2*size].point = H_p3;
+
+        sc_mul(multiexp_data[2*size+1].scalar.bytes, d.bytes, INV_EIGHT.bytes);
+        ge_p3 G_p3;
+        ge_frombytes_vartime(&G_p3, rct::G.bytes);
+        multiexp_data[2*size+1].point = G_p3;
+
+        return multiexp(multiexp_data, 0);
+    }
+
+    // Given a scalar, construct a vector of its powers:
+    //
+    // Output (1,x,x**2,...,x**{n-1})
+    static rct::keyV vector_of_scalar_powers(const rct::key &x, size_t n)
+    {
+        CHECK_AND_ASSERT_THROW_MES(n != 0, "Need n > 0");
+
+        rct::keyV res(n);
+        res[0] = rct::identity();
+        if (n == 1)
+            return res;
+        res[1] = x;
+        for (size_t i = 2; i < n; ++i)
+        {
+            sc_mul(res[i].bytes, res[i-1].bytes, x.bytes);
+        }
+        return res;
+    }
+
+    // Given a scalar, construct the sum of its powers from 2 to n (where n is a power of 2):
+    //
+    // Output x**2 + x**4 + x**6 + ... + x**n
+    static rct::key sum_of_even_powers(const rct::key &x, size_t n)
+    {
+        CHECK_AND_ASSERT_THROW_MES((n & (n - 1)) == 0, "Need n to be a power of 2");
+        CHECK_AND_ASSERT_THROW_MES(n != 0, "Need n > 0");
+
+        rct::key x1 = copy(x);
+        sc_mul(x1.bytes, x1.bytes, x1.bytes);
+
+        rct::key res = copy(x1);
+        while (n > 2)
+        {
+            sc_muladd(res.bytes, x1.bytes, res.bytes, res.bytes);
+            sc_mul(x1.bytes, x1.bytes, x1.bytes);
+            n /= 2;
+        }
+
+        return res;
+    }
+
+    // Given a scalar, return the sum of its powers from 1 to n
+    //
+    // Output x**1 + x**2 + x**3 + ... + x**n
+    static rct::key sum_of_scalar_powers(const rct::key &x, size_t n)
+    {
+        CHECK_AND_ASSERT_THROW_MES(n != 0, "Need n > 0");
+
+        rct::key res = ONE;
+        if (n == 1)
+            return x;
+
+        n += 1;
+        rct::key x1 = copy(x);
+
+        const bool is_power_of_2 = (n & (n - 1)) == 0;
+        if (is_power_of_2)
+        {
+            sc_add(res.bytes, res.bytes, x1.bytes);
+            while (n > 2)
+            {
+                sc_mul(x1.bytes, x1.bytes, x1.bytes);
+                sc_muladd(res.bytes, x1.bytes, res.bytes, res.bytes);
+                n /= 2;
+            }
+        }
+        else
+        {
+            rct::key prev = x1;
+            for (size_t i = 1; i < n; ++i)
+            {
+                if (i > 1)
+                    sc_mul(prev.bytes, prev.bytes, x1.bytes);
+                sc_add(res.bytes, res.bytes, prev.bytes);
+            }
+        }
+        sc_sub(res.bytes, res.bytes, ONE.bytes);
+
+        return res;
+    }
+
+    // Given two scalar arrays, construct the weighted inner product against another scalar
+    //
+    // Output a_0*b_0*y**1 + a_1*b_1*y**2 + ... + a_{n-1}*b_{n-1}*y**n
+    static rct::key weighted_inner_product(const epee::span<const rct::key> &a, const epee::span<const rct::key> &b, const rct::key &y)
+    {
+        CHECK_AND_ASSERT_THROW_MES(a.size() == b.size(), "Incompatible sizes of a and b");
+        rct::key res = rct::zero();
+        rct::key y_power = ONE;
+        rct::key temp;
+        for (size_t i = 0; i < a.size(); ++i)
+        {
+            sc_mul(temp.bytes, a[i].bytes, b[i].bytes);
+            sc_mul(y_power.bytes, y_power.bytes, y.bytes);
+            sc_muladd(res.bytes, temp.bytes, y_power.bytes, res.bytes);
+        }
+        return res;
+    }
+
+    static rct::key weighted_inner_product(const rct::keyV &a, const epee::span<const rct::key> &b, const rct::key &y)
+    {
+        CHECK_AND_ASSERT_THROW_MES(a.size() == b.size(), "Incompatible sizes of a and b");
+        return weighted_inner_product(epee::to_span(a), b, y);
+    }
+
+    // Fold inner-product point vectors
+    static void hadamard_fold(std::vector<ge_p3> &v, const rct::key &a, const rct::key &b)
+    {
+        CHECK_AND_ASSERT_THROW_MES((v.size() & 1) == 0, "Vector size should be even");
+        const size_t sz = v.size() / 2;
+        for (size_t n = 0; n < sz; ++n)
+        {
+            ge_dsmp c[2];
+            ge_dsm_precomp(c[0], &v[n]);
+            ge_dsm_precomp(c[1], &v[sz + n]);
+            ge_double_scalarmult_precomp_vartime2_p3(&v[n], a.bytes, c[0], b.bytes, c[1]);
+        }
+        v.resize(sz);
+    }
+
+    // Add vectors componentwise
+    static rct::keyV vector_add(const rct::keyV &a, const rct::keyV &b)
+    {
+        CHECK_AND_ASSERT_THROW_MES(a.size() == b.size(), "Incompatible sizes of a and b");
+        rct::keyV res(a.size());
+        for (size_t i = 0; i < a.size(); ++i)
+        {
+            sc_add(res[i].bytes, a[i].bytes, b[i].bytes);
+        }
+        return res;
+    }
+
+    // Add a scalar to all elements of a vector
+    static rct::keyV vector_add(const rct::keyV &a, const rct::key &b)
+    {
+        rct::keyV res(a.size());
+        for (size_t i = 0; i < a.size(); ++i)
+        {
+            sc_add(res[i].bytes, a[i].bytes, b.bytes);
+        }
+        return res;
+    }
+
+    // Subtract a scalar from all elements of a vector
+    static rct::keyV vector_subtract(const rct::keyV &a, const rct::key &b)
+    {
+        rct::keyV res(a.size());
+        for (size_t i = 0; i < a.size(); ++i)
+        {
+            sc_sub(res[i].bytes, a[i].bytes, b.bytes);
+        }
+        return res;
+    }
+
+    // Multiply a scalar by all elements of a vector
+    static rct::keyV vector_scalar(const epee::span<const rct::key> &a, const rct::key &x)
+    {
+        rct::keyV res(a.size());
+        for (size_t i = 0; i < a.size(); ++i)
+        {
+            sc_mul(res[i].bytes, a[i].bytes, x.bytes);
+        }
+        return res;
+    }
+
+    // Inversion helper function
+    static rct::key sm(rct::key y, int n, const rct::key &x)
+    {
+        while (n--)
+            sc_mul(y.bytes, y.bytes, y.bytes);
+        sc_mul(y.bytes, y.bytes, x.bytes);
+        return y;
+    }
+
+    // Compute the inverse of a nonzero
+    static rct::key invert(const rct::key &x)
+    {
+        CHECK_AND_ASSERT_THROW_MES(!(x == ZERO), "Cannot invert zero!");
+        rct::key _1, _10, _100, _11, _101, _111, _1001, _1011, _1111;
+
+        _1 = x;
+        sc_mul(_10.bytes, _1.bytes, _1.bytes);
+        sc_mul(_100.bytes, _10.bytes, _10.bytes);
+        sc_mul(_11.bytes, _10.bytes, _1.bytes);
+        sc_mul(_101.bytes, _10.bytes, _11.bytes);
+        sc_mul(_111.bytes, _10.bytes, _101.bytes);
+        sc_mul(_1001.bytes, _10.bytes, _111.bytes);
+        sc_mul(_1011.bytes, _10.bytes, _1001.bytes);
+        sc_mul(_1111.bytes, _100.bytes, _1011.bytes);
+
+        rct::key inv;
+        sc_mul(inv.bytes, _1111.bytes, _1.bytes);
+
+        inv = sm(inv, 123 + 3, _101);
+        inv = sm(inv, 2 + 2, _11);
+        inv = sm(inv, 1 + 4, _1111);
+        inv = sm(inv, 1 + 4, _1111);
+        inv = sm(inv, 4, _1001);
+        inv = sm(inv, 2, _11);
+        inv = sm(inv, 1 + 4, _1111);
+        inv = sm(inv, 1 + 3, _101);
+        inv = sm(inv, 3 + 3, _101);
+        inv = sm(inv, 3, _111);
+        inv = sm(inv, 1 + 4, _1111);
+        inv = sm(inv, 2 + 3, _111);
+        inv = sm(inv, 2 + 2, _11);
+        inv = sm(inv, 1 + 4, _1011);
+        inv = sm(inv, 2 + 4, _1011);
+        inv = sm(inv, 6 + 4, _1001);
+        inv = sm(inv, 2 + 2, _11);
+        inv = sm(inv, 3 + 2, _11);
+        inv = sm(inv, 3 + 2, _11);
+        inv = sm(inv, 1 + 4, _1001);
+        inv = sm(inv, 1 + 3, _111);
+        inv = sm(inv, 2 + 4, _1111);
+        inv = sm(inv, 1 + 4, _1011);
+        inv = sm(inv, 3, _101);
+        inv = sm(inv, 2 + 4, _1111);
+        inv = sm(inv, 3, _101);
+        inv = sm(inv, 1 + 2, _11);
+
+        return inv;
+    }
+
+    // Invert a batch of scalars, all of which _must_ be nonzero
+    static rct::keyV invert(rct::keyV x)
+    {
+        rct::keyV scratch;
+        scratch.reserve(x.size());
+
+        rct::key acc = rct::identity();
+        for (size_t n = 0; n < x.size(); ++n)
+        {
+            CHECK_AND_ASSERT_THROW_MES(!(x[n] == ZERO), "Cannot invert zero!");
+            scratch.push_back(acc);
+            if (n == 0)
+                acc = x[0];
+            else
+                sc_mul(acc.bytes, acc.bytes, x[n].bytes);
+        }
+
+        acc = invert(acc);
+
+        rct::key tmp;
+        for (int i = x.size(); i-- > 0; )
+        {
+            sc_mul(tmp.bytes, acc.bytes, x[i].bytes);
+            sc_mul(x[i].bytes, acc.bytes, scratch[i].bytes);
+            acc = tmp;
+        }
+
+        return x;
+    }
+
+    // Compute the slice of a vector
+    static epee::span<const rct::key> slice(const rct::keyV &a, size_t start, size_t stop)
+    {
+        CHECK_AND_ASSERT_THROW_MES(start < a.size(), "Invalid start index");
+        CHECK_AND_ASSERT_THROW_MES(stop <= a.size(), "Invalid stop index");
+        CHECK_AND_ASSERT_THROW_MES(start < stop, "Invalid start/stop indices");
+        return epee::span<const rct::key>(&a[start], stop - start);
+    }
+
+    // Update the transcript
+    static rct::key transcript_update(rct::key &transcript, const rct::key &update_0)
+    {
+        rct::key data[2];
+        data[0] = transcript;
+        data[1] = update_0;
+        rct::hash_to_scalar(transcript, data, sizeof(data));
+        return transcript;
+    }
+
+    static rct::key transcript_update(rct::key &transcript, const rct::key &update_0, const rct::key &update_1)
+    {
+        rct::key data[3];
+        data[0] = transcript;
+        data[1] = update_0;
+        data[2] = update_1;
+        rct::hash_to_scalar(transcript, data, sizeof(data));
+        return transcript;
+    }
+
+    // Given a value v [0..2**N) and a mask gamma, construct a range proof
+    BulletproofPlus bulletproof_plus_PROVE(const rct::key &sv, const rct::key &gamma)
+    {
+        return bulletproof_plus_PROVE(rct::keyV(1, sv), rct::keyV(1, gamma));
+    }
+
+    BulletproofPlus bulletproof_plus_PROVE(uint64_t v, const rct::key &gamma)
+    {
+        return bulletproof_plus_PROVE(std::vector<uint64_t>(1, v), rct::keyV(1, gamma));
+    }
+
+    // Given a set of values v [0..2**N) and masks gamma, construct a range proof
+    BulletproofPlus bulletproof_plus_PROVE(const rct::keyV &sv, const rct::keyV &gamma)
+    {
+        // Sanity check on inputs
+        CHECK_AND_ASSERT_THROW_MES(sv.size() == gamma.size(), "Incompatible sizes of sv and gamma");
+        CHECK_AND_ASSERT_THROW_MES(!sv.empty(), "sv is empty");
+        for (const rct::key &sve: sv)
+            CHECK_AND_ASSERT_THROW_MES(is_reduced(sve), "Invalid sv input");
+        for (const rct::key &g: gamma)
+            CHECK_AND_ASSERT_THROW_MES(is_reduced(g), "Invalid gamma input");
+
+        init_exponents();
+
+        // Useful proof bounds
+        //
+        // N: number of bits in each range (here, 64)
+        // logN: base-2 logarithm
+        // M: first power of 2 greater than or equal to the number of range proofs to aggregate
+        // logM: base-2 logarithm
+        constexpr size_t logN = 6; // log2(64)
+        constexpr size_t N = 1<<logN;
+        size_t M, logM;
+        for (logM = 0; (M = 1<<logM) <= maxM && M < sv.size(); ++logM);
+        CHECK_AND_ASSERT_THROW_MES(M <= maxM, "sv/gamma are too large");
+        const size_t logMN = logM + logN;
+        const size_t MN = M * N;
+
+        rct::keyV V(sv.size());
+        rct::keyV aL(MN), aR(MN);
+        rct::keyV aL8(MN), aR8(MN);
+        rct::key temp;
+        rct::key temp2;
+
+        // Prepare output commitments and offset by a factor of 8**(-1)
+        //
+        // This offset is applied to other group elements as well;
+        //  it allows us to apply a multiply-by-8 operation in the verifier efficiently
+        //  to ensure that the resulting group elements are in the prime-order point subgroup
+        //  and avoid much more costly multiply-by-group-order operations.
+        for (size_t i = 0; i < sv.size(); ++i)
+        {
+            rct::key gamma8, sv8;
+            sc_mul(gamma8.bytes, gamma[i].bytes, INV_EIGHT.bytes);
+            sc_mul(sv8.bytes, sv[i].bytes, INV_EIGHT.bytes);
+            rct::addKeys2(V[i], gamma8, sv8, rct::H);
+        }
+
+        // Decompose values
+        //
+        // Note that this effectively pads the set to a power of 2, which is required for the inner-product argument later.
+        for (size_t j = 0; j < M; ++j)
+        {
+            for (size_t i = N; i-- > 0; )
+            {
+                if (j < sv.size() && (sv[j][i/8] & (((uint64_t)1)<<(i%8))))
+                {
+                    aL[j*N+i] = rct::identity();
+                    aL8[j*N+i] = INV_EIGHT;
+                    aR[j*N+i] = aR8[j*N+i] = rct::zero();
+                }
+                else
+                {
+                    aL[j*N+i] = aL8[j*N+i] = rct::zero();
+                    aR[j*N+i] = MINUS_ONE;
+                    aR8[j*N+i] = MINUS_INV_EIGHT;
+                }
+            }
+        }
+
+try_again:
+        // This is a Fiat-Shamir transcript
+        rct::key transcript = copy(initial_transcript);
+        transcript = transcript_update(transcript, rct::hash_to_scalar(V));
+
+        // A
+        rct::key alpha = rct::skGen();
+        rct::key pre_A = vector_exponent(aL8, aR8);
+        rct::key A;
+        sc_mul(temp.bytes, alpha.bytes, INV_EIGHT.bytes);
+        rct::addKeys(A, pre_A, rct::scalarmultBase(temp));
+
+        // Challenges
+        rct::key y = transcript_update(transcript, A);
+        if (y == rct::zero())
+        {
+            MINFO("y is 0, trying again");
+            goto try_again;
+        }
+        rct::key z = transcript = rct::hash_to_scalar(y);
+        if (z == rct::zero())
+        {
+            MINFO("z is 0, trying again");
+            goto try_again;
+        }
+        rct::key z_squared;
+        sc_mul(z_squared.bytes, z.bytes, z.bytes);
+
+        // Windowed vector
+        // d[j*N+i] = z**(2*(j+1)) * 2**i
+        //
+        // We compute this iteratively in order to reduce scalar operations.
+        rct::keyV d(MN, rct::zero());
+        d[0] = z_squared;
+        for (size_t i = 1; i < N; i++)
+        {
+            sc_mul(d[i].bytes, d[i-1].bytes, TWO.bytes);
+        }
+
+        for (size_t j = 1; j < M; j++)
+        {
+            for (size_t i = 0; i < N; i++)
+            {
+                sc_mul(d[j*N+i].bytes, d[(j-1)*N+i].bytes, z_squared.bytes);
+            }
+        }
+
+        rct::keyV y_powers = vector_of_scalar_powers(y, MN+2);
+
+        // Prepare inner product terms
+        rct::keyV aL1 = vector_subtract(aL, z);
+
+        rct::keyV aR1 = vector_add(aR, z);
+        rct::keyV d_y(MN);
+        for (size_t i = 0; i < MN; i++)
+        {
+            sc_mul(d_y[i].bytes, d[i].bytes, y_powers[MN-i].bytes);
+        }
+        aR1 = vector_add(aR1, d_y);
+
+        rct::key alpha1 = alpha;
+        temp = ONE;
+        for (size_t j = 0; j < sv.size(); j++)
+        {
+            sc_mul(temp.bytes, temp.bytes, z_squared.bytes);
+            sc_mul(temp2.bytes, y_powers[MN+1].bytes, temp.bytes);
+            sc_muladd(alpha1.bytes, temp2.bytes, gamma[j].bytes, alpha1.bytes);
+        }
+
+        // These are used in the inner product rounds
+        size_t nprime = MN;
+        std::vector<ge_p3> Gprime(MN);
+        std::vector<ge_p3> Hprime(MN);
+        rct::keyV aprime(MN);
+        rct::keyV bprime(MN);
+
+        const rct::key yinv = invert(y);
+        rct::keyV yinvpow(MN);
+        yinvpow[0] = ONE;
+        for (size_t i = 0; i < MN; ++i)
+        {
+            Gprime[i] = Gi_p3[i];
+            Hprime[i] = Hi_p3[i];
+            if (i > 0)
+            {
+                sc_mul(yinvpow[i].bytes, yinvpow[i-1].bytes, yinv.bytes);
+            }
+            aprime[i] = aL1[i];
+            bprime[i] = aR1[i];
+        }
+        rct::keyV L(logMN);
+        rct::keyV R(logMN);
+        int round = 0;
+
+        // Inner-product rounds
+        while (nprime > 1)
+        {
+            nprime /= 2;
+
+            rct::key cL = weighted_inner_product(slice(aprime, 0, nprime), slice(bprime, nprime, bprime.size()), y);
+            rct::key cR = weighted_inner_product(vector_scalar(slice(aprime, nprime, aprime.size()), y_powers[nprime]), slice(bprime, 0, nprime), y);
+
+            rct::key dL = rct::skGen();
+            rct::key dR = rct::skGen();
+
+            L[round] = compute_LR(nprime, yinvpow[nprime], Gprime, nprime, Hprime, 0, aprime, 0, bprime, nprime, cL, dL);
+            R[round] = compute_LR(nprime, y_powers[nprime], Gprime, 0, Hprime, nprime, aprime, nprime, bprime, 0, cR, dR);
+
+            const rct::key challenge = transcript_update(transcript, L[round], R[round]);
+            if (challenge == rct::zero())
+            {
+                MINFO("challenge is 0, trying again");
+                goto try_again;
+            }
+
+            const rct::key challenge_inv = invert(challenge);
+
+            sc_mul(temp.bytes, yinvpow[nprime].bytes, challenge.bytes);
+            hadamard_fold(Gprime, challenge_inv, temp);
+            hadamard_fold(Hprime, challenge, challenge_inv);
+
+            sc_mul(temp.bytes, challenge_inv.bytes, y_powers[nprime].bytes);
+            aprime = vector_add(vector_scalar(slice(aprime, 0, nprime), challenge), vector_scalar(slice(aprime, nprime, aprime.size()), temp));
+            bprime = vector_add(vector_scalar(slice(bprime, 0, nprime), challenge_inv), vector_scalar(slice(bprime, nprime, bprime.size()), challenge));
+
+            rct::key challenge_squared;
+            sc_mul(challenge_squared.bytes, challenge.bytes, challenge.bytes);
+            rct::key challenge_squared_inv;
+            sc_mul(challenge_squared_inv.bytes, challenge_inv.bytes, challenge_inv.bytes);
+            sc_muladd(alpha1.bytes, dL.bytes, challenge_squared.bytes, alpha1.bytes);
+            sc_muladd(alpha1.bytes, dR.bytes, challenge_squared_inv.bytes, alpha1.bytes);
+
+            ++round;
+        }
+
+        // Final round computations
+        rct::key r = rct::skGen();
+        rct::key s = rct::skGen();
+        rct::key d_ = rct::skGen();
+        rct::key eta = rct::skGen();
+
+        std::vector<MultiexpData> A1_data;
+        A1_data.reserve(4);
+        A1_data.resize(4);
+
+        sc_mul(A1_data[0].scalar.bytes, r.bytes, INV_EIGHT.bytes);
+        A1_data[0].point = Gprime[0];
+
+        sc_mul(A1_data[1].scalar.bytes, s.bytes, INV_EIGHT.bytes);
+        A1_data[1].point = Hprime[0];
+
+        sc_mul(A1_data[2].scalar.bytes, d_.bytes, INV_EIGHT.bytes);
+        ge_p3 G_p3;
+        ge_frombytes_vartime(&G_p3, rct::G.bytes);
+        A1_data[2].point = G_p3;
+
+        sc_mul(temp.bytes, r.bytes, y.bytes);
+        sc_mul(temp.bytes, temp.bytes, bprime[0].bytes);
+        sc_mul(temp2.bytes, s.bytes, y.bytes);
+        sc_mul(temp2.bytes, temp2.bytes, aprime[0].bytes);
+        sc_add(temp.bytes, temp.bytes, temp2.bytes);
+        sc_mul(A1_data[3].scalar.bytes, temp.bytes, INV_EIGHT.bytes);
+        ge_p3 H_p3;
+        ge_frombytes_vartime(&H_p3, rct::H.bytes);
+        A1_data[3].point = H_p3;
+
+        rct::key A1 = multiexp(A1_data, 0);
+
+        sc_mul(temp.bytes, r.bytes, y.bytes);
+        sc_mul(temp.bytes, temp.bytes, s.bytes);
+        sc_mul(temp.bytes, temp.bytes, INV_EIGHT.bytes);
+        sc_mul(temp2.bytes, eta.bytes, INV_EIGHT.bytes);
+        rct::key B;
+        rct::addKeys2(B, temp2, temp, rct::H);
+
+        rct::key e = transcript_update(transcript, A1, B);
+        if (e == rct::zero())
+        {
+            MINFO("e is 0, trying again");
+            goto try_again;
+        }
+        rct::key e_squared;
+        sc_mul(e_squared.bytes, e.bytes, e.bytes);
+
+        rct::key r1;
+        sc_muladd(r1.bytes, aprime[0].bytes, e.bytes, r.bytes);
+
+        rct::key s1;
+        sc_muladd(s1.bytes, bprime[0].bytes, e.bytes, s.bytes);
+
+        rct::key d1;
+        sc_muladd(d1.bytes, d_.bytes, e.bytes, eta.bytes);
+        sc_muladd(d1.bytes, alpha1.bytes, e_squared.bytes, d1.bytes);
+
+        return BulletproofPlus(std::move(V), A, A1, B, r1, s1, d1, std::move(L), std::move(R));
+    }
+
+    BulletproofPlus bulletproof_plus_PROVE(const std::vector<uint64_t> &v, const rct::keyV &gamma)
+    {
+        CHECK_AND_ASSERT_THROW_MES(v.size() == gamma.size(), "Incompatible sizes of v and gamma");
+
+        // vG + gammaH
+        rct::keyV sv(v.size());
+        for (size_t i = 0; i < v.size(); ++i)
+        {
+            sv[i] = rct::d2h(v[i]);
+        }
+        return bulletproof_plus_PROVE(sv, gamma);
+    }
+
+    struct bp_plus_proof_data_t
+    {
+        rct::key y, z, e;
+        std::vector<rct::key> challenges;
+        size_t logM, inv_offset;
+    };
+
+    // Given a batch of range proofs, determine if they are all valid
+    bool bulletproof_plus_VERIFY(const std::vector<const BulletproofPlus*> &proofs)
+    {
+        init_exponents();
+
+        const size_t logN = 6;
+        const size_t N = 1 << logN;
+
+        // Set up
+        size_t max_length = 0; // size of each of the longest proof's inner-product vectors
+        size_t nV = 0; // number of output commitments across all proofs
+        size_t inv_offset = 0;
+        size_t max_logM = 0; 
+
+        std::vector<bp_plus_proof_data_t> proof_data;
+        proof_data.reserve(proofs.size());
+
+        // We'll perform only a single batch inversion across all proofs in the batch,
+        //  since batch inversion requires only one scalar inversion operation.
+        std::vector<rct::key> to_invert;
+        to_invert.reserve(11 * proofs.size()); // maximal size, given the aggregation limit
+
+        for (const BulletproofPlus *p: proofs)
+        {
+            const BulletproofPlus &proof = *p;
+
+            // Sanity checks
+            CHECK_AND_ASSERT_MES(is_reduced(proof.r1), false, "Input scalar not in range");
+            CHECK_AND_ASSERT_MES(is_reduced(proof.s1), false, "Input scalar not in range");
+            CHECK_AND_ASSERT_MES(is_reduced(proof.d1), false, "Input scalar not in range");
+
+            CHECK_AND_ASSERT_MES(proof.V.size() >= 1, false, "V does not have at least one element");
+            CHECK_AND_ASSERT_MES(proof.L.size() == proof.R.size(), false, "Mismatched L and R sizes");
+            CHECK_AND_ASSERT_MES(proof.L.size() > 0, false, "Empty proof");
+
+            max_length = std::max(max_length, proof.L.size());
+            nV += proof.V.size();
+
+            proof_data.push_back({});
+            bp_plus_proof_data_t &pd = proof_data.back();
+
+            // Reconstruct the challenges
+            rct::key transcript = copy(initial_transcript);
+            transcript = transcript_update(transcript, rct::hash_to_scalar(proof.V));
+            pd.y = transcript_update(transcript, proof.A);
+            CHECK_AND_ASSERT_MES(!(pd.y == rct::zero()), false, "y == 0");
+            pd.z = transcript = rct::hash_to_scalar(pd.y);
+            CHECK_AND_ASSERT_MES(!(pd.z == rct::zero()), false, "z == 0");
+
+            // Determine the number of inner-product rounds based on proof size
+            size_t M;
+            for (pd.logM = 0; (M = 1<<pd.logM) <= maxM && M < proof.V.size(); ++pd.logM);
+            CHECK_AND_ASSERT_MES(proof.L.size() == 6+pd.logM, false, "Proof is not the expected size");
+            max_logM = std::max(pd.logM, max_logM);
+
+            const size_t rounds = pd.logM+logN;
+            CHECK_AND_ASSERT_MES(rounds > 0, false, "Zero rounds");
+
+            // The inner-product challenges are computed per round
+            pd.challenges.resize(rounds);
+            for (size_t j = 0; j < rounds; ++j)
+            {
+                pd.challenges[j] = transcript_update(transcript, proof.L[j], proof.R[j]);
+                CHECK_AND_ASSERT_MES(!(pd.challenges[j] == rct::zero()), false, "challenges[j] == 0");
+            }
+
+            // Final challenge
+            pd.e = transcript_update(transcript,proof.A1,proof.B);
+            CHECK_AND_ASSERT_MES(!(pd.e == rct::zero()), false, "e == 0");
+
+            // Batch scalar inversions
+            pd.inv_offset = inv_offset;
+            for (size_t j = 0; j < rounds; ++j)
+                to_invert.push_back(pd.challenges[j]);
+            to_invert.push_back(pd.y);
+            inv_offset += rounds + 1;
+        }
+        CHECK_AND_ASSERT_MES(max_length < 32, false, "At least one proof is too large");
+        size_t maxMN = 1u << max_length;
+
+        rct::key temp;
+        rct::key temp2;
+
+        // Final batch proof data
+        std::vector<MultiexpData> multiexp_data;
+        multiexp_data.reserve(nV + (2 * (max_logM + logN) + 3) * proofs.size() + 2 * maxMN);
+        multiexp_data.resize(2 * maxMN);
+
+        const std::vector<rct::key> inverses = invert(std::move(to_invert));
+        to_invert.clear();
+
+        // Weights and aggregates
+        //
+        // The idea is to take the single multiscalar multiplication used in the verification
+        //  of each proof in the batch and weight it using a random weighting factor, resulting
+        //  in just one multiscalar multiplication check to zero for the entire batch.
+        // We can further simplify the verifier complexity by including common group elements
+        //  only once in this single multiscalar multiplication.
+        // Common group elements' weighted scalar sums are tracked across proofs for this reason.
+        //
+        // To build a multiscalar multiplication for each proof, we use the method described in
+        //  Section 6.1 of the preprint. Note that the result given there does not account for
+        //  the construction of the inner-product inputs that are produced in the range proof
+        //  verifier algorithm; we have done so here.
+        rct::key G_scalar = rct::zero();
+        rct::key H_scalar = rct::zero();
+        rct::keyV Gi_scalars(maxMN, rct::zero());
+        rct::keyV Hi_scalars(maxMN, rct::zero());
+
+        int proof_data_index = 0;
+        rct::keyV challenges_cache;
+        std::vector<ge_p3> proof8_V, proof8_L, proof8_R;
+
+        // Process each proof and add to the weighted batch
+        for (const BulletproofPlus *p: proofs)
+        {
+            const BulletproofPlus &proof = *p;
+            const bp_plus_proof_data_t &pd = proof_data[proof_data_index++];
+
+            CHECK_AND_ASSERT_MES(proof.L.size() == 6+pd.logM, false, "Proof is not the expected size");
+            const size_t M = 1 << pd.logM;
+            const size_t MN = M*N;
+
+            // Random weighting factor must be nonzero, which is exceptionally unlikely!
+            rct::key weight = ZERO;
+            while (weight == ZERO)
+            {
+                weight = rct::skGen();
+            }
+
+            // Rescale previously offset proof elements
+            //
+            // This ensures that all such group elements are in the prime-order subgroup.
+            proof8_V.resize(proof.V.size()); for (size_t i = 0; i < proof.V.size(); ++i) rct::scalarmult8(proof8_V[i], proof.V[i]);
+            proof8_L.resize(proof.L.size()); for (size_t i = 0; i < proof.L.size(); ++i) rct::scalarmult8(proof8_L[i], proof.L[i]);
+            proof8_R.resize(proof.R.size()); for (size_t i = 0; i < proof.R.size(); ++i) rct::scalarmult8(proof8_R[i], proof.R[i]);
+            ge_p3 proof8_A1;
+            ge_p3 proof8_B;
+            ge_p3 proof8_A;
+            rct::scalarmult8(proof8_A1, proof.A1);
+            rct::scalarmult8(proof8_B, proof.B);
+            rct::scalarmult8(proof8_A, proof.A);
+
+            // Compute necessary powers of the y-challenge
+            rct::key y_MN = copy(pd.y);
+            rct::key y_MN_1;
+            size_t temp_MN = MN;
+            while (temp_MN > 1)
+            {
+                sc_mul(y_MN.bytes, y_MN.bytes, y_MN.bytes);
+                temp_MN /= 2;
+            }
+            sc_mul(y_MN_1.bytes, y_MN.bytes, pd.y.bytes);
+
+            // V_j: -e**2 * z**(2*j+1) * y**(MN+1) * weight
+            rct::key e_squared;
+            sc_mul(e_squared.bytes, pd.e.bytes, pd.e.bytes);
+
+            rct::key z_squared;
+            sc_mul(z_squared.bytes, pd.z.bytes, pd.z.bytes);
+
+            sc_sub(temp.bytes, ZERO.bytes, e_squared.bytes);
+            sc_mul(temp.bytes, temp.bytes, y_MN_1.bytes);
+            sc_mul(temp.bytes, temp.bytes, weight.bytes);
+            for (size_t j = 0; j < proof8_V.size(); j++)
+            {
+                sc_mul(temp.bytes, temp.bytes, z_squared.bytes);
+                multiexp_data.emplace_back(temp, proof8_V[j]);
+            }
+
+            // B: -weight
+            sc_mul(temp.bytes, MINUS_ONE.bytes, weight.bytes);
+            multiexp_data.emplace_back(temp, proof8_B);
+
+            // A1: -weight*e
+            sc_mul(temp.bytes, temp.bytes, pd.e.bytes);
+            multiexp_data.emplace_back(temp, proof8_A1);
+
+            // A: -weight*e*e
+            rct::key minus_weight_e_squared;
+            sc_mul(minus_weight_e_squared.bytes, temp.bytes, pd.e.bytes);
+            multiexp_data.emplace_back(minus_weight_e_squared, proof8_A);
+
+            // G: weight*d1
+            sc_muladd(G_scalar.bytes, weight.bytes, proof.d1.bytes, G_scalar.bytes);
+
+            // Windowed vector
+            // d[j*N+i] = z**(2*(j+1)) * 2**i
+            rct::keyV d(MN, rct::zero());
+            d[0] = z_squared;
+            for (size_t i = 1; i < N; i++)
+            {
+                sc_add(d[i].bytes, d[i-1].bytes, d[i-1].bytes);
+            }
+
+            for (size_t j = 1; j < M; j++)
+            {
+                for (size_t i = 0; i < N; i++)
+                {
+                    sc_mul(d[j*N+i].bytes, d[(j-1)*N+i].bytes, z_squared.bytes);
+                }
+            }
+
+            // More efficient computation of sum(d)
+            rct::key sum_d;
+            sc_mul(sum_d.bytes, TWO_SIXTY_FOUR_MINUS_ONE.bytes, sum_of_even_powers(pd.z, 2*M).bytes);
+
+            // H: weight*( r1*y*s1 + e**2*( y**(MN+1)*z*sum(d) + (z**2-z)*sum(y) ) )
+            rct::key sum_y = sum_of_scalar_powers(pd.y, MN);
+            sc_sub(temp.bytes, z_squared.bytes, pd.z.bytes);
+            sc_mul(temp.bytes, temp.bytes, sum_y.bytes);
+
+            sc_mul(temp2.bytes, y_MN_1.bytes, pd.z.bytes);
+            sc_mul(temp2.bytes, temp2.bytes, sum_d.bytes);
+            sc_add(temp.bytes, temp.bytes, temp2.bytes);
+            sc_mul(temp.bytes, temp.bytes, e_squared.bytes);
+            sc_mul(temp2.bytes, proof.r1.bytes, pd.y.bytes);
+            sc_mul(temp2.bytes, temp2.bytes, proof.s1.bytes);
+            sc_add(temp.bytes, temp.bytes, temp2.bytes);
+            sc_muladd(H_scalar.bytes, temp.bytes, weight.bytes, H_scalar.bytes);
+
+            // Compute the number of rounds for the inner-product argument
+            const size_t rounds = pd.logM+logN;
+            CHECK_AND_ASSERT_MES(rounds > 0, false, "Zero rounds");
+
+            const rct::key *challenges_inv = &inverses[pd.inv_offset];
+            const rct::key yinv = inverses[pd.inv_offset + rounds];
+
+            // Compute challenge products
+            challenges_cache.resize(1<<rounds);
+            challenges_cache[0] = challenges_inv[0];
+            challenges_cache[1] = pd.challenges[0];
+            for (size_t j = 1; j < rounds; ++j)
+            {
+                const size_t slots = 1<<(j+1);
+                for (size_t s = slots; s-- > 0; --s)
+                {
+                    sc_mul(challenges_cache[s].bytes, challenges_cache[s/2].bytes, pd.challenges[j].bytes);
+                    sc_mul(challenges_cache[s-1].bytes, challenges_cache[s/2].bytes, challenges_inv[j].bytes);
+                }
+            }
+
+            // Gi and Hi
+            rct::key e_r1_w_y;
+            sc_mul(e_r1_w_y.bytes, pd.e.bytes, proof.r1.bytes);
+            sc_mul(e_r1_w_y.bytes, e_r1_w_y.bytes, weight.bytes);
+            rct::key e_s1_w;
+            sc_mul(e_s1_w.bytes, pd.e.bytes, proof.s1.bytes);
+            sc_mul(e_s1_w.bytes, e_s1_w.bytes, weight.bytes);
+            rct::key e_squared_z_w;
+            sc_mul(e_squared_z_w.bytes, e_squared.bytes, pd.z.bytes);
+            sc_mul(e_squared_z_w.bytes, e_squared_z_w.bytes, weight.bytes);
+            rct::key minus_e_squared_z_w;
+            sc_sub(minus_e_squared_z_w.bytes, ZERO.bytes, e_squared_z_w.bytes);
+            rct::key minus_e_squared_w_y;
+            sc_sub(minus_e_squared_w_y.bytes, ZERO.bytes, e_squared.bytes);
+            sc_mul(minus_e_squared_w_y.bytes, minus_e_squared_w_y.bytes, weight.bytes);
+            sc_mul(minus_e_squared_w_y.bytes, minus_e_squared_w_y.bytes, y_MN.bytes);
+            for (size_t i = 0; i < MN; ++i)
+            {
+                rct::key g_scalar = copy(e_r1_w_y);
+                rct::key h_scalar;
+
+                // Use the binary decomposition of the index
+                sc_muladd(g_scalar.bytes, g_scalar.bytes, challenges_cache[i].bytes, e_squared_z_w.bytes);
+                sc_muladd(h_scalar.bytes, e_s1_w.bytes, challenges_cache[(~i) & (MN-1)].bytes, minus_e_squared_z_w.bytes);
+
+                // Complete the scalar derivation
+                sc_add(Gi_scalars[i].bytes, Gi_scalars[i].bytes, g_scalar.bytes);
+                sc_muladd(h_scalar.bytes, minus_e_squared_w_y.bytes, d[i].bytes, h_scalar.bytes);
+                sc_add(Hi_scalars[i].bytes, Hi_scalars[i].bytes, h_scalar.bytes);
+
+                // Update iterated values
+                sc_mul(e_r1_w_y.bytes, e_r1_w_y.bytes, yinv.bytes);
+                sc_mul(minus_e_squared_w_y.bytes, minus_e_squared_w_y.bytes, yinv.bytes);
+            }
+
+            // L_j: -weight*e*e*challenges[j]**2
+            // R_j: -weight*e*e*challenges[j]**(-2)
+            for (size_t j = 0; j < rounds; ++j)
+            {
+                sc_mul(temp.bytes, pd.challenges[j].bytes, pd.challenges[j].bytes);
+                sc_mul(temp.bytes, temp.bytes, minus_weight_e_squared.bytes);
+                multiexp_data.emplace_back(temp, proof8_L[j]);
+
+                sc_mul(temp.bytes, challenges_inv[j].bytes, challenges_inv[j].bytes);
+                sc_mul(temp.bytes, temp.bytes, minus_weight_e_squared.bytes);
+                multiexp_data.emplace_back(temp, proof8_R[j]);
+            }
+        }
+
+        // Verify all proofs in the weighted batch
+        multiexp_data.emplace_back(G_scalar, rct::G);
+        multiexp_data.emplace_back(H_scalar, rct::H);
+        for (size_t i = 0; i < maxMN; ++i)
+        {
+            multiexp_data[i * 2] = {Gi_scalars[i], Gi_p3[i]};
+            multiexp_data[i * 2 + 1] = {Hi_scalars[i], Hi_p3[i]};
+        }
+        if (!(multiexp(multiexp_data, 2 * maxMN) == rct::identity()))
+        {
+            MERROR("Verification failure");
+            return false;
+        }
+
+        return true;
+    }
+
+    bool bulletproof_plus_VERIFY(const std::vector<BulletproofPlus> &proofs)
+    {
+        std::vector<const BulletproofPlus*> proof_pointers;
+        proof_pointers.reserve(proofs.size());
+        for (const BulletproofPlus &proof: proofs)
+            proof_pointers.push_back(&proof);
+        return bulletproof_plus_VERIFY(proof_pointers);
+    }
+
+    bool bulletproof_plus_VERIFY(const BulletproofPlus &proof)
+    {
+        std::vector<const BulletproofPlus*> proofs;
+        proofs.push_back(&proof);
+        return bulletproof_plus_VERIFY(proofs);
+    }
+}

--- a/src/ringct/bulletproofs_plus.h
+++ b/src/ringct/bulletproofs_plus.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2017-2024, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#ifndef BULLETPROOFS_PLUS_H
+#define BULLETPROOFS_PLUS_H
+
+#include "rctTypes.h"
+
+namespace rct
+{
+
+BulletproofPlus bulletproof_plus_PROVE(const rct::key &v, const rct::key &gamma);
+BulletproofPlus bulletproof_plus_PROVE(uint64_t v, const rct::key &gamma);
+BulletproofPlus bulletproof_plus_PROVE(const rct::keyV &v, const rct::keyV &gamma);
+BulletproofPlus bulletproof_plus_PROVE(const std::vector<uint64_t> &v, const rct::keyV &gamma);
+bool bulletproof_plus_VERIFY(const BulletproofPlus &proof);
+bool bulletproof_plus_VERIFY(const std::vector<const BulletproofPlus*> &proofs);
+bool bulletproof_plus_VERIFY(const std::vector<BulletproofPlus> &proofs);
+
+}
+
+#endif

--- a/src/ringct/rctOps.cpp
+++ b/src/ringct/rctOps.cpp
@@ -453,6 +453,18 @@ namespace rct {
         return res;
     }
 
+    //Computes 8P into a p3 point, saving a byte roundtrip (Bulletproofs+, HF14)
+    void scalarmult8(ge_p3 &res, const key &P)
+    {
+        ge_p3 p3;
+        CHECK_AND_ASSERT_THROW_MES_L1(ge_frombytes_vartime(&p3, P.bytes) == 0, "ge_frombytes_vartime failed at "+boost::lexical_cast<std::string>(__LINE__));
+        ge_p2 p2;
+        ge_p3_to_p2(&p2, &p3);
+        ge_p1p1 p1;
+        ge_mul8(&p1, &p2);
+        ge_p1p1_to_p3(&res, &p1);
+    }
+
     //Computes lA where l is the curve order
     bool isInMainSubgroup(const key & a) {
         ge_p3 p3;

--- a/src/ringct/rctOps.cpp
+++ b/src/ringct/rctOps.cpp
@@ -545,6 +545,23 @@ namespace rct {
         ge_tobytes(aAbB.bytes, &rv);
     }
 
+    // addKeys_aGbBcC
+    // computes aG + bB + cC
+    // G is the fixed basepoint and B,C require precomputation
+    void addKeys_aGbBcC(key &aGbBcC, const key &a, const key &b, const ge_dsmp B, const key &c, const ge_dsmp C) {
+        ge_p2 rv;
+        ge_triple_scalarmult_base_vartime(&rv, a.bytes, b.bytes, B, c.bytes, C);
+        ge_tobytes(aGbBcC.bytes, &rv);
+    }
+
+    // addKeys_aAbBcC
+    // computes aA + bB + cC
+    // A,B,C require precomputation
+    void addKeys_aAbBcC(key &aAbBcC, const key &a, const ge_dsmp A, const key &b, const ge_dsmp B, const key &c, const ge_dsmp C) {
+        ge_p2 rv;
+        ge_triple_scalarmult_precomp_vartime(&rv, a.bytes, A, b.bytes, B, c.bytes, C);
+        ge_tobytes(aAbBcC.bytes, &rv);
+    }
 
     //subtract Keys (subtracts curve points)
     //AB = A - B where A, B are curve points
@@ -704,6 +721,16 @@ namespace rct {
         ge_p1p1_to_p3(&res, &point2);        
         ge_p3_tobytes(pointk.bytes, &res);
     }    
+
+    // Hash a key to p3 representation
+    void hash_to_p3(ge_p3 &hash8_p3, const key &k) {
+      key hash_key = cn_fast_hash(k);
+      ge_p2 hash_p2;
+      ge_fromfe_frombytes_vartime(&hash_p2, hash_key.bytes);
+      ge_p1p1 hash8_p1p1;
+      ge_mul8(&hash8_p1p1, &hash_p2);
+      ge_p1p1_to_p3(&hash8_p3, &hash8_p1p1);
+    }
 
     //sums a vector of curve points (for scalars use sc_add)
     void sumKeys(key & Csum, const keyV &  Cis) {

--- a/src/ringct/rctOps.h
+++ b/src/ringct/rctOps.h
@@ -147,6 +147,12 @@ namespace rct {
     //B must be input after applying "precomp"
     void addKeys3(key &aAbB, const key &a, const key &A, const key &b, const ge_dsmp B);
     void addKeys3(key &aAbB, const key &a, const ge_dsmp A, const key &b, const ge_dsmp B);
+    //aGbBcC = aG + bB + cC where a, b, c are scalars, G is the basepoint and
+    //B, C are curve points input after applying "precomp". CLSAG (HF14).
+    void addKeys_aGbBcC(key &aGbBcC, const key &a, const key &b, const ge_dsmp B, const key &c, const ge_dsmp C);
+    //aAbBcC = aA + bB + cC where a, b, c are scalars and A, B, C are curve
+    //points input after applying "precomp". CLSAG (HF14).
+    void addKeys_aAbBcC(key &aAbBcC, const key &a, const ge_dsmp A, const key &b, const ge_dsmp B, const key &c, const ge_dsmp C);
     //AB = A - B where A, B are curve points
     void subKeys(key &AB, const key &A, const  key &B);
     //checks if A, B are equal as curve points
@@ -175,10 +181,12 @@ namespace rct {
     key cn_fast_hash(const key64 keys);
     key hash_to_scalar(const key64 keys);
 
-    //returns hashToPoint as described in https://github.com/ShenNoether/ge_fromfe_writeup 
+    //returns hashToPoint as described in https://github.com/ShenNoether/ge_fromfe_writeup
     key hashToPointSimple(const key &in);
     key hashToPoint(const key &in);
     void hashToPoint(key &out, const key &in);
+    //hash a key to p3 representation, for CLSAG (HF14) key image bases
+    void hash_to_p3(ge_p3 &hash8_p3, const key &k);
 
     //sums a vector of curve points (for scalars use sc_add)
     void sumKeys(key & Csum, const key &Cis);

--- a/src/ringct/rctOps.h
+++ b/src/ringct/rctOps.h
@@ -128,6 +128,7 @@ namespace rct {
 	key scalarmultH_v2(const key & a);
 
 	key scalarmult8(const key & P);
+    void scalarmult8(ge_p3 &res, const key & P);
     bool isInMainSubgroup(const key & a);
 
     //Curve addition / subtractions

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -35,6 +35,8 @@
 #include "rctSigs.h"
 #include "bulletproofs.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
+#include "cryptonote_config.h"
+#include "device/device.hpp"
 
 using namespace crypto;
 using namespace std;
@@ -171,6 +173,143 @@ namespace rct {
       }
       return verifyBorromean(bb, P1_p3, P2_p3);
     }
+
+    // Generate a CLSAG signature
+    // See paper by Goodell et al. (https://eprint.iacr.org/2019/654)
+    //
+    // The keys are set as follows:
+    //   P[l] == p*G
+    //   C[l] == z*G
+    //   C[i] == C_nonzero[i] - C_offset (for hashing purposes) for all i
+    clsag CLSAG_Gen(const key &message, const keyV & P, const key & p, const keyV & C, const key & z, const keyV & C_nonzero, const key & C_offset, const unsigned int l, hw::device &hwdev) {
+        clsag sig;
+        size_t n = P.size(); // ring size
+        CHECK_AND_ASSERT_THROW_MES(n == C.size(), "Signing and commitment key vector sizes must match!");
+        CHECK_AND_ASSERT_THROW_MES(n == C_nonzero.size(), "Signing and commitment key vector sizes must match!");
+        CHECK_AND_ASSERT_THROW_MES(l < n, "Signing index out of range!");
+
+        // Key images
+        ge_p3 H_p3;
+        hash_to_p3(H_p3,P[l]);
+        key H;
+        ge_p3_tobytes(H.bytes,&H_p3);
+
+        key D;
+
+        // Initial values
+        key a;
+        key aG;
+        key aH;
+
+        hwdev.clsag_prepare(p,z,sig.I,D,H,a,aG,aH);
+
+        geDsmp I_precomp;
+        geDsmp D_precomp;
+        precomp(I_precomp.k,sig.I);
+        precomp(D_precomp.k,D);
+
+        // Offset key image
+        scalarmultKey(sig.D,D,INV_EIGHT);
+
+        // Aggregation hashes
+        keyV mu_P_to_hash(2*n+4); // domain, I, D, P, C, C_offset
+        keyV mu_C_to_hash(2*n+4); // domain, I, D, P, C, C_offset
+        sc_0(mu_P_to_hash[0].bytes);
+        memcpy(mu_P_to_hash[0].bytes,config::HASH_KEY_CLSAG_AGG_0,sizeof(config::HASH_KEY_CLSAG_AGG_0)-1);
+        sc_0(mu_C_to_hash[0].bytes);
+        memcpy(mu_C_to_hash[0].bytes,config::HASH_KEY_CLSAG_AGG_1,sizeof(config::HASH_KEY_CLSAG_AGG_1)-1);
+        for (size_t i = 1; i < n+1; ++i) {
+            mu_P_to_hash[i] = P[i-1];
+            mu_C_to_hash[i] = P[i-1];
+        }
+        for (size_t i = n+1; i < 2*n+1; ++i) {
+            mu_P_to_hash[i] = C_nonzero[i-n-1];
+            mu_C_to_hash[i] = C_nonzero[i-n-1];
+        }
+        mu_P_to_hash[2*n+1] = sig.I;
+        mu_P_to_hash[2*n+2] = sig.D;
+        mu_P_to_hash[2*n+3] = C_offset;
+        mu_C_to_hash[2*n+1] = sig.I;
+        mu_C_to_hash[2*n+2] = sig.D;
+        mu_C_to_hash[2*n+3] = C_offset;
+        key mu_P, mu_C;
+        mu_P = hash_to_scalar(mu_P_to_hash);
+        mu_C = hash_to_scalar(mu_C_to_hash);
+
+        // Initial commitment
+        keyV c_to_hash(2*n+5); // domain, P, C, C_offset, message, aG, aH
+        key c;
+        sc_0(c_to_hash[0].bytes);
+        memcpy(c_to_hash[0].bytes,config::HASH_KEY_CLSAG_ROUND,sizeof(config::HASH_KEY_CLSAG_ROUND)-1);
+        for (size_t i = 1; i < n+1; ++i)
+        {
+            c_to_hash[i] = P[i-1];
+            c_to_hash[i+n] = C_nonzero[i-1];
+        }
+        c_to_hash[2*n+1] = C_offset;
+        c_to_hash[2*n+2] = message;
+
+        c_to_hash[2*n+3] = aG;
+        c_to_hash[2*n+4] = aH;
+
+        hwdev.clsag_hash(c_to_hash,c);
+        
+        size_t i;
+        i = (l + 1) % n;
+        if (i == 0)
+            copy(sig.c1, c);
+
+        // Decoy indices
+        sig.s = keyV(n);
+        key c_new;
+        key L;
+        key R;
+        key c_p; // = c[i]*mu_P
+        key c_c; // = c[i]*mu_C
+        geDsmp P_precomp;
+        geDsmp C_precomp;
+        geDsmp H_precomp;
+        ge_p3 Hi_p3;
+
+        while (i != l) {
+            sig.s[i] = skGen();
+            sc_0(c_new.bytes);
+            sc_mul(c_p.bytes,mu_P.bytes,c.bytes);
+            sc_mul(c_c.bytes,mu_C.bytes,c.bytes);
+
+            // Precompute points
+            precomp(P_precomp.k,P[i]);
+            precomp(C_precomp.k,C[i]);
+
+            // Compute L
+            addKeys_aGbBcC(L,sig.s[i],c_p,P_precomp.k,c_c,C_precomp.k);
+
+            // Compute R
+            hash_to_p3(Hi_p3,P[i]);
+            ge_dsm_precomp(H_precomp.k, &Hi_p3);
+            addKeys_aAbBcC(R,sig.s[i],H_precomp.k,c_p,I_precomp.k,c_c,D_precomp.k);
+
+            c_to_hash[2*n+3] = L;
+            c_to_hash[2*n+4] = R;
+            hwdev.clsag_hash(c_to_hash,c_new);
+            copy(c,c_new);
+            
+            i = (i + 1) % n;
+            if (i == 0)
+                copy(sig.c1,c);
+        }
+
+        // Compute final scalar
+        hwdev.clsag_sign(c,a,p,z,mu_P,mu_C,sig.s[l]);
+        memwipe(&a, sizeof(key));
+
+        return sig;
+    }
+
+    clsag CLSAG_Gen(const key &message, const keyV & P, const key & p, const keyV & C, const key & z, const keyV & C_nonzero, const key & C_offset, const unsigned int l) {
+        return CLSAG_Gen(message, P, p, C, z, C_nonzero, C_offset, l, hw::get_device("default"));
+    }
+
 
     //Multilayered Spontaneous Anonymous Group Signatures (MLSAG signatures)
     //This is a just slghtly more efficient version than the ones described below
@@ -557,6 +696,36 @@ namespace rct {
         return result;
     }
 
+    clsag proveRctCLSAGSimple(const key &message, const ctkeyV &pubs, const ctkey &inSk, const key &a, const key &Cout, unsigned int index, hw::device &hwdev) {
+        //setup vars
+        size_t rows = 1;
+        size_t cols = pubs.size();
+        CHECK_AND_ASSERT_THROW_MES(cols >= 1, "Empty pubs");
+        keyV tmp(rows + 1);
+        keyV sk(rows + 1);
+        keyM M(cols, tmp);
+
+        keyV P, C, C_nonzero;
+        P.reserve(pubs.size());
+        C.reserve(pubs.size());
+        C_nonzero.reserve(pubs.size());
+        for (const ctkey &k: pubs)
+        {
+            P.push_back(k.dest);
+            C_nonzero.push_back(k.mask);
+            rct::key tmp;
+            subKeys(tmp, k.mask, Cout);
+            C.push_back(tmp);
+        }
+
+        sk[0] = copy(inSk.dest);
+        sc_sub(sk[1].bytes, inSk.mask.bytes, a.bytes);
+        clsag result = CLSAG_Gen(message, P, sk[0], C, sk[1], C_nonzero, Cout, index, hwdev);
+        memwipe(sk.data(), sk.size() * sizeof(key));
+        return result;
+    }
+
+
     //Ring-ct MG sigs
     //Prove: 
     //   c.f. https://eprint.iacr.org/2015/1098 section 4. definition 10. 
@@ -664,6 +833,121 @@ namespace rct {
         }
         catch (...) { return false; }
     }
+
+    bool verRctCLSAGSimple(const key &message, const clsag &sig, const ctkeyV & pubs, const key & C_offset) {
+        try
+        {
+            PERF_TIMER(verRctCLSAGSimple);
+            const size_t n = pubs.size();
+
+            // Check data
+            CHECK_AND_ASSERT_MES(n >= 1, false, "Empty pubs");
+            CHECK_AND_ASSERT_MES(n == sig.s.size(), false, "Signature scalar vector is the wrong size!");
+            for (size_t i = 0; i < n; ++i)
+                CHECK_AND_ASSERT_MES(sc_check(sig.s[i].bytes) == 0, false, "Bad signature scalar!");
+            CHECK_AND_ASSERT_MES(sc_check(sig.c1.bytes) == 0, false, "Bad signature commitment!");
+            CHECK_AND_ASSERT_MES(!(sig.I == rct::identity()), false, "Bad key image!");
+
+            // Cache commitment offset for efficient subtraction later
+            ge_p3 C_offset_p3;
+            CHECK_AND_ASSERT_MES(ge_frombytes_vartime(&C_offset_p3, C_offset.bytes) == 0, false, "point conv failed");
+            ge_cached C_offset_cached;
+            ge_p3_to_cached(&C_offset_cached, &C_offset_p3);
+
+            // Prepare key images
+            key c = copy(sig.c1);
+            key D_8 = scalarmult8(sig.D);
+            CHECK_AND_ASSERT_MES(!(D_8 == rct::identity()), false, "Bad auxiliary key image!");
+            geDsmp I_precomp;
+            geDsmp D_precomp;
+            precomp(I_precomp.k,sig.I);
+            precomp(D_precomp.k,D_8);
+
+            // Aggregation hashes
+            keyV mu_P_to_hash(2*n+4); // domain, I, D, P, C, C_offset
+            keyV mu_C_to_hash(2*n+4); // domain, I, D, P, C, C_offset
+            sc_0(mu_P_to_hash[0].bytes);
+            memcpy(mu_P_to_hash[0].bytes,config::HASH_KEY_CLSAG_AGG_0,sizeof(config::HASH_KEY_CLSAG_AGG_0)-1);
+            sc_0(mu_C_to_hash[0].bytes);
+            memcpy(mu_C_to_hash[0].bytes,config::HASH_KEY_CLSAG_AGG_1,sizeof(config::HASH_KEY_CLSAG_AGG_1)-1);
+            for (size_t i = 1; i < n+1; ++i) {
+                mu_P_to_hash[i] = pubs[i-1].dest;
+                mu_C_to_hash[i] = pubs[i-1].dest;
+            }
+            for (size_t i = n+1; i < 2*n+1; ++i) {
+                mu_P_to_hash[i] = pubs[i-n-1].mask;
+                mu_C_to_hash[i] = pubs[i-n-1].mask;
+            }
+            mu_P_to_hash[2*n+1] = sig.I;
+            mu_P_to_hash[2*n+2] = sig.D;
+            mu_P_to_hash[2*n+3] = C_offset;
+            mu_C_to_hash[2*n+1] = sig.I;
+            mu_C_to_hash[2*n+2] = sig.D;
+            mu_C_to_hash[2*n+3] = C_offset;
+            key mu_P, mu_C;
+            mu_P = hash_to_scalar(mu_P_to_hash);
+            mu_C = hash_to_scalar(mu_C_to_hash);
+
+            // Set up round hash
+            keyV c_to_hash(2*n+5); // domain, P, C, C_offset, message, L, R
+            sc_0(c_to_hash[0].bytes);
+            memcpy(c_to_hash[0].bytes,config::HASH_KEY_CLSAG_ROUND,sizeof(config::HASH_KEY_CLSAG_ROUND)-1);
+            for (size_t i = 1; i < n+1; ++i)
+            {
+                c_to_hash[i] = pubs[i-1].dest;
+                c_to_hash[i+n] = pubs[i-1].mask;
+            }
+            c_to_hash[2*n+1] = C_offset;
+            c_to_hash[2*n+2] = message;
+            key c_p; // = c[i]*mu_P
+            key c_c; // = c[i]*mu_C
+            key c_new;
+            key L;
+            key R;
+            geDsmp P_precomp;
+            geDsmp C_precomp;
+            size_t i = 0;
+            ge_p3 hash8_p3;
+            geDsmp hash_precomp;
+            ge_p3 temp_p3;
+            ge_p1p1 temp_p1;
+
+            while (i < n) {
+                sc_0(c_new.bytes);
+                sc_mul(c_p.bytes,mu_P.bytes,c.bytes);
+                sc_mul(c_c.bytes,mu_C.bytes,c.bytes);
+
+                // Precompute points for L/R
+                precomp(P_precomp.k,pubs[i].dest);
+
+                CHECK_AND_ASSERT_MES(ge_frombytes_vartime(&temp_p3, pubs[i].mask.bytes) == 0, false, "point conv failed");
+                ge_sub(&temp_p1,&temp_p3,&C_offset_cached);
+                ge_p1p1_to_p3(&temp_p3,&temp_p1);
+                ge_dsm_precomp(C_precomp.k,&temp_p3);
+
+                // Compute L
+                addKeys_aGbBcC(L,sig.s[i],c_p,P_precomp.k,c_c,C_precomp.k);
+
+                // Compute R
+                hash_to_p3(hash8_p3,pubs[i].dest);
+                ge_dsm_precomp(hash_precomp.k, &hash8_p3);
+                addKeys_aAbBcC(R,sig.s[i],hash_precomp.k,c_p,I_precomp.k,c_c,D_precomp.k);
+
+                c_to_hash[2*n+3] = L;
+                c_to_hash[2*n+4] = R;
+                c_new = hash_to_scalar(c_to_hash);
+                CHECK_AND_ASSERT_MES(!(c_new == rct::zero()), false, "Bad signature hash");
+                copy(c,c_new);
+
+                i = i + 1;
+            }
+            sc_sub(c_new.bytes,c.bytes,sig.c1.bytes);
+            return sc_isnonzero(c_new.bytes) == 0;
+        }
+        catch (...) { return false; }
+    }
+
+
 
     //These functions get keys from blockchain
     //replace these when connecting blockchain

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -34,6 +34,7 @@
 #include "common/util.h"
 #include "rctSigs.h"
 #include "bulletproofs.h"
+#include "bulletproofs_plus.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_config.h"
 #include "device/device.hpp"
@@ -78,6 +79,44 @@ namespace
 
         return rct::Bulletproof{rct::keyV(n_outs, I), I, I, I, I, I, I, rct::keyV(nrl, I), rct::keyV(nrl, I), I, I, I};
     }
+
+    rct::BulletproofPlus make_dummy_bulletproof_plus(const std::vector<uint64_t> &outamounts, rct::keyV &C, rct::keyV &masks)
+    {
+        const size_t n_outs = outamounts.size();
+        const rct::key I = rct::identity();
+        size_t nrl = 0;
+        while ((1u << nrl) < n_outs)
+          ++nrl;
+        nrl += 6;
+
+        C.resize(n_outs);
+        masks.resize(n_outs);
+        for (size_t i = 0; i < n_outs; ++i)
+        {
+            masks[i] = I;
+            rct::key sv8, sv;
+            sv = rct::zero();
+            sv.bytes[0] = outamounts[i] & 255;
+            sv.bytes[1] = (outamounts[i] >> 8) & 255;
+            sv.bytes[2] = (outamounts[i] >> 16) & 255;
+            sv.bytes[3] = (outamounts[i] >> 24) & 255;
+            sv.bytes[4] = (outamounts[i] >> 32) & 255;
+            sv.bytes[5] = (outamounts[i] >> 40) & 255;
+            sv.bytes[6] = (outamounts[i] >> 48) & 255;
+            sv.bytes[7] = (outamounts[i] >> 56) & 255;
+            sc_mul(sv8.bytes, sv.bytes, rct::INV_EIGHT.bytes);
+            rct::addKeys2(C[i], rct::INV_EIGHT, sv8, rct::H);
+        }
+
+        return rct::BulletproofPlus{rct::keyV(n_outs, I), I, I, I, I, I, I, rct::keyV(nrl, I), rct::keyV(nrl, I)};
+    }
+
+    rct::clsag make_dummy_clsag(size_t ring_size)
+    {
+        const rct::key I = rct::identity();
+        const size_t n_scalars = ring_size;
+        return rct::clsag{rct::keyV(n_scalars, I), I, I, I};
+    }
 }
 
 namespace rct {
@@ -112,6 +151,32 @@ namespace rct {
     bool verBulletproof(const std::vector<const Bulletproof*> &proofs)
     {
       try { return bulletproof_VERIFY_v2(proofs); }
+      // we can get deep throws from ge_frombytes_vartime if input isn't valid
+      catch (...) { return false; }
+    }
+
+    BulletproofPlus proveRangeBulletproofPlus(keyV &C, keyV &masks, const std::vector<uint64_t> &amounts, epee::span<const key> sk, hw::device &hwdev)
+    {
+        CHECK_AND_ASSERT_THROW_MES(amounts.size() == sk.size(), "Invalid amounts/sk sizes");
+        masks.resize(amounts.size());
+        for (size_t i = 0; i < masks.size(); ++i)
+            masks[i] = hwdev.genCommitmentMask(sk[i]);
+        BulletproofPlus proof = bulletproof_plus_PROVE(amounts, masks);
+        CHECK_AND_ASSERT_THROW_MES(proof.V.size() == amounts.size(), "V does not have the expected size");
+        C = proof.V;
+        return proof;
+    }
+
+    bool verBulletproofPlus(const BulletproofPlus &proof)
+    {
+      try { return bulletproof_plus_VERIFY(proof); }
+      // we can get deep throws from ge_frombytes_vartime if input isn't valid
+      catch (...) { return false; }
+    }
+
+    bool verBulletproofPlus(const std::vector<const BulletproofPlus*> &proofs)
+    {
+      try { return bulletproof_plus_VERIFY(proofs); }
       // we can get deep throws from ge_frombytes_vartime if input isn't valid
       catch (...) { return false; }
     }
@@ -567,9 +632,10 @@ namespace rct {
       hashes.push_back(hash2rct(h));
 
       keyV kv;
-      if (rv.type == RCTTypeBulletproof1Simple || 
+      if (rv.type == RCTTypeBulletproof1Simple ||
           rv.type == RCTTypeBulletproof1Full ||
-          rv.type == RCTTypeBulletproof2)
+          rv.type == RCTTypeBulletproof2 ||
+          rv.type == RCTTypeCLSAG)
       {
         kv.reserve((6*2+9) * rv.p.bulletproofs.size());
         for (const auto &p: rv.p.bulletproofs)
@@ -589,6 +655,25 @@ namespace rct {
           kv.push_back(p.a);
           kv.push_back(p.b);
           kv.push_back(p.t);
+        }
+      }
+      else if (rv.type == RCTTypeBulletproofPlus)
+      {
+        kv.reserve((6*2+6) * rv.p.bulletproofs_plus.size());
+        for (const auto &p: rv.p.bulletproofs_plus)
+        {
+          // V are not hashed as they're expanded from outPk.mask
+          // (and thus hashed as part of rctSigBase above)
+          kv.push_back(p.A);
+          kv.push_back(p.A1);
+          kv.push_back(p.B);
+          kv.push_back(p.r1);
+          kv.push_back(p.s1);
+          kv.push_back(p.d1);
+          for (size_t n = 0; n < p.L.size(); ++n)
+            kv.push_back(p.L[n]);
+          for (size_t n = 0; n < p.R.size(); ++n)
+            kv.push_back(p.R[n]);
         }
       }
       else
@@ -1074,12 +1159,27 @@ namespace rct {
       xmr_amount txnFee, const ctkeyM & mixRing, const keyV &amount_keys, const std::vector<multisig_kLRki> *kLRki, multisig_out *msout, 
       const std::vector<unsigned int> & index, ctkeyV &outSk, const RCTConfig &rct_config, hw::device &hwdev)
     {
-      const bool v2 = (rct_config.range_proof_type != RangeProofBorromean && rct_config.is_v2);
-
-      if (v2)
-        return genRctSimple_v2(message, inSk, destinations, inamounts, outamounts, txnFee, mixRing, amount_keys, kLRki, msout, index, outSk, rct_config, hwdev);
-      else
+      if (rct_config.range_proof_type == RangeProofBorromean)
         return genRctSimple_v1(message, inSk, destinations, inamounts, outamounts, txnFee, mixRing, amount_keys, kLRki, msout, index, outSk, rct_config, hwdev);
+
+      // Monero master's bp_version selection: 0 = latest, 4 = BP+ with CLSAG,
+      // 3 = BP with CLSAG, 2 = BP v2 with MLSAG, 1 = BP v1 with MLSAG. The
+      // v1/v2 generators keep Nerva's pre-HF14 shapes; v3 is Monero master's
+      // generator for the CLSAG types (multisig excluded with CLSAG).
+      switch (rct_config.bp_version)
+      {
+        case 0:
+        case 4:
+        case 3:
+          CHECK_AND_ASSERT_THROW_MES(!kLRki && !msout, "Multisig is not supported with CLSAG signatures");
+          return genRctSimple_v3(message, inSk, destinations, inamounts, outamounts, txnFee, mixRing, amount_keys, index, outSk, rct_config, hwdev);
+        case 2:
+          return genRctSimple_v2(message, inSk, destinations, inamounts, outamounts, txnFee, mixRing, amount_keys, kLRki, msout, index, outSk, rct_config, hwdev);
+        case 1:
+          return genRctSimple_v1(message, inSk, destinations, inamounts, outamounts, txnFee, mixRing, amount_keys, kLRki, msout, index, outSk, rct_config, hwdev);
+        default:
+          ASSERT_MES_AND_THROW("Unsupported BP version: " << rct_config.bp_version);
+      }
     }
 
     rctSig genRctSimple_v1(const key &message, const ctkeyV & inSk, const keyV & destinations, const vector<xmr_amount> &inamounts, const vector<xmr_amount> &outamounts,
@@ -1308,6 +1408,140 @@ namespace rct {
         return rv;
     }
 
+    // HF14 generator for the CLSAG types (6 with Bulletproofs, 7 with
+    // Bulletproofs+), Monero master's genRctSimple. The pre-CLSAG bp_versions
+    // stay with genRctSimple_v1/_v2 above, and multisig is excluded with
+    // CLSAG, so this only accepts bp_version 0, 3 and 4.
+    rctSig genRctSimple_v3(const key &message, const ctkeyV & inSk, const keyV & destinations, const vector<xmr_amount> &inamounts, const vector<xmr_amount> &outamounts,
+      xmr_amount txnFee, const ctkeyM & mixRing, const keyV &amount_keys, const std::vector<unsigned int> & index,
+      ctkeyV &outSk, const RCTConfig &rct_config, hw::device &hwdev)
+    {
+        const bool bulletproof_or_plus = rct_config.range_proof_type > RangeProofBorromean;
+        CHECK_AND_ASSERT_THROW_MES(bulletproof_or_plus, "genRctSimple_v3 called without a bulletproof range proof type");
+        CHECK_AND_ASSERT_THROW_MES(inamounts.size() > 0, "Empty inamounts");
+        CHECK_AND_ASSERT_THROW_MES(inamounts.size() == inSk.size(), "Different number of inamounts/inSk");
+        CHECK_AND_ASSERT_THROW_MES(outamounts.size() == destinations.size(), "Different number of amounts/destinations");
+        CHECK_AND_ASSERT_THROW_MES(amount_keys.size() == destinations.size(), "Different number of amount_keys/destinations");
+        CHECK_AND_ASSERT_THROW_MES(index.size() == inSk.size(), "Different number of index/inSk");
+        CHECK_AND_ASSERT_THROW_MES(mixRing.size() == inSk.size(), "Different number of mixRing/inSk");
+        for (size_t n = 0; n < mixRing.size(); ++n) {
+          CHECK_AND_ASSERT_THROW_MES(index[n] < mixRing[n].size(), "Bad index into mixRing");
+        }
+
+        rctSig rv;
+        switch (rct_config.bp_version)
+        {
+          case 0:
+          case 4:
+            rv.type = RCTTypeBulletproofPlus;
+            break;
+          case 3:
+            rv.type = RCTTypeCLSAG;
+            break;
+          default:
+            ASSERT_MES_AND_THROW("Unsupported BP version: " << rct_config.bp_version);
+        }
+
+        rv.message = message;
+        rv.outPk.resize(destinations.size());
+        rv.ecdhInfo.resize(destinations.size());
+
+        size_t i;
+        keyV masks(destinations.size()); //sk mask..
+        outSk.resize(destinations.size());
+        for (i = 0; i < destinations.size(); i++) {
+            //add destination to sig
+            rv.outPk[i].dest = copy(destinations[i]);
+        }
+
+        rv.p.bulletproofs.clear();
+        rv.p.bulletproofs_plus.clear();
+        {
+            const bool plus = is_rct_bulletproof_plus(rv.type);
+            CHECK_AND_ASSERT_THROW_MES(rct_config.range_proof_type == rct::RangeProofPaddedBulletproof,
+                "Unsupported range proof type: " << rct_config.range_proof_type);
+            {
+                rct::keyV C, masks;
+                if (hwdev.get_mode() == hw::device::TRANSACTION_CREATE_FAKE)
+                {
+                    // use a fake bulletproof for speed
+                    if (plus)
+                      rv.p.bulletproofs_plus.push_back(make_dummy_bulletproof_plus(outamounts, C, masks));
+                    else
+                      rv.p.bulletproofs.push_back(make_dummy_bulletproof(outamounts, C, masks));
+                }
+                else
+                {
+                    const epee::span<const key> keys{&amount_keys[0], amount_keys.size()};
+                    if (plus)
+                      rv.p.bulletproofs_plus.push_back(proveRangeBulletproofPlus(C, masks, outamounts, keys, hwdev));
+                    else
+                      rv.p.bulletproofs.push_back(proveRangeBulletproof(C, masks, outamounts, keys, hwdev));
+                    #ifdef DBG
+                    if (plus)
+                      CHECK_AND_ASSERT_THROW_MES(verBulletproofPlus(rv.p.bulletproofs_plus.back()), "verBulletproofPlus failed on newly created proof");
+                    else
+                      CHECK_AND_ASSERT_THROW_MES(verBulletproof(rv.p.bulletproofs.back(), true), "verBulletproof failed on newly created proof");
+                    #endif
+                }
+                for (i = 0; i < outamounts.size(); ++i)
+                {
+                    rv.outPk[i].mask = rct::scalarmult8(C[i]);
+                    outSk[i].mask = masks[i];
+                }
+            }
+        }
+
+        key sumout = zero();
+        for (i = 0; i < outSk.size(); ++i)
+        {
+            sc_add(sumout.bytes, outSk[i].mask.bytes, sumout.bytes);
+
+            //mask amount and mask
+            rv.ecdhInfo[i].mask = copy(outSk[i].mask);
+            rv.ecdhInfo[i].amount = d2h(outamounts[i]);
+            hwdev.ecdhEncode(rv.ecdhInfo[i], amount_keys[i], rv.type == RCTTypeBulletproof2 || rv.type == RCTTypeCLSAG || rv.type == RCTTypeBulletproofPlus);
+        }
+
+        //set txn fee
+        rv.txnFee = txnFee;
+        rv.mixRing = mixRing;
+        keyV &pseudoOuts = rv.p.pseudoOuts;
+        pseudoOuts.resize(inamounts.size());
+        if (is_rct_clsag(rv.type))
+            rv.p.CLSAGs.resize(inamounts.size());
+        else
+            rv.p.MGs.resize(inamounts.size());
+        key sumpouts = zero(); //sum pseudoOut masks
+        keyV a(inamounts.size());
+        for (i = 0 ; i < inamounts.size() - 1; i++) {
+            skGen(a[i]);
+            sc_add(sumpouts.bytes, a[i].bytes, sumpouts.bytes);
+            genC_v2(pseudoOuts[i], a[i], inamounts[i]);
+        }
+        sc_sub(a[i].bytes, sumout.bytes, sumpouts.bytes);
+        genC_v2(pseudoOuts[i], a[i], inamounts[i]);
+        DP(pseudoOuts[i]);
+
+        key full_message = get_pre_mlsag_hash(rv,hwdev);
+
+        for (i = 0 ; i < inamounts.size(); i++)
+        {
+            if (is_rct_clsag(rv.type))
+            {
+                if (hwdev.get_mode() == hw::device::TRANSACTION_CREATE_FAKE)
+                    rv.p.CLSAGs[i] = make_dummy_clsag(rv.mixRing[i].size());
+                else
+                    rv.p.CLSAGs[i] = proveRctCLSAGSimple(full_message, rv.mixRing[i], inSk[i], a[i], pseudoOuts[i], index[i], hwdev);
+            }
+            else
+            {
+                rv.p.MGs[i] = proveRctMGSimple(full_message, rv.mixRing[i], inSk[i], a[i], pseudoOuts[i], NULL, NULL, index[i], hwdev);
+            }
+        }
+        return rv;
+    }
+
     bool verRct(const rctSig & rv, bool semantics) {
         PERF_TIMER(verRct);
         CHECK_AND_ASSERT_MES(rv.type == RCTTypeFull || rv.type == RCTTypeBulletproof1Full, false, "verRct called on non-full rctSig");
@@ -1467,19 +1701,33 @@ namespace rct {
         tools::threadpool::waiter waiter;
         std::deque<bool> results;
         std::vector<const Bulletproof*> proofs;
+        std::vector<const BulletproofPlus*> proofs_plus;
         size_t max_non_bp_proofs = 0, offset = 0;
 
         for (const rctSig *rvp: rvv)
         {
           CHECK_AND_ASSERT_MES(rvp, false, "rctSig pointer is NULL");
           const rctSig &rv = *rvp;
-          CHECK_AND_ASSERT_MES(rv.type == RCTTypeSimple || rv.type == RCTTypeBulletproof2,
+          CHECK_AND_ASSERT_MES(rv.type == RCTTypeSimple || rv.type == RCTTypeBulletproof2 || rv.type == RCTTypeCLSAG || rv.type == RCTTypeBulletproofPlus,
               false, "verRctSemanticsSimple called on non simple rctSig");
           const bool bulletproof = is_rct_bulletproof(rv.type);
-          if (bulletproof)
+          const bool bulletproof_plus = is_rct_bulletproof_plus(rv.type);
+          if (bulletproof || bulletproof_plus)
           {
-            CHECK_AND_ASSERT_MES(rv.outPk.size() == n_bulletproof_amounts(rv.p.bulletproofs), false, "Mismatched sizes of outPk and bulletproofs");
-            CHECK_AND_ASSERT_MES(rv.p.pseudoOuts.size() == rv.p.MGs.size(), false, "Mismatched sizes of rv.p.pseudoOuts and rv.p.MGs");
+            if (bulletproof_plus)
+              CHECK_AND_ASSERT_MES(rv.outPk.size() == n_bulletproof_plus_amounts(rv.p.bulletproofs_plus), false, "Mismatched sizes of outPk and bulletproofs_plus");
+            else
+              CHECK_AND_ASSERT_MES(rv.outPk.size() == n_bulletproof_amounts(rv.p.bulletproofs), false, "Mismatched sizes of outPk and bulletproofs");
+            if (is_rct_clsag(rv.type))
+            {
+              CHECK_AND_ASSERT_MES(rv.p.MGs.empty(), false, "MGs are not empty for CLSAG");
+              CHECK_AND_ASSERT_MES(rv.p.pseudoOuts.size() == rv.p.CLSAGs.size(), false, "Mismatched sizes of rv.p.pseudoOuts and rv.p.CLSAGs");
+            }
+            else
+            {
+              CHECK_AND_ASSERT_MES(rv.p.CLSAGs.empty(), false, "CLSAGs are not empty for MLSAG");
+              CHECK_AND_ASSERT_MES(rv.p.pseudoOuts.size() == rv.p.MGs.size(), false, "Mismatched sizes of rv.p.pseudoOuts and rv.p.MGs");
+            }
             CHECK_AND_ASSERT_MES(rv.pseudoOuts.empty(), false, "rv.pseudoOuts is not empty");
           }
           else
@@ -1490,7 +1738,7 @@ namespace rct {
           }
           CHECK_AND_ASSERT_MES(rv.outPk.size() == rv.ecdhInfo.size(), false, "Mismatched sizes of outPk and rv.ecdhInfo");
 
-          if (!bulletproof)
+          if (!bulletproof && !bulletproof_plus)
             max_non_bp_proofs += rv.p.rangeSigs.size();
         }
 
@@ -1500,7 +1748,8 @@ namespace rct {
           const rctSig &rv = *rvp;
 
           const bool bulletproof = is_rct_bulletproof(rv.type);
-          const keyV &pseudoOuts = bulletproof ? rv.p.pseudoOuts : rv.pseudoOuts;
+          const bool bulletproof_plus = is_rct_bulletproof_plus(rv.type);
+          const keyV &pseudoOuts = bulletproof || bulletproof_plus ? rv.p.pseudoOuts : rv.pseudoOuts;
 
           rct::keyV masks(rv.outPk.size());
           for (size_t i = 0; i < rv.outPk.size(); i++) {
@@ -1520,7 +1769,12 @@ namespace rct {
             return false;
           }
 
-          if (bulletproof)
+          if (bulletproof_plus)
+          {
+            for (size_t i = 0; i < rv.p.bulletproofs_plus.size(); i++)
+              proofs_plus.push_back(&rv.p.bulletproofs_plus[i]);
+          }
+          else if (bulletproof)
           {
             for (size_t i = 0; i < rv.p.bulletproofs.size(); i++)
               proofs.push_back(&rv.p.bulletproofs[i]);
@@ -1531,6 +1785,11 @@ namespace rct {
               tpool.submit(&waiter, [&, i, offset] { results[i+offset] = verRange(rv.outPk[i].mask, rv.p.rangeSigs[i]); });
             offset += rv.p.rangeSigs.size();
           }
+        }
+        if (!proofs_plus.empty() && !verBulletproofPlus(proofs_plus))
+        {
+          LOG_PRINT_L1("Aggregate range proof verified failed");
+          return false;
         }
         if (!proofs.empty() && !verBulletproof(proofs))
         {
@@ -1625,11 +1884,12 @@ namespace rct {
       {
         PERF_TIMER(verRctNonSemanticsSimple);
 
-        CHECK_AND_ASSERT_MES(rv.type == RCTTypeSimple || rv.type == RCTTypeBulletproof2,
+        CHECK_AND_ASSERT_MES(rv.type == RCTTypeSimple || rv.type == RCTTypeBulletproof2 || rv.type == RCTTypeCLSAG || rv.type == RCTTypeBulletproofPlus,
             false, "verRctNonSemanticsSimple called on non simple rctSig");
         const bool bulletproof = is_rct_bulletproof(rv.type);
+        const bool bulletproof_plus = is_rct_bulletproof_plus(rv.type);
         // semantics check is early, and mixRing/MGs aren't resolved yet
-        if (bulletproof)
+        if (bulletproof || bulletproof_plus)
           CHECK_AND_ASSERT_MES(rv.p.pseudoOuts.size() == rv.mixRing.size(), false, "Mismatched sizes of rv.p.pseudoOuts and mixRing");
         else
           CHECK_AND_ASSERT_MES(rv.pseudoOuts.size() == rv.mixRing.size(), false, "Mismatched sizes of rv.pseudoOuts and mixRing");
@@ -1640,7 +1900,7 @@ namespace rct {
         tools::threadpool& tpool = tools::threadpool::getInstance();
         tools::threadpool::waiter waiter;
 
-        const keyV &pseudoOuts = bulletproof ? rv.p.pseudoOuts : rv.pseudoOuts;
+        const keyV &pseudoOuts = bulletproof || bulletproof_plus ? rv.p.pseudoOuts : rv.pseudoOuts;
 
         const key message = get_pre_mlsag_hash(rv, hw::get_device("default"));
 
@@ -1648,14 +1908,17 @@ namespace rct {
         results.resize(rv.mixRing.size());
         for (size_t i = 0 ; i < rv.mixRing.size() ; i++) {
           tpool.submit(&waiter, [&, i] {
-              results[i] = verRctMGSimple_v2(message, rv.p.MGs[i], rv.mixRing[i], pseudoOuts[i]);
+              if (is_rct_clsag(rv.type))
+                  results[i] = verRctCLSAGSimple(message, rv.p.CLSAGs[i], rv.mixRing[i], pseudoOuts[i]);
+              else
+                  results[i] = verRctMGSimple_v2(message, rv.p.MGs[i], rv.mixRing[i], pseudoOuts[i]);
           });
         }
         waiter.wait(&tpool);
 
         for (size_t i = 0; i < results.size(); ++i) {
           if (!results[i]) {
-            LOG_PRINT_L1("verRctMGSimple_v2 failed for input " << i);
+            LOG_PRINT_L1("verRctMGSimple/verRctCLSAGSimple failed for input " << i);
             return false;
           }
         }
@@ -1716,13 +1979,13 @@ namespace rct {
     }
 
     xmr_amount decodeRctSimple(const rctSig & rv, const key & sk, unsigned int i, key &mask, hw::device &hwdev) {
-        CHECK_AND_ASSERT_MES(rv.type == RCTTypeSimple || rv.type == RCTTypeBulletproof1Simple || rv.type == RCTTypeBulletproof2, false, "decodeRct called on non simple rctSig");
+        CHECK_AND_ASSERT_MES(rv.type == RCTTypeSimple || rv.type == RCTTypeBulletproof1Simple || rv.type == RCTTypeBulletproof2 || rv.type == RCTTypeCLSAG || rv.type == RCTTypeBulletproofPlus, false, "decodeRct called on non simple rctSig");
         CHECK_AND_ASSERT_THROW_MES(i < rv.ecdhInfo.size(), "Bad index");
         CHECK_AND_ASSERT_THROW_MES(rv.outPk.size() == rv.ecdhInfo.size(), "Mismatched sizes of rv.outPk and rv.ecdhInfo");
 
         //mask amount and mask
         ecdhTuple ecdh_info = rv.ecdhInfo[i];
-        hwdev.ecdhDecode(ecdh_info, sk, rv.type == RCTTypeBulletproof2);
+        hwdev.ecdhDecode(ecdh_info, sk, rv.type == RCTTypeBulletproof2 || rv.type == RCTTypeCLSAG || rv.type == RCTTypeBulletproofPlus);
         mask = ecdh_info.mask;
         key amount = ecdh_info.amount;
         key C = rv.outPk[i].mask;

--- a/src/ringct/rctSigs.h
+++ b/src/ringct/rctSigs.h
@@ -137,8 +137,13 @@ namespace rct {
 	rctSig genRctSimple_v1(const key & message, const ctkeyV & inSk, const keyV & destinations, const std::vector<xmr_amount> & inamounts, const std::vector<xmr_amount> & outamounts, 
         xmr_amount txnFee, const ctkeyM & mixRing, const keyV &amount_keys, const std::vector<multisig_kLRki> *kLRki, multisig_out *msout, 
         const std::vector<unsigned int> & index, ctkeyV &outSk, const RCTConfig &rct_config, hw::device &hwdev);
-    rctSig genRctSimple_v2(const key & message, const ctkeyV & inSk, const keyV & destinations, const std::vector<xmr_amount> & inamounts, const std::vector<xmr_amount> & outamounts, 
-        xmr_amount txnFee, const ctkeyM & mixRing, const keyV &amount_keys, const std::vector<multisig_kLRki> *kLRki, multisig_out *msout, 
+    rctSig genRctSimple_v2(const key & message, const ctkeyV & inSk, const keyV & destinations, const std::vector<xmr_amount> & inamounts, const std::vector<xmr_amount> & outamounts,
+        xmr_amount txnFee, const ctkeyM & mixRing, const keyV &amount_keys, const std::vector<multisig_kLRki> *kLRki, multisig_out *msout,
+        const std::vector<unsigned int> & index, ctkeyV &outSk, const RCTConfig &rct_config, hw::device &hwdev);
+    // HF14: Monero master's generator for the CLSAG types (6 and 7); multisig
+    // is excluded with CLSAG so it takes no kLRki/msout
+    rctSig genRctSimple_v3(const key & message, const ctkeyV & inSk, const keyV & destinations, const std::vector<xmr_amount> & inamounts, const std::vector<xmr_amount> & outamounts,
+        xmr_amount txnFee, const ctkeyM & mixRing, const keyV &amount_keys,
         const std::vector<unsigned int> & index, ctkeyV &outSk, const RCTConfig &rct_config, hw::device &hwdev);
 
 	bool verRct(const rctSig & rv, bool semantics);

--- a/src/ringct/rctSigs.h
+++ b/src/ringct/rctSigs.h
@@ -77,6 +77,13 @@ namespace rct {
     mgSig MLSAG_Gen(const key &message, const keyM & pk, const keyV & xx, const multisig_kLRki *kLRki, key *mscout, const unsigned int index, size_t dsRows, hw::device &hwdev);
     bool MLSAG_Ver(const key &message, const keyM &pk, const mgSig &sig, size_t dsRows);
 
+    //CLSAG signatures (HF14, ported from Monero)
+    // c.f. https://eprint.iacr.org/2019/654
+    clsag CLSAG_Gen(const key &message, const keyV & P, const key & p, const keyV & C, const key & z, const keyV & C_nonzero, const key & C_offset, const unsigned int l, hw::device &hwdev);
+    clsag CLSAG_Gen(const key &message, const keyV & P, const key & p, const keyV & C, const key & z, const keyV & C_nonzero, const key & C_offset, const unsigned int l);
+    clsag proveRctCLSAGSimple(const key &, const ctkeyV &, const ctkey &, const key &, const key &, unsigned int, hw::device &);
+    bool verRctCLSAGSimple(const key &, const clsag &, const ctkeyV &, const key &);
+
     //proveRange and verRange
     //proveRange gives C, and mask such that \sumCi = C
     //   c.f. https://eprint.iacr.org/2015/1098 section 5.1

--- a/src/ringct/rctTypes.cpp
+++ b/src/ringct/rctTypes.cpp
@@ -217,6 +217,7 @@ namespace rct {
             case RCTTypeSimple:
             case RCTTypeBulletproof1Simple:
             case RCTTypeBulletproof2:
+            case RCTTypeCLSAG:
                 return true;
             default:
                 return false;
@@ -230,6 +231,18 @@ namespace rct {
             case RCTTypeBulletproof1Simple:
             case RCTTypeBulletproof1Full:
             case RCTTypeBulletproof2:
+            case RCTTypeCLSAG:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    bool is_rct_clsag(int type)
+    {
+        switch (type)
+        {
+            case RCTTypeCLSAG:
                 return true;
             default:
                 return false;

--- a/src/ringct/rctTypes.cpp
+++ b/src/ringct/rctTypes.cpp
@@ -218,6 +218,7 @@ namespace rct {
             case RCTTypeBulletproof1Simple:
             case RCTTypeBulletproof2:
             case RCTTypeCLSAG:
+            case RCTTypeBulletproofPlus:
                 return true;
             default:
                 return false;
@@ -238,11 +239,23 @@ namespace rct {
         }
     }
 
+    bool is_rct_bulletproof_plus(int type)
+    {
+        switch (type)
+        {
+            case RCTTypeBulletproofPlus:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     bool is_rct_clsag(int type)
     {
         switch (type)
         {
             case RCTTypeCLSAG:
+            case RCTTypeBulletproofPlus:
                 return true;
             default:
                 return false;
@@ -304,6 +317,57 @@ namespace rct {
         for (const Bulletproof &proof: proofs)
         {
             size_t n2 = n_bulletproof_max_amounts(proof);
+            CHECK_AND_ASSERT_MES(n2 < std::numeric_limits<uint32_t>::max() - n, 0, "Invalid number of bulletproofs");
+            if (n2 == 0)
+                return 0;
+            n += n2;
+        }
+        return n;
+    }
+
+    size_t n_bulletproof_plus_amounts(const BulletproofPlus &proof)
+    {
+        CHECK_AND_ASSERT_MES(proof.L.size() >= 6, 0, "Invalid bulletproof L size");
+        CHECK_AND_ASSERT_MES(proof.L.size() == proof.R.size(), 0, "Mismatched bulletproof L/R size");
+        static const size_t extra_bits = 4;
+        static_assert((1 << extra_bits) == BULLETPROOF_PLUS_MAX_OUTPUTS, "log2(BULLETPROOF_PLUS_MAX_OUTPUTS) is out of date");
+        CHECK_AND_ASSERT_MES(proof.L.size() <= 6 + extra_bits, 0, "Invalid bulletproof L size");
+        CHECK_AND_ASSERT_MES(proof.V.size() <= (1u<<(proof.L.size()-6)), 0, "Invalid bulletproof V/L");
+        CHECK_AND_ASSERT_MES(proof.V.size() * 2 > (1u<<(proof.L.size()-6)), 0, "Invalid bulletproof V/L");
+        CHECK_AND_ASSERT_MES(proof.V.size() > 0, 0, "Empty bulletproof");
+        return proof.V.size();
+    }
+
+    size_t n_bulletproof_plus_amounts(const std::vector<BulletproofPlus> &proofs)
+    {
+        size_t n = 0;
+        for (const BulletproofPlus &proof: proofs)
+        {
+            size_t n2 = n_bulletproof_plus_amounts(proof);
+            CHECK_AND_ASSERT_MES(n2 < std::numeric_limits<uint32_t>::max() - n, 0, "Invalid number of bulletproofs");
+            if (n2 == 0)
+                return 0;
+            n += n2;
+        }
+        return n;
+    }
+
+    size_t n_bulletproof_plus_max_amounts(const BulletproofPlus &proof)
+    {
+        CHECK_AND_ASSERT_MES(proof.L.size() >= 6, 0, "Invalid bulletproof L size");
+        CHECK_AND_ASSERT_MES(proof.L.size() == proof.R.size(), 0, "Mismatched bulletproof L/R size");
+        static const size_t extra_bits = 4;
+        static_assert((1 << extra_bits) == BULLETPROOF_PLUS_MAX_OUTPUTS, "log2(BULLETPROOF_PLUS_MAX_OUTPUTS) is out of date");
+        CHECK_AND_ASSERT_MES(proof.L.size() <= 6 + extra_bits, 0, "Invalid bulletproof L size");
+        return 1 << (proof.L.size() - 6);
+    }
+
+    size_t n_bulletproof_plus_max_amounts(const std::vector<BulletproofPlus> &proofs)
+    {
+        size_t n = 0;
+        for (const BulletproofPlus &proof: proofs)
+        {
+            size_t n2 = n_bulletproof_plus_max_amounts(proof);
             CHECK_AND_ASSERT_MES(n2 < std::numeric_limits<uint32_t>::max() - n, 0, "Invalid number of bulletproofs");
             if (n2 == 0)
                 return 0;

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -162,6 +162,23 @@ namespace rct {
             // FIELD(II) - not serialized, it can be reconstructed
         END_SERIALIZE()
     };
+
+    // CLSAG signature (HF14, ported from Monero)
+    // c.f. https://eprint.iacr.org/2019/654
+    struct clsag {
+        keyV s; // scalars
+        key c1;
+
+        key I; // signing key image
+        key D; // commitment key image
+
+        BEGIN_SERIALIZE_OBJECT()
+            FIELD(s)
+            FIELD(c1)
+            // FIELD(I) - not serialized, it can be reconstructed
+            FIELD(D)
+        END_SERIALIZE()
+    };
     //contains the data for an Borromean sig
     // also contains the "Ci" values such that
     // \sum Ci = C
@@ -233,7 +250,12 @@ namespace rct {
       RCTTypeSimple = 2,
       RCTTypeBulletproof1Full = 3,
       RCTTypeBulletproof1Simple = 4,
-      RCTTypeBulletproof2 = 5
+      RCTTypeBulletproof2 = 5,
+      // HF14: CLSAG ring signatures. Monero numbers this 5; Nerva's 5 was
+      // already taken by Bulletproof2 (the enums diverged after the fork),
+      // so it is 6 here. The type byte is consensus and serialized, it can
+      // never be renumbered.
+      RCTTypeCLSAG = 6
     };
     enum RangeProofType { RangeProofBorromean, RangeProofBulletproof, RangeProofMultiOutputBulletproof, RangeProofPaddedBulletproof };
     struct RCTConfig {
@@ -262,9 +284,9 @@ namespace rct {
           FIELD(type)
           if (type == RCTTypeNull)
             return ar.stream().good();
-          if (type != RCTTypeFull && type != RCTTypeSimple && 
-              type != RCTTypeBulletproof1Full && type != RCTTypeBulletproof1Simple && 
-              type != RCTTypeBulletproof2)
+          if (type != RCTTypeFull && type != RCTTypeSimple &&
+              type != RCTTypeBulletproof1Full && type != RCTTypeBulletproof1Simple &&
+              type != RCTTypeBulletproof2 && type != RCTTypeCLSAG)
             return false;
           VARINT_FIELD(txnFee)
           // inputs/outputs not saved, only here for serialization help
@@ -293,7 +315,7 @@ namespace rct {
             return false;
           for (size_t i = 0; i < outputs; ++i)
           {
-            if (type == RCTTypeBulletproof2)
+            if (type == RCTTypeBulletproof2 || type == RCTTypeCLSAG)
             {
               ar.begin_object();
               if (!typename Archive<W>::is_saving())
@@ -330,6 +352,7 @@ namespace rct {
         std::vector<rangeSig> rangeSigs;
         std::vector<Bulletproof> bulletproofs;
         std::vector<mgSig> MGs; // simple rct has N, full has 1
+        std::vector<clsag> CLSAGs; // HF14: replaces MGs from RCTTypeCLSAG on
         keyV pseudoOuts; //C - for simple rct
 
         template<bool W, template <bool> class Archive>
@@ -344,11 +367,11 @@ namespace rct {
             return false;
           if (type == RCTTypeNull)
             return ar.stream().good();
-          if (type != RCTTypeFull && type != RCTTypeSimple && 
+          if (type != RCTTypeFull && type != RCTTypeSimple &&
               type != RCTTypeBulletproof1Full && type != RCTTypeBulletproof1Simple &&
-              type != RCTTypeBulletproof2)
+              type != RCTTypeBulletproof2 && type != RCTTypeCLSAG)
             return false;
-          if (type == RCTTypeBulletproof2)
+          if (type == RCTTypeBulletproof2 || type == RCTTypeCLSAG)
           {
             uint32_t nbp = bulletproofs.size();
             VARINT_FIELD(nbp)
@@ -396,6 +419,61 @@ namespace rct {
                 ar.delimit_array();
             }
             ar.end_array();
+          }
+
+          if (type == RCTTypeCLSAG)
+          {
+            ar.tag("CLSAGs");
+            ar.begin_array();
+            PREPARE_CUSTOM_VECTOR_SERIALIZATION(inputs, CLSAGs);
+            if (CLSAGs.size() != inputs)
+              return false;
+            for (size_t i = 0; i < inputs; ++i)
+            {
+              // we save the CLSAGs contents directly, because we want it to save its
+              // arrays without the size prefixes, and the load can't know what size
+              // to expect if it's not in the data
+              ar.begin_object();
+              ar.tag("s");
+              ar.begin_array();
+              PREPARE_CUSTOM_VECTOR_SERIALIZATION(mixin + 1, CLSAGs[i].s);
+              if (CLSAGs[i].s.size() != mixin + 1)
+                return false;
+              for (size_t j = 0; j <= mixin; ++j)
+              {
+                FIELDS(CLSAGs[i].s[j])
+                if (mixin + 1 - j > 1)
+                  ar.delimit_array();
+              }
+              ar.end_array();
+
+              ar.tag("c1");
+              FIELDS(CLSAGs[i].c1)
+
+              // CLSAGs[i].I not saved, it can be reconstructed
+              ar.tag("D");
+              FIELDS(CLSAGs[i].D)
+              ar.end_object();
+
+              if (inputs - i > 1)
+                 ar.delimit_array();
+            }
+
+            ar.end_array();
+
+            ar.tag("pseudoOuts");
+            ar.begin_array();
+            PREPARE_CUSTOM_VECTOR_SERIALIZATION(inputs, pseudoOuts);
+            if (pseudoOuts.size() != inputs)
+              return false;
+            for (size_t i = 0; i < inputs; ++i)
+            {
+              FIELDS(pseudoOuts[i])
+              if (inputs - i > 1)
+                ar.delimit_array();
+            }
+            ar.end_array();
+            return ar.stream().good();
           }
 
           ar.tag("MGs");
@@ -469,12 +547,12 @@ namespace rct {
         rctSigPrunable p;
         keyV& get_pseudo_outs()
         {
-          return type == RCTTypeBulletproof1Full || type == RCTTypeBulletproof1Simple || type == RCTTypeBulletproof2 ? p.pseudoOuts : pseudoOuts;
+          return type == RCTTypeBulletproof1Full || type == RCTTypeBulletproof1Simple || type == RCTTypeBulletproof2 || type == RCTTypeCLSAG ? p.pseudoOuts : pseudoOuts;
         }
 
         keyV const& get_pseudo_outs() const
         {
-          return type == RCTTypeBulletproof1Full || type == RCTTypeBulletproof1Simple || type == RCTTypeBulletproof2 ? p.pseudoOuts : pseudoOuts;
+          return type == RCTTypeBulletproof1Full || type == RCTTypeBulletproof1Simple || type == RCTTypeBulletproof2 || type == RCTTypeCLSAG ? p.pseudoOuts : pseudoOuts;
         }
     };
 
@@ -582,6 +660,7 @@ namespace rct {
     bool is_rct_simple(int type);
     bool is_rct_bulletproof(int type);
     bool is_rct_borromean(int type);
+    bool is_rct_clsag(int type);
 
     static inline const rct::key &pk2rct(const crypto::public_key &pk) { return (const rct::key&)pk; }
     static inline const rct::key &sk2rct(const crypto::secret_key &sk) { return (const rct::key&)sk; }
@@ -630,6 +709,7 @@ VARIANT_TAG(debug_archive, rct::ctkeyV, "rct::ctkeyV");
 VARIANT_TAG(debug_archive, rct::ctkeyM, "rct::ctkeyM");
 VARIANT_TAG(debug_archive, rct::ecdhTuple, "rct::ecdhTuple");
 VARIANT_TAG(debug_archive, rct::mgSig, "rct::mgSig");
+VARIANT_TAG(debug_archive, rct::clsag, "rct::clsag");
 VARIANT_TAG(debug_archive, rct::rangeSig, "rct::rangeSig");
 VARIANT_TAG(debug_archive, rct::boroSig, "rct::boroSig");
 VARIANT_TAG(debug_archive, rct::rctSig, "rct::rctSig");
@@ -652,6 +732,7 @@ VARIANT_TAG(binary_archive, rct::rctSig, 0x9b);
 VARIANT_TAG(binary_archive, rct::Bulletproof, 0x9c);
 VARIANT_TAG(binary_archive, rct::multisig_kLRki, 0x9d);
 VARIANT_TAG(binary_archive, rct::multisig_out, 0x9e);
+VARIANT_TAG(binary_archive, rct::clsag, 0x9f);
 
 VARIANT_TAG(json_archive, rct::key, "rct_key");
 VARIANT_TAG(json_archive, rct::key64, "rct_key64");
@@ -668,5 +749,6 @@ VARIANT_TAG(json_archive, rct::rctSig, "rct_rctSig");
 VARIANT_TAG(json_archive, rct::Bulletproof, "rct_bulletproof");
 VARIANT_TAG(json_archive, rct::multisig_kLRki, "rct_multisig_kLR");
 VARIANT_TAG(json_archive, rct::multisig_out, "rct_multisig_out");
+VARIANT_TAG(json_archive, rct::clsag, "rct_clsag");
 
 #endif  /* RCTTYPES_H */

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -237,6 +237,45 @@ namespace rct {
     size_t n_bulletproof_amounts(const std::vector<Bulletproof> &proofs);
     size_t n_bulletproof_max_amounts(const std::vector<Bulletproof> &proofs);
 
+    // Bulletproofs+ range proofs (HF14, ported from Monero)
+    // Preprint: https://eprint.iacr.org/2020/735
+    struct BulletproofPlus
+    {
+      rct::keyV V;
+      rct::key A, A1, B;
+      rct::key r1, s1, d1;
+      rct::keyV L, R;
+
+      BulletproofPlus(): V(), A(), A1(), B(), r1(), s1(), d1(), L(), R() {}
+      BulletproofPlus(const rct::key &V, const rct::key &A, const rct::key &A1, const rct::key &B, const rct::key &r1, const rct::key &s1, const rct::key &d1, const rct::keyV &L, const rct::keyV &R):
+        V({V}), A(A), A1(A1), B(B), r1(r1), s1(s1), d1(d1), L(L), R(R) {}
+      BulletproofPlus(const rct::keyV &V, const rct::key &A, const rct::key &A1, const rct::key &B, const rct::key &r1, const rct::key &s1, const rct::key &d1, const rct::keyV &L, const rct::keyV &R):
+        V(V), A(A), A1(A1), B(B), r1(r1), s1(s1), d1(d1), L(L), R(R) {}
+
+      bool operator==(const BulletproofPlus &other) const { return V == other.V && A == other.A && A1 == other.A1 && B == other.B && r1 == other.r1 && s1 == other.s1 && d1 == other.d1 && L == other.L && R == other.R; }
+
+      BEGIN_SERIALIZE_OBJECT()
+        // Commitments aren't saved, they're restored via outPk
+        // FIELD(V)
+        FIELD(A)
+        FIELD(A1)
+        FIELD(B)
+        FIELD(r1)
+        FIELD(s1)
+        FIELD(d1)
+        FIELD(L)
+        FIELD(R)
+
+        if (L.empty() || L.size() != R.size())
+          return false;
+      END_SERIALIZE()
+    };
+
+    size_t n_bulletproof_plus_amounts(const BulletproofPlus &proof);
+    size_t n_bulletproof_plus_max_amounts(const BulletproofPlus &proof);
+    size_t n_bulletproof_plus_amounts(const std::vector<BulletproofPlus> &proofs);
+    size_t n_bulletproof_plus_max_amounts(const std::vector<BulletproofPlus> &proofs);
+
     //A container to hold all signatures necessary for RingCT
     // rangeSigs holds all the rangeproof data of a transaction
     // MG holds the MLSAG signature of a transaction
@@ -255,7 +294,10 @@ namespace rct {
       // already taken by Bulletproof2 (the enums diverged after the fork),
       // so it is 6 here. The type byte is consensus and serialized, it can
       // never be renumbered.
-      RCTTypeCLSAG = 6
+      RCTTypeCLSAG = 6,
+      // HF14: CLSAG with Bulletproofs+ range proofs (Monero's 6 is our 7,
+      // same renumbering reason as CLSAG)
+      RCTTypeBulletproofPlus = 7
     };
     enum RangeProofType { RangeProofBorromean, RangeProofBulletproof, RangeProofMultiOutputBulletproof, RangeProofPaddedBulletproof };
     struct RCTConfig {
@@ -286,7 +328,7 @@ namespace rct {
             return ar.stream().good();
           if (type != RCTTypeFull && type != RCTTypeSimple &&
               type != RCTTypeBulletproof1Full && type != RCTTypeBulletproof1Simple &&
-              type != RCTTypeBulletproof2 && type != RCTTypeCLSAG)
+              type != RCTTypeBulletproof2 && type != RCTTypeCLSAG && type != RCTTypeBulletproofPlus)
             return false;
           VARINT_FIELD(txnFee)
           // inputs/outputs not saved, only here for serialization help
@@ -315,7 +357,7 @@ namespace rct {
             return false;
           for (size_t i = 0; i < outputs; ++i)
           {
-            if (type == RCTTypeBulletproof2 || type == RCTTypeCLSAG)
+            if (type == RCTTypeBulletproof2 || type == RCTTypeCLSAG || type == RCTTypeBulletproofPlus)
             {
               ar.begin_object();
               if (!typename Archive<W>::is_saving())
@@ -353,6 +395,7 @@ namespace rct {
         std::vector<Bulletproof> bulletproofs;
         std::vector<mgSig> MGs; // simple rct has N, full has 1
         std::vector<clsag> CLSAGs; // HF14: replaces MGs from RCTTypeCLSAG on
+        std::vector<BulletproofPlus> bulletproofs_plus; // HF14
         keyV pseudoOuts; //C - for simple rct
 
         template<bool W, template <bool> class Archive>
@@ -369,9 +412,28 @@ namespace rct {
             return ar.stream().good();
           if (type != RCTTypeFull && type != RCTTypeSimple &&
               type != RCTTypeBulletproof1Full && type != RCTTypeBulletproof1Simple &&
-              type != RCTTypeBulletproof2 && type != RCTTypeCLSAG)
+              type != RCTTypeBulletproof2 && type != RCTTypeCLSAG && type != RCTTypeBulletproofPlus)
             return false;
-          if (type == RCTTypeBulletproof2 || type == RCTTypeCLSAG)
+          if (type == RCTTypeBulletproofPlus)
+          {
+            uint32_t nbp = bulletproofs_plus.size();
+            VARINT_FIELD(nbp)
+            ar.tag("bpp");
+            ar.begin_array();
+            if (nbp > outputs)
+              return false;
+            PREPARE_CUSTOM_VECTOR_SERIALIZATION(nbp, bulletproofs_plus);
+            for (size_t i = 0; i < nbp; ++i)
+            {
+              FIELDS(bulletproofs_plus[i])
+              if (nbp - i > 1)
+                ar.delimit_array();
+            }
+            if (n_bulletproof_plus_max_amounts(bulletproofs_plus) < outputs)
+              return false;
+            ar.end_array();
+          }
+          else if (type == RCTTypeBulletproof2 || type == RCTTypeCLSAG)
           {
             uint32_t nbp = bulletproofs.size();
             VARINT_FIELD(nbp)
@@ -421,7 +483,7 @@ namespace rct {
             ar.end_array();
           }
 
-          if (type == RCTTypeCLSAG)
+          if (type == RCTTypeCLSAG || type == RCTTypeBulletproofPlus)
           {
             ar.tag("CLSAGs");
             ar.begin_array();
@@ -547,12 +609,12 @@ namespace rct {
         rctSigPrunable p;
         keyV& get_pseudo_outs()
         {
-          return type == RCTTypeBulletproof1Full || type == RCTTypeBulletproof1Simple || type == RCTTypeBulletproof2 || type == RCTTypeCLSAG ? p.pseudoOuts : pseudoOuts;
+          return type == RCTTypeBulletproof1Full || type == RCTTypeBulletproof1Simple || type == RCTTypeBulletproof2 || type == RCTTypeCLSAG || type == RCTTypeBulletproofPlus ? p.pseudoOuts : pseudoOuts;
         }
 
         keyV const& get_pseudo_outs() const
         {
-          return type == RCTTypeBulletproof1Full || type == RCTTypeBulletproof1Simple || type == RCTTypeBulletproof2 || type == RCTTypeCLSAG ? p.pseudoOuts : pseudoOuts;
+          return type == RCTTypeBulletproof1Full || type == RCTTypeBulletproof1Simple || type == RCTTypeBulletproof2 || type == RCTTypeCLSAG || type == RCTTypeBulletproofPlus ? p.pseudoOuts : pseudoOuts;
         }
     };
 
@@ -659,6 +721,7 @@ namespace rct {
 
     bool is_rct_simple(int type);
     bool is_rct_bulletproof(int type);
+    bool is_rct_bulletproof_plus(int type);
     bool is_rct_borromean(int type);
     bool is_rct_clsag(int type);
 
@@ -710,6 +773,7 @@ VARIANT_TAG(debug_archive, rct::ctkeyM, "rct::ctkeyM");
 VARIANT_TAG(debug_archive, rct::ecdhTuple, "rct::ecdhTuple");
 VARIANT_TAG(debug_archive, rct::mgSig, "rct::mgSig");
 VARIANT_TAG(debug_archive, rct::clsag, "rct::clsag");
+VARIANT_TAG(debug_archive, rct::BulletproofPlus, "rct::bulletproof_plus");
 VARIANT_TAG(debug_archive, rct::rangeSig, "rct::rangeSig");
 VARIANT_TAG(debug_archive, rct::boroSig, "rct::boroSig");
 VARIANT_TAG(debug_archive, rct::rctSig, "rct::rctSig");
@@ -733,6 +797,7 @@ VARIANT_TAG(binary_archive, rct::Bulletproof, 0x9c);
 VARIANT_TAG(binary_archive, rct::multisig_kLRki, 0x9d);
 VARIANT_TAG(binary_archive, rct::multisig_out, 0x9e);
 VARIANT_TAG(binary_archive, rct::clsag, 0x9f);
+VARIANT_TAG(binary_archive, rct::BulletproofPlus, 0xa0);
 
 VARIANT_TAG(json_archive, rct::key, "rct_key");
 VARIANT_TAG(json_archive, rct::key64, "rct_key64");
@@ -750,5 +815,6 @@ VARIANT_TAG(json_archive, rct::Bulletproof, "rct_bulletproof");
 VARIANT_TAG(json_archive, rct::multisig_kLRki, "rct_multisig_kLR");
 VARIANT_TAG(json_archive, rct::multisig_out, "rct_multisig_out");
 VARIANT_TAG(json_archive, rct::clsag, "rct_clsag");
+VARIANT_TAG(json_archive, rct::BulletproofPlus, "rct_bulletproof_plus");
 
 #endif  /* RCTTYPES_H */

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -250,6 +250,12 @@ namespace rct {
         ctkeyV outPk;
         xmr_amount txnFee; // contains b
 
+        // never leave the consensus-relevant type byte uninitialized, as
+        // Monero master
+        rctSigBase() :
+          type(RCTTypeNull), message{}, mixRing{}, pseudoOuts{}, ecdhInfo{}, outPk{}, txnFee(0)
+        {}
+
         template<bool W, template <bool> class Archive>
         bool serialize_rctsig_base(Archive<W> &ar, size_t inputs, size_t outputs)
         {
@@ -329,6 +335,13 @@ namespace rct {
         template<bool W, template <bool> class Archive>
         bool serialize_rctsig_prunable(Archive<W> &ar, uint8_t type, size_t inputs, size_t outputs, size_t mixin)
         {
+          // overflow guards on the size arithmetic below, as Monero master
+          if (inputs >= 0xffffffff)
+            return false;
+          if (outputs >= 0xffffffff)
+            return false;
+          if (mixin >= 0xffffffff)
+            return false;
           if (type == RCTTypeNull)
             return ar.stream().good();
           if (type != RCTTypeFull && type != RCTTypeSimple && 

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -302,7 +302,10 @@ namespace rct {
     enum RangeProofType { RangeProofBorromean, RangeProofBulletproof, RangeProofMultiOutputBulletproof, RangeProofPaddedBulletproof };
     struct RCTConfig {
       RangeProofType range_proof_type;
-      bool is_v2;
+      // Monero master's field, replacing the old bool is_v2 at HF14:
+      // 0 = latest, 1 = BP v1 (MLSAG), 2 = BP v2 (MLSAG),
+      // 3 = BP with CLSAG, 4 = BP+ with CLSAG
+      int bp_version;
     };
     struct rctSigBase {
         uint8_t type;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -768,6 +768,8 @@ namespace cryptonote
                 case rct::RCTTypeSimple:
                 case rct::RCTTypeBulletproof1Simple:
                 case rct::RCTTypeBulletproof2:
+                case rct::RCTTypeCLSAG:
+                case rct::RCTTypeBulletproofPlus:
                   tx_amount = rct::decodeRctSimple(tx.rct_signatures, rct::sk2rct(scalar1), i, mask, hwdev);
                   break;
                 case rct::RCTTypeFull:

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -116,7 +116,10 @@ void read_hex(const rapidjson::Value& val, epee::span<std::uint8_t> dest)
     throw WRONG_TYPE("string");
   }
 
-  if (!epee::from_hex::to_buffer(dest, {val.GetString(), val.Size()}))
+  // GetStringLength, not Size: Size() is the array accessor and reads the
+  // wrong union member for strings (asserts in debug builds). Matches
+  // Monero master.
+  if (!epee::from_hex::to_buffer(dest, {val.GetString(), val.GetStringLength()}))
   {
     throw BAD_INPUT();
   }

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -1013,6 +1013,7 @@ void toJsonValue(rapidjson::Document& doc, const rct::rctSig& sig, rapidjson::Va
     INSERT_INTO_JSON_OBJECT(prunable, doc, bulletproofs, sig.p.bulletproofs);
     INSERT_INTO_JSON_OBJECT(prunable, doc, mlsags, sig.p.MGs);
     INSERT_INTO_JSON_OBJECT(prunable, doc, clsags, sig.p.CLSAGs);
+    INSERT_INTO_JSON_OBJECT(prunable, doc, bulletproofs_plus, sig.p.bulletproofs_plus);
     INSERT_INTO_JSON_OBJECT(prunable, doc, pseudo_outs, sig.get_pseudo_outs());
 
     val.AddMember("prunable", prunable, doc.GetAllocator());
@@ -1046,6 +1047,7 @@ void fromJsonValue(const rapidjson::Value& val, rct::rctSig& sig)
     GET_FROM_JSON_OBJECT(prunable, sig.p.bulletproofs, bulletproofs);
     GET_FROM_JSON_OBJECT(prunable, sig.p.MGs, mlsags);
     GET_FROM_JSON_OBJECT(prunable, sig.p.CLSAGs, clsags);
+    GET_FROM_JSON_OBJECT(prunable, sig.p.bulletproofs_plus, bulletproofs_plus);
     GET_FROM_JSON_OBJECT(prunable, pseudo_outs, pseudo_outs);
 
     sig.get_pseudo_outs() = std::move(pseudo_outs);
@@ -1151,6 +1153,39 @@ void fromJsonValue(const rapidjson::Value& val, rct::Bulletproof& p)
   GET_FROM_JSON_OBJECT(val, p.a, a);
   GET_FROM_JSON_OBJECT(val, p.b, b);
   GET_FROM_JSON_OBJECT(val, p.t, t);
+}
+
+void toJsonValue(rapidjson::Document& doc, const rct::BulletproofPlus& p, rapidjson::Value& val)
+{
+  val.SetObject();
+
+  INSERT_INTO_JSON_OBJECT(val, doc, V, p.V);
+  INSERT_INTO_JSON_OBJECT(val, doc, A, p.A);
+  INSERT_INTO_JSON_OBJECT(val, doc, A1, p.A1);
+  INSERT_INTO_JSON_OBJECT(val, doc, B, p.B);
+  INSERT_INTO_JSON_OBJECT(val, doc, r1, p.r1);
+  INSERT_INTO_JSON_OBJECT(val, doc, s1, p.s1);
+  INSERT_INTO_JSON_OBJECT(val, doc, d1, p.d1);
+  INSERT_INTO_JSON_OBJECT(val, doc, L, p.L);
+  INSERT_INTO_JSON_OBJECT(val, doc, R, p.R);
+}
+
+void fromJsonValue(const rapidjson::Value& val, rct::BulletproofPlus& p)
+{
+  if (!val.IsObject())
+  {
+    throw WRONG_TYPE("json object");
+  }
+
+  GET_FROM_JSON_OBJECT(val, p.V, V);
+  GET_FROM_JSON_OBJECT(val, p.A, A);
+  GET_FROM_JSON_OBJECT(val, p.A1, A1);
+  GET_FROM_JSON_OBJECT(val, p.B, B);
+  GET_FROM_JSON_OBJECT(val, p.r1, r1);
+  GET_FROM_JSON_OBJECT(val, p.s1, s1);
+  GET_FROM_JSON_OBJECT(val, p.d1, d1);
+  GET_FROM_JSON_OBJECT(val, p.L, L);
+  GET_FROM_JSON_OBJECT(val, p.R, R);
 }
 
 void toJsonValue(rapidjson::Document& doc, const rct::boroSig& sig, rapidjson::Value& val)

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -1012,6 +1012,7 @@ void toJsonValue(rapidjson::Document& doc, const rct::rctSig& sig, rapidjson::Va
     INSERT_INTO_JSON_OBJECT(prunable, doc, range_proofs, sig.p.rangeSigs);
     INSERT_INTO_JSON_OBJECT(prunable, doc, bulletproofs, sig.p.bulletproofs);
     INSERT_INTO_JSON_OBJECT(prunable, doc, mlsags, sig.p.MGs);
+    INSERT_INTO_JSON_OBJECT(prunable, doc, clsags, sig.p.CLSAGs);
     INSERT_INTO_JSON_OBJECT(prunable, doc, pseudo_outs, sig.get_pseudo_outs());
 
     val.AddMember("prunable", prunable, doc.GetAllocator());
@@ -1044,6 +1045,7 @@ void fromJsonValue(const rapidjson::Value& val, rct::rctSig& sig)
     GET_FROM_JSON_OBJECT(prunable, sig.p.rangeSigs, range_proofs);
     GET_FROM_JSON_OBJECT(prunable, sig.p.bulletproofs, bulletproofs);
     GET_FROM_JSON_OBJECT(prunable, sig.p.MGs, mlsags);
+    GET_FROM_JSON_OBJECT(prunable, sig.p.CLSAGs, clsags);
     GET_FROM_JSON_OBJECT(prunable, pseudo_outs, pseudo_outs);
 
     sig.get_pseudo_outs() = std::move(pseudo_outs);
@@ -1215,6 +1217,28 @@ void fromJsonValue(const rapidjson::Value& val, rct::mgSig& sig)
 
   GET_FROM_JSON_OBJECT(val, sig.ss, ss);
   GET_FROM_JSON_OBJECT(val, sig.cc, cc);
+}
+
+void toJsonValue(rapidjson::Document& doc, const rct::clsag& sig, rapidjson::Value& val)
+{
+  val.SetObject();
+
+  INSERT_INTO_JSON_OBJECT(val, doc, s, sig.s);
+  INSERT_INTO_JSON_OBJECT(val, doc, c1, sig.c1);
+  // sig.I not serialized, it can be reconstructed from the tx vin
+  INSERT_INTO_JSON_OBJECT(val, doc, D, sig.D);
+}
+
+void fromJsonValue(const rapidjson::Value& val, rct::clsag& sig)
+{
+  if (!val.IsObject())
+  {
+    throw WRONG_TYPE("json object");
+  }
+
+  GET_FROM_JSON_OBJECT(val, sig.s, s);
+  GET_FROM_JSON_OBJECT(val, sig.c1, c1);
+  GET_FROM_JSON_OBJECT(val, sig.D, D);
 }
 
 void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::DaemonInfo& info, rapidjson::Value& val)

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -279,6 +279,9 @@ void fromJsonValue(const rapidjson::Value& val, rct::mgSig& sig);
 void toJsonValue(rapidjson::Document& doc, const rct::clsag& sig, rapidjson::Value& val);
 void fromJsonValue(const rapidjson::Value& val, rct::clsag& sig);
 
+void toJsonValue(rapidjson::Document& doc, const rct::BulletproofPlus& p, rapidjson::Value& val);
+void fromJsonValue(const rapidjson::Value& val, rct::BulletproofPlus& p);
+
 void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::DaemonInfo& info, rapidjson::Value& val);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::DaemonInfo& info);
 

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -276,6 +276,9 @@ void fromJsonValue(const rapidjson::Value& val, rct::boroSig& sig);
 void toJsonValue(rapidjson::Document& doc, const rct::mgSig& sig, rapidjson::Value& val);
 void fromJsonValue(const rapidjson::Value& val, rct::mgSig& sig);
 
+void toJsonValue(rapidjson::Document& doc, const rct::clsag& sig, rapidjson::Value& val);
+void fromJsonValue(const rapidjson::Value& val, rct::clsag& sig);
+
 void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::DaemonInfo& info, rapidjson::Value& val);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::DaemonInfo& info);
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4647,6 +4647,10 @@ boost::optional<epee::wipeable_string> simple_wallet::open_wallet(const boost::p
       prefix = tr("Opened wallet");
     message_writer(console_color_white, true) <<
       prefix << ": " << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
+    if (m_wallet->multisig())
+    {
+      message_writer(console_color_red, true) << tr("WARNING: multisig is a disabled legacy feature. From fork 14 this wallet cannot spend; move any funds before the fork.");
+    }
     if (m_wallet->get_account().get_device()) {
        message_writer(console_color_white, true) << "Wallet is on device: " << m_wallet->get_account().get_device().get_name();
     }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -987,7 +987,19 @@ bool simple_wallet::prepare_multisig_main(const std::vector<std::string> &args, 
 
   SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return false;);
 
-  std::string multisig_info = m_wallet->get_multisig_info();
+  // get_multisig_info() throws now that enrollment is disabled; without a
+  // catch the exception sails past on_command to epee's console handler and
+  // the user gets a log line instead of an error message
+  std::string multisig_info;
+  try
+  {
+    multisig_info = m_wallet->get_multisig_info();
+  }
+  catch (const std::exception &e)
+  {
+    fail_msg_writer() << tr("Error creating multisig: ") << e.what();
+    return false;
+  }
   success_msg_writer() << multisig_info;
   success_msg_writer() << tr("Send this multisig info to all other participants, then use make_multisig <threshold> <info1> [<info2>...] with others' multisig info");
   success_msg_writer() << tr("This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet's participants ");

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -6419,11 +6419,11 @@ bool wallet2::sign_tx(unsigned_tx_set &exported_txs, std::vector<wallet2::pendin
     LOG_PRINT_L1(" " << (n+1) << ": " << sd.sources.size() << " inputs, ring size " << sd.sources[0].outputs.size());
     signed_txes.ptx.push_back(pending_tx());
     tools::wallet2::pending_tx &ptx = signed_txes.ptx.back();
-    rct::RCTConfig rct_config = { rct::RangeProofBorromean, 0 };
+    rct::RCTConfig rct_config = { rct::RangeProofBorromean, 1 };
     if (sd.use_bulletproofs)
     {
       rct_config.range_proof_type = rct::RangeProofPaddedBulletproof;
-      rct_config.is_v2 = use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0);
+      rct_config.bp_version = use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0) ? 2 : 1;
     }
     crypto::secret_key tx_key;
     std::vector<crypto::secret_key> additional_tx_keys;
@@ -6900,11 +6900,11 @@ bool wallet2::sign_multisig_tx(multisig_tx_set &exported_txs, std::vector<crypto
     cryptonote::transaction tx;
     rct::multisig_out msout = ptx.multisig_sigs.front().msout;
     auto sources = sd.sources;
-    rct::RCTConfig rct_config = { rct::RangeProofBorromean, 0 };
+    rct::RCTConfig rct_config = { rct::RangeProofBorromean, 1 };
     if (sd.use_bulletproofs)
     {
       rct_config.range_proof_type = rct::RangeProofPaddedBulletproof;
-      rct_config.is_v2 = use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0);
+      rct_config.bp_version = use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0) ? 2 : 1;
     }
     bool r = cryptonote::construct_tx_with_tx_key(m_account.get_keys(), m_subaddresses, sources, sd.splitted_dsts, ptx.change_dts.addr, sd.extra, tx, sd.unlock_time, 
       ptx.tx_key, ptx.additional_tx_keys, current_tx_version, rct_config, &msout, false);
@@ -7368,7 +7368,7 @@ void wallet2::light_wallet_get_outs(std::vector<std::vector<tools::wallet2::get_
   tools::COMMAND_RPC_GET_RANDOM_OUTS::response ores;
   
   size_t light_wallet_requested_outputs_count = (size_t)((fake_outputs_count + 1) * 1.5 + 1);
-  const bool v2 = (rct_config.range_proof_type != rct::RangeProofBorromean && rct_config.is_v2);
+  const bool v2 = (rct_config.range_proof_type != rct::RangeProofBorromean && rct_config.bp_version >= 2);
   
   // Amounts to ask for
   // MyMonero api handle amounts and fees as strings
@@ -7479,7 +7479,7 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
     return;
   }
 
-  const bool v2 = (rct_config.range_proof_type != rct::RangeProofBorromean && rct_config.is_v2);
+  const bool v2 = (rct_config.range_proof_type != rct::RangeProofBorromean && rct_config.bp_version >= 2);
 
   if (fake_outputs_count > 0)
   {
@@ -8205,7 +8205,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
     THROW_WALLET_EXCEPTION_IF(it_to_replace == src.outputs.end(), error::wallet_internal_error,
         "real output not found");
 
-    const bool v2 = (rct_config.range_proof_type != rct::RangeProofBorromean && rct_config.is_v2);
+    const bool v2 = (rct_config.range_proof_type != rct::RangeProofBorromean && rct_config.bp_version >= 2);
 
     tx_output_entry real_oe;
     real_oe.first = td.m_global_output_index;
@@ -9037,7 +9037,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   const bool bulletproof = use_fork_rules(BULLETPROOF_SIMPLE_FORK_HEIGHT, 0);
   const rct::RCTConfig rct_config {
     bulletproof ? rct::RangeProofPaddedBulletproof : rct::RangeProofBorromean,
-    bulletproof && use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0)
+    bulletproof && use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0) ? 2 : 1
   };
 
   const uint64_t fee_per_kb  = get_per_kb_fee();
@@ -9660,7 +9660,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
   const rct::RCTConfig rct_config
   {
     bulletproof ? rct::RangeProofPaddedBulletproof : rct::RangeProofBorromean,
-    bulletproof && use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0)
+    bulletproof && use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0) ? 2 : 1
   };
 
   LOG_PRINT_L2("Starting with " << unused_transfers_indices.size() << " non-dust outputs and " << unused_dust_indices.size() << " dust outputs");

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -312,6 +312,16 @@ uint64_t calculate_fee(uint64_t fee_per_kb, const cryptonote::blobdata &blob, ui
   return calculate_fee(fee_per_kb, blob.size(), fee_multiplier);
 }
 
+uint64_t calculate_fee(uint64_t fee_per_kb, const cryptonote::transaction &tx, const cryptonote::blobdata &blob, uint64_t fee_multiplier)
+{
+  // the daemon fee-checks a type-7 transaction on its clawed-back weight,
+  // not its blob size, so the final fee must be computed on the same
+  // number; legacy types keep the blob-size fee so pre-fork fees do not move
+  if (tx.rct_signatures.type == rct::RCTTypeBulletproofPlus)
+    return calculate_fee(fee_per_kb, cryptonote::get_transaction_weight(tx, blob.size()), fee_multiplier);
+  return calculate_fee(fee_per_kb, blob, fee_multiplier);
+}
+
 std::string get_weight_string(size_t weight)
 {
   return std::to_string(weight) + " weight";
@@ -799,7 +809,7 @@ void drop_from_short_history(std::list<crypto::hash> &short_chain_history, size_
   }
 }
 
-size_t estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof)
+size_t estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, bool bulletproof_plus)
 {
   size_t size = 0;
 
@@ -823,18 +833,21 @@ size_t estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra
   size += 1;
 
   // rangeSigs
-  if (bulletproof)
+  if (bulletproof || bulletproof_plus)
   {
     size_t log_padded_outputs = 0;
     while ((1<<log_padded_outputs) < n_outputs)
       ++log_padded_outputs;
-    size += (2 * (6 + log_padded_outputs) + 4 + 5) * 32 + 3;
+    size += (2 * (6 + log_padded_outputs) + (bulletproof_plus ? 6 : (4 + 5))) * 32 + 3;
   }
   else
     size += (2*64*32+32+64*32) * n_outputs;
 
-  // MGs
-  size += n_inputs * (64 * (mixin+1) + 32);
+  // MGs/CLSAGs
+  if (clsag)
+    size += n_inputs * (32 * (mixin+1) + 64);
+  else
+    size += n_inputs * (64 * (mixin+1) + 32);
 
   // mixRing - not serialized, can be reconstructed
   /* size += 2 * 32 * (mixin+1) * n_inputs; */
@@ -842,19 +855,54 @@ size_t estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra
   // pseudoOuts
   size += 32 * n_inputs;
   // ecdhInfo
-  size += 2 * 32 * n_outputs;
+  // the legacy 64-byte-per-output estimate stays for the pre-HF14 types so
+  // their fee estimates do not move; the CLSAG types use the trimmed
+  // encoding's real cost, as Monero master
+  if (clsag || bulletproof_plus)
+    size += 8 * n_outputs;
+  else
+    size += 2 * 32 * n_outputs;
   // outPk - only commitment is saved
   size += 32 * n_outputs;
   // txnFee
   size += 4;
 
-  LOG_PRINT_L2("estimated rct tx size for " << n_inputs << " inputs with ring size " << (mixin+1) << " and " << n_outputs << " outputs: " << size << " (" << ((32 * n_inputs/*+1*/) + 2 * 32 * (mixin+1) * n_inputs + 32 * n_outputs) << " saved)");
+  LOG_PRINT_L2("estimated " << (bulletproof_plus ? "bulletproof plus" : bulletproof ? "bulletproof" : "borromean") << " rct tx size for " << n_inputs << " inputs with ring size " << (mixin+1) << " and " << n_outputs << " outputs: " << size << " (" << ((32 * n_inputs/*+1*/) + 2 * 32 * (mixin+1) * n_inputs + 32 * n_outputs) << " saved)");
   return size;
 }
 
-size_t estimate_tx_weight(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof)
+uint64_t estimate_tx_weight(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, bool bulletproof_plus)
 {
-  return estimate_rct_tx_size(n_inputs, mixin, n_outputs + 1, extra_size, bulletproof);
+  size_t size = estimate_rct_tx_size(n_inputs, mixin, n_outputs + 1, extra_size, bulletproof, clsag, bulletproof_plus);
+  // the consensus weight of a padded Bulletproof+ transaction includes the
+  // clawback (Monero master's estimate_tx_weight shape); without it a
+  // >2 output type-7 transaction would underpay its fee. The change output
+  // estimate_rct_tx_size adds above is a real output of the final
+  // transaction, so the clawback pads from it too
+  const int real_outputs = n_outputs + 1;
+  if (bulletproof_plus && real_outputs > 2)
+  {
+    const uint64_t bp_base = (32 * (6 + 7 * 2)) / 2; // notional size of a 2 output proof, normalized to 1 proof (ie, divided by 2)
+    size_t log_padded_outputs = 2;
+    while ((1<<log_padded_outputs) < real_outputs)
+      ++log_padded_outputs;
+    uint64_t nlr = 2 * (6 + log_padded_outputs);
+    const uint64_t bp_size = 32 * (6 + nlr);
+    const uint64_t bp_clawback = (bp_base * (1<<log_padded_outputs) - bp_size) * 4 / 5;
+    MDEBUG("clawback on tx size: " << bp_clawback);
+    size += bp_clawback;
+  }
+  return size;
+}
+
+uint8_t get_bulletproof_plus_fork()
+{
+  return HF_VERSION_BULLETPROOF_PLUS;
+}
+
+uint8_t get_clsag_fork()
+{
+  return HF_VERSION_CLSAG;
 }
 
 bool get_short_payment_id(crypto::hash8 &payment_id8, const tools::wallet2::pending_tx &ptx, hw::device &hwdev)
@@ -1717,6 +1765,8 @@ static uint64_t decodeRct(const rct::rctSig & rv, const crypto::key_derivation &
     case rct::RCTTypeSimple:
     case rct::RCTTypeBulletproof1Simple:
     case rct::RCTTypeBulletproof2:
+    case rct::RCTTypeCLSAG:
+    case rct::RCTTypeBulletproofPlus:
       return rct::decodeRctSimple(rv, rct::sk2rct(scalar1), i, mask, hwdev);
     case rct::RCTTypeFull:
     case rct::RCTTypeBulletproof1Full:
@@ -4697,6 +4747,13 @@ std::string wallet2::make_multisig(const epee::wipeable_string &password,
   const std::vector<crypto::public_key> &spend_keys,
   uint32_t threshold)
 {
+  // Nerva's multisig is the pre-rework legacy implementation (upstream
+  // replaced its key exchange after the 2022 disclosures and still flags
+  // even the fixed version experimental). New enrollment is disabled;
+  // existing multisig wallets keep working until HF14 so funds can move.
+  THROW_WALLET_EXCEPTION_IF(true, error::wallet_internal_error,
+      "Multisig is disabled: the implementation is legacy and unaudited. Existing multisig wallets can spend until fork 14.");
+
   CHECK_AND_ASSERT_THROW_MES(!view_keys.empty(), "empty view keys");
   CHECK_AND_ASSERT_THROW_MES(view_keys.size() == spend_keys.size(), "Mismatched view/spend key sizes");
   CHECK_AND_ASSERT_THROW_MES(threshold > 1 && threshold <= spend_keys.size() + 1, "Invalid threshold");
@@ -4804,6 +4861,13 @@ std::string wallet2::make_multisig(const epee::wipeable_string &password,
 std::string wallet2::exchange_multisig_keys(const epee::wipeable_string &password,
   const std::vector<std::string> &info)
   {
+  // Nerva's multisig is the pre-rework legacy implementation (upstream
+  // replaced its key exchange after the 2022 disclosures and still flags
+  // even the fixed version experimental). New enrollment is disabled;
+  // existing multisig wallets keep working until HF14 so funds can move.
+  THROW_WALLET_EXCEPTION_IF(true, error::wallet_internal_error,
+      "Multisig is disabled: the implementation is legacy and unaudited. Existing multisig wallets can spend until fork 14.");
+
   THROW_WALLET_EXCEPTION_IF(info.empty(),
     error::wallet_internal_error, "Empty multisig info");
 
@@ -5051,6 +5115,13 @@ bool wallet2::finalize_multisig(const epee::wipeable_string &password, const std
 
 std::string wallet2::get_multisig_info() const
 {
+  // Nerva's multisig is the pre-rework legacy implementation (upstream
+  // replaced its key exchange after the 2022 disclosures and still flags
+  // even the fixed version experimental). New enrollment is disabled;
+  // existing multisig wallets keep working until HF14 so funds can move.
+  THROW_WALLET_EXCEPTION_IF(true, error::wallet_internal_error,
+      "Multisig is disabled: the implementation is legacy and unaudited. Existing multisig wallets can spend until fork 14.");
+
   // It's a signed package of private view key and public spend key
   const crypto::secret_key skey = cryptonote::get_multisig_blinded_secret_key(get_account().get_keys().m_view_secret_key);
   const crypto::public_key pkey = get_multisig_signer_public_key(get_account().get_keys().m_spend_secret_key);
@@ -5497,6 +5568,9 @@ void wallet2::load(const std::string& wallet_, const epee::wipeable_string& pass
   {
     MERROR("Failed to initialize MMS, it will be unusable");
   }
+
+  if (m_multisig)
+    MWARNING("This is a multisig wallet. Multisig is a disabled legacy feature: from fork 14 this wallet cannot spend. Move any funds before the fork.");
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::trim_hashchain()
@@ -6419,12 +6493,8 @@ bool wallet2::sign_tx(unsigned_tx_set &exported_txs, std::vector<wallet2::pendin
     LOG_PRINT_L1(" " << (n+1) << ": " << sd.sources.size() << " inputs, ring size " << sd.sources[0].outputs.size());
     signed_txes.ptx.push_back(pending_tx());
     tools::wallet2::pending_tx &ptx = signed_txes.ptx.back();
-    rct::RCTConfig rct_config = { rct::RangeProofBorromean, 1 };
-    if (sd.use_bulletproofs)
-    {
-      rct_config.range_proof_type = rct::RangeProofPaddedBulletproof;
-      rct_config.bp_version = use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0) ? 2 : 1;
-    }
+    rct::RCTConfig rct_config = sd.rct_config;
+    check_hf14_construction_allowed(rct_config.bp_version == 0 || rct_config.bp_version >= 3);
     crypto::secret_key tx_key;
     std::vector<crypto::secret_key> additional_tx_keys;
     rct::multisig_out msout;
@@ -6900,12 +6970,8 @@ bool wallet2::sign_multisig_tx(multisig_tx_set &exported_txs, std::vector<crypto
     cryptonote::transaction tx;
     rct::multisig_out msout = ptx.multisig_sigs.front().msout;
     auto sources = sd.sources;
-    rct::RCTConfig rct_config = { rct::RangeProofBorromean, 1 };
-    if (sd.use_bulletproofs)
-    {
-      rct_config.range_proof_type = rct::RangeProofPaddedBulletproof;
-      rct_config.bp_version = use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0) ? 2 : 1;
-    }
+    rct::RCTConfig rct_config = sd.rct_config;
+    check_hf14_construction_allowed(rct_config.bp_version == 0 || rct_config.bp_version >= 3);
     bool r = cryptonote::construct_tx_with_tx_key(m_account.get_keys(), m_subaddresses, sources, sd.splitted_dsts, ptx.change_dts.addr, sd.extra, tx, sd.unlock_time, 
       ptx.tx_key, ptx.additional_tx_keys, current_tx_version, rct_config, &msout, false);
     THROW_WALLET_EXCEPTION_IF(!r, error::tx_not_constructed, sd.sources, sd.splitted_dsts, sd.unlock_time, m_nettype);
@@ -8352,7 +8418,8 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
   ptx.construction_data.selected_transfers = ptx.selected_transfers;
   ptx.construction_data.extra = tx.extra;
   ptx.construction_data.unlock_time = unlock_time;
-  ptx.construction_data.use_bulletproofs = !tx.rct_signatures.p.bulletproofs.empty();
+  ptx.construction_data.use_bulletproofs = !tx.rct_signatures.p.bulletproofs.empty() || !tx.rct_signatures.p.bulletproofs_plus.empty();
+  ptx.construction_data.rct_config = rct_config;
   ptx.construction_data.dests = dsts;
   // record which subaddress indices are being used as inputs
   ptx.construction_data.subaddr_account = subaddr_account;
@@ -9035,9 +9102,12 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   uint64_t needed_fee, available_for_fee = 0;
   uint64_t upper_transaction_weight_limit = get_upper_transaction_weight_limit();
   const bool bulletproof = use_fork_rules(BULLETPROOF_SIMPLE_FORK_HEIGHT, 0);
+  const bool clsag = use_fork_rules(get_clsag_fork(), 0);
+  const bool bulletproof_plus = use_fork_rules(get_bulletproof_plus_fork(), 0);
+  check_hf14_construction_allowed(bulletproof_plus);
   const rct::RCTConfig rct_config {
     bulletproof ? rct::RangeProofPaddedBulletproof : rct::RangeProofBorromean,
-    bulletproof && use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0) ? 2 : 1
+    bulletproof_plus ? 4 : bulletproof && use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0) ? 2 : 1
   };
 
   const uint64_t fee_per_kb  = get_per_kb_fee();
@@ -9174,7 +9244,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
 
   // this is used to build a tx that's 1 or 2 inputs, and 2 outputs, which
   // will get us a known fee.
-  uint64_t estimated_fee = calculate_fee(fee_per_kb, estimate_rct_tx_size(2, fake_outs_count, 2, extra.size(), bulletproof), fee_multiplier);
+  uint64_t estimated_fee = calculate_fee(fee_per_kb, estimate_rct_tx_size(2, fake_outs_count, 2, extra.size(), bulletproof, clsag, bulletproof_plus), fee_multiplier);
   preferred_inputs = pick_preferred_rct_inputs(needed_money + estimated_fee, subaddr_account, subaddr_indices);
   if (!preferred_inputs.empty())
   {
@@ -9286,7 +9356,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
     }
     else
     {
-      while (!dsts.empty() && dsts[0].amount <= available_amount && estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size()+1, extra.size(), bulletproof) < TX_WEIGHT_TARGET(upper_transaction_weight_limit))
+      while (!dsts.empty() && dsts[0].amount <= available_amount && estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size()+1, extra.size(), bulletproof, clsag, bulletproof_plus) < TX_WEIGHT_TARGET(upper_transaction_weight_limit))
       {
         // we can fully pay that destination
         LOG_PRINT_L2("We can fully pay " << get_account_address_as_str(m_nettype, dsts[0].is_subaddress, dsts[0].addr) <<
@@ -9298,7 +9368,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
         ++original_output_index;
       }
 
-      if (available_amount > 0 && !dsts.empty() && estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size()+1, extra.size(), bulletproof) < TX_WEIGHT_TARGET(upper_transaction_weight_limit)) {
+      if (available_amount > 0 && !dsts.empty() && estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size()+1, extra.size(), bulletproof, clsag, bulletproof_plus) < TX_WEIGHT_TARGET(upper_transaction_weight_limit)) {
         // we can partially fill that destination
         LOG_PRINT_L2("We can partially pay " << get_account_address_as_str(m_nettype, dsts[0].is_subaddress, dsts[0].addr) <<
           " for " << print_money(available_amount) << "/" << print_money(dsts[0].amount));
@@ -9322,7 +9392,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
       }
       else
       {
-        const size_t estimated_rct_tx_weight = estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size(), extra.size(), bulletproof);
+        const size_t estimated_rct_tx_weight = estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size(), extra.size(), bulletproof, clsag, bulletproof_plus);
         try_tx = dsts.empty() || (estimated_rct_tx_weight >= TX_WEIGHT_TARGET(upper_transaction_weight_limit));
         THROW_WALLET_EXCEPTION_IF(try_tx && tx.dsts.empty(), error::tx_too_big, estimated_rct_tx_weight, upper_transaction_weight_limit);
       }
@@ -9332,7 +9402,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
       cryptonote::transaction test_tx;
       pending_tx test_ptx;
 
-      const size_t estimated_tx_size = estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size(), extra.size(), bulletproof);
+      const size_t estimated_tx_size = estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size(), extra.size(), bulletproof, clsag, bulletproof_plus);
       needed_fee = calculate_fee(fee_per_kb, estimated_tx_size, fee_multiplier);
 
       uint64_t inputs = 0, outputs = needed_fee;
@@ -9353,7 +9423,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
         test_tx, test_ptx, rct_config);
 
       auto txBlob = t_serializable_object_to_blob(test_ptx.tx);
-      needed_fee = calculate_fee(fee_per_kb, txBlob, fee_multiplier);
+      needed_fee = calculate_fee(fee_per_kb, test_ptx.tx, txBlob, fee_multiplier);
       available_for_fee = test_ptx.fee + test_ptx.change_dts.amount + (!test_ptx.dust_added_to_fee ? test_ptx.dust : 0);
       LOG_PRINT_L2("Made a " << get_weight_string(test_ptx.tx, txBlob.size()) << " tx, with " << print_money(available_for_fee) << " available for fee (" <<
         print_money(needed_fee) << " needed)");
@@ -9394,7 +9464,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
             test_tx, test_ptx, rct_config);
 
           txBlob = t_serializable_object_to_blob(test_ptx.tx);
-          needed_fee = calculate_fee(fee_per_kb, txBlob, fee_multiplier);
+          needed_fee = calculate_fee(fee_per_kb, test_ptx.tx, txBlob, fee_multiplier);
           LOG_PRINT_L2("Made an attempt at a  final " << get_weight_string(test_ptx.tx, txBlob.size()) << " tx, with " << print_money(test_ptx.fee) <<
             " fee  and " << print_money(test_ptx.change_dts.amount) << " change");
         }
@@ -9657,10 +9727,13 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
   const uint64_t fee_multiplier = get_fee_multiplier(priority);
 
   const bool bulletproof = use_fork_rules(BULLETPROOF_SIMPLE_FORK_HEIGHT, 0);
+  const bool clsag = use_fork_rules(get_clsag_fork(), 0);
+  const bool bulletproof_plus = use_fork_rules(get_bulletproof_plus_fork(), 0);
+  check_hf14_construction_allowed(bulletproof_plus);
   const rct::RCTConfig rct_config
   {
     bulletproof ? rct::RangeProofPaddedBulletproof : rct::RangeProofBorromean,
-    bulletproof && use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0) ? 2 : 1
+    bulletproof_plus ? 4 : bulletproof && use_fork_rules(BULLETPROOF_FULL_FORK_HEIGHT, 0) ? 2 : 1
   };
 
   LOG_PRINT_L2("Starting with " << unused_transfers_indices.size() << " non-dust outputs and " << unused_dust_indices.size() << " dust outputs");
@@ -9699,14 +9772,14 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
     // here, check if we need to sent tx and start a new one
     LOG_PRINT_L2("Considering whether to create a tx now, " << tx.selected_transfers.size() << " inputs, tx limit "
       << upper_transaction_weight_limit);
-    const size_t estimated_rct_tx_weight = estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size() + 1, extra.size(), bulletproof);
+    const size_t estimated_rct_tx_weight = estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size() + 1, extra.size(), bulletproof, clsag, bulletproof_plus);
     bool try_tx = (unused_dust_indices.empty() && unused_transfers_indices.empty()) || ( estimated_rct_tx_weight >= TX_WEIGHT_TARGET(upper_transaction_weight_limit));
 
     if (try_tx) {
       cryptonote::transaction test_tx;
       pending_tx test_ptx;
 
-      const size_t estimated_tx_size = estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size(), extra.size(), bulletproof);
+      const size_t estimated_tx_size = estimate_tx_weight(tx.selected_transfers.size(), fake_outs_count, tx.dsts.size(), extra.size(), bulletproof, clsag, bulletproof_plus);
       needed_fee = calculate_fee(fee_per_kb, estimated_tx_size, fee_multiplier);
 
       for (size_t i = 0; i < ((outputs > 1) ? outputs - 1 : outputs); ++i)
@@ -9751,7 +9824,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
           test_tx, test_ptx, rct_config);
 
         txBlob = t_serializable_object_to_blob(test_ptx.tx);
-        needed_fee = calculate_fee(fee_per_kb, txBlob, fee_multiplier);
+        needed_fee = calculate_fee(fee_per_kb, test_ptx.tx, txBlob, fee_multiplier);
         LOG_PRINT_L2("Made an attempt at a final " << get_weight_string(test_ptx.tx, txBlob.size()) << " tx, with " << print_money(test_ptx.fee) <<
           " fee  and " << print_money(test_ptx.change_dts.amount) << " change");
       } while (needed_fee > test_ptx.fee);
@@ -9922,6 +9995,20 @@ uint8_t wallet2::get_current_tx_version()
   return (hf >= V2_TX_FORK_HEIGHT) ? TRANSACTION_VERSION_V2 : TRANSACTION_VERSION_V1;
 }
 
+void wallet2::check_hf14_construction_allowed(bool needs_clsag) const
+{
+  if (!needs_clsag)
+    return;
+  // HF14 transactions are CLSAG-signed. The Ledger integration still speaks
+  // the pre-CLSAG app protocol and multisig is excluded with CLSAG, so both
+  // must refuse before construction starts rather than produce something the
+  // network rejects.
+  THROW_WALLET_EXCEPTION_IF(key_on_device(), error::wallet_internal_error,
+      "This wallet's keys are on a hardware device whose integration predates CLSAG; it cannot create HF14 transactions");
+  THROW_WALLET_EXCEPTION_IF(m_multisig, error::wallet_internal_error,
+      "Multisig wallets cannot create HF14 (CLSAG) transactions");
+}
+//----------------------------------------------------------------------------------------------------
 bool wallet2::use_fork_rules(uint8_t version, int64_t early_blocks)
 {
   // TODO: How to get fork rule info from light wallet node?
@@ -10519,7 +10606,7 @@ void wallet2::check_tx_key_helper(const cryptonote::transaction &tx, const crypt
         crypto::secret_key scalar1;
         crypto::derivation_to_scalar(found_derivation, n, scalar1);
         rct::ecdhTuple ecdh_info = tx.rct_signatures.ecdhInfo[n];
-        rct::ecdhDecode(ecdh_info, rct::sk2rct(scalar1), tx.rct_signatures.type == rct::RCTTypeBulletproof2);
+        rct::ecdhDecode(ecdh_info, rct::sk2rct(scalar1), tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG || tx.rct_signatures.type == rct::RCTTypeBulletproofPlus);
         const rct::key C = tx.rct_signatures.outPk[n].mask;
         rct::key Ctmp;
         THROW_WALLET_EXCEPTION_IF(sc_check(ecdh_info.mask.bytes) != 0, error::wallet_internal_error, "Bad ECDH input mask");
@@ -11123,7 +11210,7 @@ bool wallet2::check_reserve_proof(const cryptonote::account_public_address &addr
       crypto::secret_key shared_secret;
       crypto::derivation_to_scalar(derivation, proof.index_in_tx, shared_secret);
       rct::ecdhTuple ecdh_info = tx.rct_signatures.ecdhInfo[proof.index_in_tx];
-      rct::ecdhDecode(ecdh_info, rct::sk2rct(shared_secret), tx.rct_signatures.type == rct::RCTTypeBulletproof2);
+      rct::ecdhDecode(ecdh_info, rct::sk2rct(shared_secret), tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG || tx.rct_signatures.type == rct::RCTTypeBulletproofPlus);
       amount = rct::h2d(ecdh_info.amount);
     }
     total += amount;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -431,6 +431,9 @@ private:
       std::vector<uint8_t> extra;
       uint64_t unlock_time;
       bool use_bulletproofs;
+      // authoritative range proof / signature scheme selection (HF14); the
+      // use_bulletproofs bool stays for old archives and callers
+      rct::RCTConfig rct_config = { rct::RangeProofBorromean, 1 };
       std::vector<cryptonote::tx_destination_entry> dests; // original setup, does not include change
       uint32_t subaddr_account;   // subaddress account of your wallet to be used in this transfer
       std::set<uint32_t> subaddr_indices;  // set of address indices used as inputs in this transfer
@@ -1036,6 +1039,10 @@ private:
     uint8_t get_current_hard_fork();
     void get_hard_fork_info(uint8_t version, uint64_t &earliest_height);
     bool use_fork_rules(uint8_t version, int64_t early_blocks = 0);
+    // throws when an HF14 (CLSAG) transaction is requested on a wallet that
+    // cannot sign one: hardware-device keys (pre-CLSAG Ledger protocol) or
+    // multisig accounts
+    void check_hf14_construction_allowed(bool needs_clsag) const;
     uint8_t get_current_tx_version();
 
     std::string get_wallet_file() const;
@@ -1508,6 +1515,9 @@ private:
   };
 }
 
+// HF14: tx_construction_data carries rct_config from version 1 on
+BOOST_CLASS_VERSION(tools::wallet2::tx_construction_data, 1)
+
 namespace boost
 {
   namespace serialization
@@ -1660,6 +1670,15 @@ namespace boost
       a & x.subaddr_indices;
       a & x.selected_transfers;
       a & x.use_bulletproofs;
+      if (ver < 1)
+      {
+        // pre-HF14 archives carry only the bool; synthesize the config the
+        // old signing code would have used
+        if (Archive::is_loading::value)
+          x.rct_config = { x.use_bulletproofs ? rct::RangeProofPaddedBulletproof : rct::RangeProofBorromean, x.use_bulletproofs ? 2 : 1 };
+        return;
+      }
+      a & x.rct_config;
     }
 
     template <class Archive>

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4087,7 +4087,18 @@ namespace tools
       return false;
     }
 
-    res.multisig_info = m_wallet->get_multisig_info();
+    // get_multisig_info refuses with a throw now that enrollment is
+    // disabled; answer with a proper RPC error instead of a dropped call
+    try
+    {
+      res.multisig_info = m_wallet->get_multisig_info();
+    }
+    catch (const std::exception &e)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = e.what();
+      return false;
+    }
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Implements HF14: the privacy upgrade from the roadmap (CLSAG +
Bulletproofs+) and the CryptoNight-Adaptive v7 PoW change, activating
together at fork 14. Tracking issue #116 - its validation gates remain
open past this merge, so it should stay open.

For users: transactions get about 25% smaller and verify faster, same
privacy. For miners: per-core hashrate evens out across consumer
hardware, small boards stay first-class. Nothing changes on any network until fork heights are set, and none is
yet; heights are chosen network by network (testnet first) per the
validation gates in #116.

Only rct type 7 (CLSAG + Bulletproofs+) activates for new transactions.
Type 6 (CLSAG with the older Bulletproofs) is fully implemented and
verifiable but rejected at every height - it is the intermediate the
port went through, kept so the CLSAG and Bulletproofs+ steps stay
auditable on their own.

## Commits

- `fix(serialization): read_hex string length accessor`
- `fix(ringct): overflow guards and initialized type byte in rctSig`
- `feat(ringct): CLSAG signatures, ported from Monero`
- `feat(ringct): Bulletproofs+ range proofs, ported from Monero`
- `feat(consensus): verify and gate CLSAG + Bulletproofs+ at HF14`
- `refactor(cryptonote_core): adopt tx_verification_utils for input proof verification`
- `feat(wallet): create type-7 (CLSAG + Bulletproofs+) transactions at HF14`
- `feat(hf14): CryptoNight-Adaptive v7, per-nonce mutable-buffer chase`
- `test(hf14): out-of-tree check harness for the HF14 port` (plus two
  `fixup!` commits from the review, kept unsquashed so the fixes stay
  reviewable against their comments)

## Deviations by design

Ported against Monero master 52f02f2. RCTTypeCLSAG = 6 and
RCTTypeBulletproofPlus = 7 (Monero's 5/6 are already taken by our
on-chain history). Deliberately not included: upstream's multisig rework
(legacy multisig is disabled instead, see below), the input verification
cache (the file layout lands without it), view tags and ring size 16
(HF15 per the roadmap). Multisig setup is disabled - the legacy
implementation is unaudited; existing multisig wallets warn and can spend
until the fork. Hardware-device wallets cannot sign HF14 transactions
(pre-CLSAG Ledger protocol).

## Verification

- Every ported function diffs at zero lines against upstream, or with
  each deviation named; the two bulletproofs_plus files are
  byte-identical copies.
- Monero's CLSAG and bulletproofs_plus test batteries ported and
  passing, including tamper and torsion cases. These, plus checks for
  the Nerva-specific glue the upstream diff cannot vouch for (the 6/7
  renumbering through all three encoders, the fee and weight
  arithmetic, CNA v7 against a standalone reference), are now in-tree
  under `contrib/hf14checks` (review ask; details in #116).
- Cross-implementation interop both directions, 24 signatures each way:
  balance and range-proof semantics verify as-is and every CLSAG
  cross-verifies; the serialized base is byte-identical except the
  renumbered type byte, which is part of the signed message by design.
- Serialization roundtrips for all three encoders, including pre-change
  archives; legacy behavior bit-stable (type-5 wire encoding and fee
  estimates unchanged).
- Wallet estimators cover real serialized type-7 signatures; the fee
  clawback equals consensus arithmetic.
- CNA v7's per-nonce chase is validated bit-for-bit against a standalone
  reference, and the checkpoint (time-memory) attack on the buffer is
  implemented and comes out slower than just storing it (0.53-0.63x the
  throughput), so the residency requirement holds. The chase issues exactly
  3,145,728 accesses per hash for every seed, and coverage stays 62.6-63.3%
  across 150 seeds, so no seed is cheaper to hash than another. Measured:
  per-core gap 1.37x (570 ms on an aarch64 Cortex-A57 core at 1.43 GHz against
  416 ms on a 4.8 GHz x86-64 core, medians of 7 on idle machines) against 4.86x
  for v6 measured identically, with a 3.36x clock ratio between them; a 16 GB
  GPU at 1.66x a 14-thread x86-64 box against 4.66x for v6, same card one run.
  The ASIC barrier cannot be measured; structurally it rests on the per-nonce
  program driving the addresses, buffer residency and DRAM latency, and v6 is
  the reference point rather than something this beats. Verify cost is where
  v7 loses to v6: ~410 ms per hash on a 4.8 GHz core, 572 ms on the A57,
  against ~14 ms for v6.
- Full builds of every target. The PoW HW/SW self-test now runs on a
  varied seed and asserts the buffer is populated (review catch: the
  original all-zero seed zeroed the fill and exercised under 1% of the
  buffer), and passes on x86_64 and aarch64, all four AES paths.





