### PR TITLE
fix: force SSE2 float math on 32-bit x86 for difficulty determinism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -794,6 +794,16 @@ else ()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_FLAG}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAG}")
 
+    # 32-bit x86 defaults to x87 (80-bit) float math, which can round differently
+    # from the 64-bit SSE2 math on other builds. next_difficulty_v6 truncates a
+    # double to the target, so that gap can fork 32-bit vs 64-bit nodes. Force SSE2
+    # so every x86 build computes difficulty identically.
+    if (NOT BUILD_64 AND NOT ARM AND NOT PPC64LE AND NOT PPC64 AND NOT PPC AND NOT S390X AND NOT RISCV AND NOT LOONGARCH)
+        message(STATUS "Forcing SSE2 float math on 32-bit x86 for cross-platform difficulty determinism")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -mfpmath=sse")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -mfpmath=sse")
+    endif ()
+
     set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings -Wno-error=extra -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized")
     if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         if (ARM)


### PR DESCRIPTION
Closes #119.

Forces `-msse2 -mfpmath=sse` on 32-bit x86 builds so their floating-point math matches the 64-bit SSE2 math used everywhere else, closing the difficulty-truncation divergence that can fork 32-bit vs 64-bit nodes.

`next_difficulty_v6` (the live algorithm for HF6+) computes the target in `double` and truncates to `uint64_t`. 32-bit x86 defaults to x87 (80-bit intermediate precision), so when the result lands within ~1 ULP of an integer boundary it can truncate one off from the 64-bit SSE2 result, and the two nodes disagree on `check_hash`.

## Why this and not an integer rewrite

Rewriting `next_difficulty_v6` to integer/fixed-point would change the difficulty values every node computes, i.e. a consensus change requiring a hard fork. Forcing SSE2 instead makes the divergent 32-bit builds agree with the 64-bit majority that already defines the canonical chain, so it deploys without a fork. `next_difficulty_v6` has no `a*b+c` pattern, so there is no FMA-contraction divergence left; the SSE2 flag is sufficient. (Integer math stays available as a belt-and-suspenders option for a future hard fork.)

## Scope

Applied only to 32-bit x86 (`NOT BUILD_64` and not ARM/PPC/S390X/RISCV/LOONGARCH). 64-bit x86 already uses SSE2 by default; ARM and others are unaffected (and `-msse2` would be invalid there).

## Testing

- `cmake` reconfigures clean; the block is correctly skipped on 64-bit and ARM.
- Gating verified across arches via a standalone check: 32-bit x86 -> `-msse2 -mfpmath=sse`; 64-bit x86 / 32-bit ARM / 64-bit ARM -> no change.
- The `i686 Win` / `i686 Linux` / `i686 musl` CI jobs exercise the actual 32-bit build with the new flags.
