### PR TITLE
Wallet created while the daemon is unreachable scans past the end of the chain

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -11278,8 +11278,19 @@ uint64_t wallet2::get_daemon_blockchain_target_height(string &err)
 
 uint64_t wallet2::get_approximate_blockchain_height() const
 {
-  const time_t init_time = 1504387246;
-  uint64_t approx_blockchain_height = (time(NULL) - init_time) / DIFFICULTY_TARGET;
+  // The test chains are relaunched from scratch, so no date hardcoded here
+  // stays true for them, and guessing high makes a new wallet skip the blocks
+  // it was meant to scan. They are short, so start at the beginning.
+  if (m_nettype != MAINNET)
+    return 0;
+  // Timestamp of the first block of the chain. The constant here used to be
+  // eight months earlier than that, which put the guess a few hundred thousand
+  // blocks past the tip.
+  const time_t chain_start = 1525169251;
+  const time_t now = time(NULL);
+  if (now <= chain_start)
+    return 0;   // clock set before the chain existed, no guess worth making
+  uint64_t approx_blockchain_height = (now - chain_start) / DIFFICULTY_TARGET;
   LOG_PRINT_L2("Calculated blockchain height: " << approx_blockchain_height);
   return approx_blockchain_height;
 }


### PR DESCRIPTION
Fixes #123.

When a new wallet can't reach a daemon it guesses where to start scanning. The guess counted 60 second blocks from 1504387246, which is eight months before our first block, and it used that same date on every network. On mainnet it lands about 350k blocks past the tip. On a test chain that is days old it lands millions past it. The wallet then scans nothing and shows an empty balance, which is the "new wallet shows no transactions, restoring from seed fixes it" report.

It counts from the real first block now. On the test chains it doesn't guess at all, because they get relaunched from scratch so no date hardcoded here stays true, and they are short enough to scan from the beginning.

Creating a wallet offline used to start at ~4.65M on mainnet and ~4.6M on testnet. It now starts at 4308795 on mainnet, against a tip around 4.35M, and at 0 on testnet.

One correction to the issue: this isn't block time drift. Our lifetime average is 60.1s against a 60s target, so drift is only about 7k blocks of the error and the wrong date is the other 346k. That also means recalibrating holds, it costs about 900 blocks a year against the 43200 block margin the caller already subtracts.

I left out defaulting mainnet to 0 when the daemon is down. It is the safest option in the issue but it would make every wallet created offline rescan 4.3M blocks, and the corrected date already lands 38k below the tip.
