### PR TITLE
Coinbase sum over a long range overflows 64 bits

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1029,17 +1029,29 @@ namespace cryptonote
     }
   }
   //---------------------------------------------------------------
-  std::string print_money(uint64_t amount, unsigned int decimal_point)
+  static void insert_money_decimal_point(std::string &s, unsigned int decimal_point)
   {
     if (decimal_point == (unsigned int)-1)
       decimal_point = default_decimal_point;
-    std::string s = std::to_string(amount);
     if(s.size() < decimal_point+1)
     {
       s.insert(0, decimal_point+1 - s.size(), '0');
     }
     if (decimal_point > 0)
       s.insert(s.size() - decimal_point, ".");
+  }
+  //---------------------------------------------------------------
+  std::string print_money(uint64_t amount, unsigned int decimal_point)
+  {
+    std::string s = std::to_string(amount);
+    insert_money_decimal_point(s, decimal_point);
+    return s;
+  }
+  //---------------------------------------------------------------
+  std::string print_money(const boost::multiprecision::uint128_t &amount, unsigned int decimal_point)
+  {
+    std::string s = amount.str();
+    insert_money_decimal_point(s, decimal_point);
     return s;
   }
   //---------------------------------------------------------------

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -30,6 +30,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
+#include <boost/multiprecision/cpp_int.hpp>
 #include "blobdatatype.h"
 #include "cryptonote_basic_impl.h"
 #include "tx_extra.h"
@@ -142,6 +143,7 @@ namespace cryptonote
   unsigned int get_default_decimal_point();
   std::string get_unit(unsigned int decimal_point = -1);
   std::string print_money(uint64_t amount, unsigned int decimal_point = -1);
+  std::string print_money(const boost::multiprecision::uint128_t &amount, unsigned int decimal_point = -1);
   //---------------------------------------------------------------
   template<class t_object>
   bool t_serializable_object_from_blob(t_object& to, const blobdata& b_blob)

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1189,10 +1189,12 @@ namespace cryptonote
     return m_mempool.check_for_key_images(key_im, spent);
   }
   //-----------------------------------------------------------------------------------------------
-  std::pair<uint64_t, uint64_t> core::get_coinbase_tx_sum(const uint64_t start_offset, const size_t count)
+  std::pair<boost::multiprecision::uint128_t, boost::multiprecision::uint128_t> core::get_coinbase_tx_sum(const uint64_t start_offset, const size_t count)
   {
-    uint64_t emission_amount = 0;
-    uint64_t total_fee_amount = 0;
+    // A sum over the whole chain passed what 64 bits hold, so the running
+    // totals have to be wider than the per block amounts they add up.
+    boost::multiprecision::uint128_t emission_amount = 0;
+    boost::multiprecision::uint128_t total_fee_amount = 0;
     if (count)
     {
       const uint64_t end = start_offset + count - 1;
@@ -1214,7 +1216,7 @@ namespace cryptonote
       });
     }
 
-    return std::pair<uint64_t, uint64_t>(emission_amount, total_fee_amount);
+    return std::pair<boost::multiprecision::uint128_t, boost::multiprecision::uint128_t>(emission_amount, total_fee_amount);
   }
 
   uint64_t core::get_generated_coins()

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -33,6 +33,7 @@
 
 #include <ctime>
 
+#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
 
@@ -746,9 +747,9 @@ namespace cryptonote
      /**
       * @brief get the sum of coinbase tx amounts between blocks
       *
-      * @return the number of blocks to sync in one go
+      * @return the emission total and the fee total over the range
       */
-     std::pair<uint64_t, uint64_t> get_coinbase_tx_sum(const uint64_t start_offset, const size_t count);
+     std::pair<boost::multiprecision::uint128_t, boost::multiprecision::uint128_t> get_coinbase_tx_sum(const uint64_t start_offset, const size_t count);
 
       /**
       * @brief get the sum of coinbase tx amounts for the entire chain

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -40,6 +40,7 @@
 #include "cryptonote_basic/difficulty.h"
 #include "cryptonote_basic/hardfork.h"
 #include <boost/format.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
 #include <ctime>
 #include <string>
 
@@ -1857,11 +1858,16 @@ bool t_rpc_command_executor::print_coinbase_tx_sum(uint64_t height, uint64_t cou
     }
   }
 
+  // A daemon from before the sum was widened leaves the top halves at 0, which
+  // reassembles to exactly the value it sent.
+  const boost::multiprecision::uint128_t emission = (boost::multiprecision::uint128_t(res.emission_amount_top64) << 64) | res.emission_amount;
+  const boost::multiprecision::uint128_t fees = (boost::multiprecision::uint128_t(res.fee_amount_top64) << 64) | res.fee_amount;
+
   tools::msg_writer() << "Sum of coinbase transactions between block heights ["
     << height << ", " << (height + count) << ") is "
-    << cryptonote::print_money(res.emission_amount + res.fee_amount) << " "
-    << "consisting of " << cryptonote::print_money(res.emission_amount) 
-    << " in emissions, and " << cryptonote::print_money(res.fee_amount) << " in fees";
+    << cryptonote::print_money(emission + fees) << " "
+    << "consisting of " << cryptonote::print_money(emission)
+    << " in emissions, and " << cryptonote::print_money(fees) << " in fees";
   return true;
 }
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -117,10 +117,12 @@ namespace
     return (value + quantum - 1) / quantum * quantum;
   }
 
-  void store_difficulty(cryptonote::difficulty_type_128 difficulty, uint64_t &sdiff, uint64_t &stop64)
+  // The low half keeps the field an older caller already parses; reading it
+  // alone is only correct while the value fits in 64 bits.
+  void store_128(boost::multiprecision::uint128_t value, uint64_t &slow64, uint64_t &stop64)
   {
-    sdiff = (difficulty & 0xffffffffffffffff).convert_to<uint64_t>();
-    stop64 = ((difficulty >> 64) & 0xffffffffffffffff).convert_to<uint64_t>();
+    slow64 = (value & 0xffffffffffffffff).convert_to<uint64_t>();
+    stop64 = ((value >> 64) & 0xffffffffffffffff).convert_to<uint64_t>();
   }
 }
 
@@ -342,7 +344,7 @@ namespace cryptonote
     res.testnet = net_type == TESTNET;
     res.stagenet = net_type == STAGENET;
     res.nettype = net_type == MAINNET ? "mainnet" : net_type == TESTNET ? "testnet" : net_type == STAGENET ? "stagenet" : "fakechain";
-    store_difficulty(m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(res.height - 1),
+    store_128(m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(res.height - 1),
         res.cumulative_difficulty, res.cumulative_difficulty_top64);
     res.block_size_limit = res.block_weight_limit = m_core.get_blockchain_storage().get_current_cumulative_block_weight_limit();
     res.block_size_median = res.block_weight_median = m_core.get_blockchain_storage().get_current_cumulative_block_weight_median();
@@ -1901,7 +1903,7 @@ namespace cryptonote
     response.depth = m_core.get_current_blockchain_height() - height - 1;
     response.hash = string_tools::pod_to_hex(hash);
     response.difficulty = m_core.get_blockchain_storage().block_difficulty(height);
-    store_difficulty(m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(height),
+    store_128(m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(height),
         response.cumulative_difficulty, response.cumulative_difficulty_top64);
     response.reward = get_block_reward(blk);
     response.block_size = response.block_weight = m_core.get_blockchain_storage().get_db().get_block_weight(height);
@@ -2510,9 +2512,9 @@ namespace cryptonote
       res.status = "height or count is too large";
       return true;
     }
-    std::pair<uint64_t, uint64_t> amounts = m_core.get_coinbase_tx_sum(req.height, req.count);
-    res.emission_amount = amounts.first;
-    res.fee_amount = amounts.second;
+    std::pair<boost::multiprecision::uint128_t, boost::multiprecision::uint128_t> amounts = m_core.get_coinbase_tx_sum(req.height, req.count);
+    store_128(amounts.first, res.emission_amount, res.emission_amount_top64);
+    store_128(amounts.second, res.fee_amount, res.fee_amount_top64);
     res.status = CORE_RPC_STATUS_OK;
     return true;
   }
@@ -2585,7 +2587,7 @@ namespace cryptonote
       for (const auto &i: chains)
       {
         res.chains.push_back(COMMAND_RPC_GET_ALTERNATE_CHAINS::chain_info{epee::string_tools::pod_to_hex(get_block_hash(i.first.bl)), i.first.height, i.second.size(), 0, 0, {}, std::string()});
-        store_difficulty(i.first.cumulative_difficulty, res.chains.back().cumulative_difficulty, res.chains.back().cumulative_difficulty_top64);
+        store_128(i.first.cumulative_difficulty, res.chains.back().cumulative_difficulty, res.chains.back().cumulative_difficulty_top64);
         res.chains.back().block_hashes.reserve(i.second.size());
         for (const crypto::hash &block_id: i.second)
           res.chains.back().block_hashes.push_back(epee::string_tools::pod_to_hex(block_id));

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -87,7 +87,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 4
-#define CORE_RPC_VERSION_MINOR 0
+#define CORE_RPC_VERSION_MINOR 1
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -1957,12 +1957,16 @@ namespace cryptonote
     struct response_t: public rpc_response_base
     {
       uint64_t emission_amount;
+      uint64_t emission_amount_top64;
       uint64_t fee_amount;
+      uint64_t fee_amount_top64;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(emission_amount)
+        KV_SERIALIZE(emission_amount_top64)
         KV_SERIALIZE(fee_amount)
+        KV_SERIALIZE(fee_amount_top64)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;


### PR DESCRIPTION
`get_coinbase_tx_sum` adds up coinbase minus fees over a block range. Asked for the whole chain it answered 796076.392758448384 XNV against a real 19242820.466468, short by exactly 2^64 atomic units, because the accumulators were `uint64` and the emission passed that a while ago.

Summing the same range in chunks of 100000 gives the right total, since no single chunk overflows. That is what the supply tooling does, which is why its number has been right while the daemon's has not.

Accumulators and return type are 128 bit now. Per block amounts stay `uint64`, and `MONEY_SUPPLY` and `already_generated_coins` are untouched, so none of this reaches consensus and it can ship in a point release.

### Over RPC

`emission_amount` and `fee_amount` still carry the low 64 bits, so anything reading just those sees no change. The high half arrives in the new `emission_amount_top64` and `fee_amount_top64` — the same `<name>` + `<name>_top64` shape this tree already uses for `cumulative_difficulty`, rather than Monero's `wide_*` hex string, which this tree does not use on any wire. `store_difficulty` is generalised to `store_128` and now serves both. `CORE_RPC_VERSION_MINOR` goes to 1 for the added fields.

The daemon CLI rebuilds the value from the two halves rather than trusting a single wide field, so it still prints the right number against a daemon that predates this change, where the high halves are absent and default to 0.

### Measured

On a copy of mainnet at height 4343869, before and after:

    emission_amount_top64      0            ->  1
    full range total           796076.39    ->  19242820.466468 XNV
    difference                              18446744073709551616, exactly 2^64
    low 64 bits                unchanged
    one call vs 44 chunks      disagreed    ->  equal

The 19242820.466468 matches what the supply tooling derives from its own checkpoint at block 4300000, which was never fed into the code.

Verified locally: the four changed translation units plus `wallet2`, `simplewallet`, `wallet_rpc_server`, `blockchain`, `blockchain_import` and `rctSigs` compile clean; the `uint64` `print_money` path is byte-identical to before across the range; the 128 bit split round-trips at 0, 1, 2^63, 2^64 ± 1 and 2^128 - 1; and an old-daemon response parsed through the real epee serializer leaves the new fields at 0 and reassembles to exactly the value it sent.

### Left out on purpose

Our bounds check rejects only `count > chain height`, where Monero rejects `count > chain height - height`. Ours accepts a range running past the tip and answers OK with a short sum. Worth fixing, but it turns a call that succeeds today into an error, so it does not belong in the same change.

`emission_amount += coinbase_amount - tx_fee_amount` is still `uint64` arithmetic. With a `uint64` accumulator an underflow there cancelled out mod 2^64; with a 128 bit one it would not. Safe today because `validate_miner_transaction` rejects any block where `money_in_use != base_reward + fee`, and this tree never sets `partial_block_reward` — noted so that check is not relaxed later without revisiting the line.
