### PR TITLE
fix(wallet): sweep rebuilt the transaction with a fee its destinations were not sized for

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9476,7 +9476,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
         tx.ptx = test_ptx;
         tx.weight = get_transaction_weight(test_tx, txBlob.size());
         tx.outs = outs;
-        tx.needed_fee = needed_fee;
+        // the fee the tx was built with; the rebuild below sizes change against it
+        tx.needed_fee = test_ptx.fee;
         accumulated_fee += test_ptx.fee;
         accumulated_change += test_ptx.change_dts.amount;
         adding_fee = false;
@@ -9836,7 +9837,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
       tx.ptx = test_ptx;
       tx.weight = get_transaction_weight(test_tx, txBlob.size());
       tx.outs = outs;
-      tx.needed_fee = needed_fee;
+      // the fee the tx was built with; a sweep has no change to absorb a lower one
+      tx.needed_fee = test_ptx.fee;
       accumulated_fee += test_ptx.fee;
       accumulated_change += test_ptx.change_dts.amount;
       if (!unused_transfers_indices.empty() || !unused_dust_indices.empty())


### PR DESCRIPTION
Closes #127.

The fee loop settles on a transaction built with fee F, then stores the fee recomputed from that transaction, F'. The loop exits when F' is at or below F, and it is usually below. The signing pass then rebuilds from the stored fee while the destinations are still sized for F, so F - F' comes back as change nobody asked for. A sweep has no change to absorb it, so sanity_check refuses the wallet's own transaction and the sweep never gets built.

Now it stores the fee the transaction was built with. That is what upstream does at both sites, and accumulated_fee on the next line was already using it, so the two stop disagreeing. create_transactions_2 had the same divergence and is fixed with it, it just has change to hide the difference in. It came in with dbec0a5, the Masari rebase, so it looks like a porting artifact rather than a decision.

Reproduced on a private testnet mined past the HF14 fork, 1101 blocks to one wallet, same height and same unlocked balance on both runs:

    before   ERROR  Total received 255100.829046170979, expected 255100.848475510979
    after    OK     2 transactions

The trigger is the per KB rounding in calculate_fee, kB = (bytes + 1023) / 1024. F and F' differ only when the estimate and the built transaction land in different KB buckets, so it turns on transaction size, not on the transaction format or the fork.

It fails before the fork too, which I checked rather than assumed. Sweeping one wallet at ten different below_amount thresholds, so each sweep pulls a different number of inputs, on chains below and above the fork:

                        before      after
    pre fork, HF13      6 failures  0 failures
    post fork, HF14     fails       passes

Pre fork is HF13, the format mainnet runs today. Two earlier pre fork runs of mine passed and that was one bucket of luck, not the format protecting anything.

So this is not gated on HF14. A mainnet wallet with enough outputs can hit it today.

On effects, since it is a money path. tx.needed_fee has two consumers, both the fee argument to transfer_selected_rct in the rebuild. The fee can only move up, never down, since the loop exits when F' is at or below F, so it cannot underpay and get rejected. The transaction carries one output fewer with the spurious change gone. The cost is paying F instead of F', 0.0028 on a 0.166 fee in the report.

---

Maintainer note: the author is unavailable, so this branch was rebased onto master and the two review points settled in place. The comment blocks at both sites were trimmed to one line each. The second commit, the `relay-sanity-checks` toggle, was split out: its root cause is still open and is tracked in #139, so it does not ride along on a squash that closes #127. The dropped commit is attached as a patch on #139.
