### PR TITLE
fix(db): block removal left stale entries in the proof of work seed cache

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -800,6 +800,22 @@ void BlockchainLMDB::remove_block()
 
   if ((result = mdb_cursor_del(m_cur_block_info, 0)))
       throw1(DB_ERROR(lmdb_error("Failed to add removal of block info to db transaction: ", result).c_str()));
+
+  // m_block_cache feeds the proof of work seed by height (get_cna_v2_data,
+  // get_cna_v6_data) and nothing else invalidated it. A popped block left in it
+  // makes later seeds draw on a chain that no longer exists, so the node hashes
+  // differently from the network and rejects every block as bad proof of work.
+  // Seeds read 256 blocks back so the cache normally trails the tip;
+  // ensure_batch_longhashes warms it to the tip during catch-up sync.
+  //
+  // Lower the height, keep the vector: readers resolve a height before taking
+  // the shared lock, so shrinking could walk one off the end.
+  {
+    const uint64_t new_height = m_height - 1;
+    boost::unique_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
+    if (m_block_cache_height.load(std::memory_order_relaxed) > new_height)
+      m_block_cache_height.store(new_height, std::memory_order_release);
+  }
 }
 
 uint64_t BlockchainLMDB::add_transaction_data(const crypto::hash& blk_hash, const std::pair<transaction, blobdata>& txp, const crypto::hash& tx_hash, const crypto::hash& tx_prunable_hash)
@@ -2395,6 +2411,12 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
 
   boost::unique_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
 
+  // Re-check under the lock: another thread may have filled the cache while we
+  // waited, and storing our own smaller height below would drop its entries.
+  const uint64_t have = m_block_cache_height.load(std::memory_order_relaxed);
+  if (have >= height)
+    return;
+
   m_block_cache.reserve(height);
 
   // Read block_info via the standard batch-aware cursor pattern. During batch
@@ -2410,7 +2432,9 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
   TXN_PREFIX_RDONLY();
   RCURSOR(block_info);
 
-  for (uint64_t index = m_block_cache.size(); index < height; ++index)
+  // Start from the cached height, not the vector size: remove_block lowers the
+  // height without shrinking, so these slots may hold popped blocks. Overwrite.
+  for (uint64_t index = have; index < height; ++index)
   {
     MDB_val_set(query, index);
     if (auto r = mdb_cursor_get(m_cur_block_info, (MDB_val*)&zerokval, &query, MDB_GET_BOTH))
@@ -2421,7 +2445,10 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
     entry.timestamp = bi->bi_timestamp;
     entry.diff_lo   = bi->bi_diff_lo;
     entry.coins     = bi->bi_coins;
-    m_block_cache.push_back(entry);
+    if (index < m_block_cache.size())
+      m_block_cache[static_cast<size_t>(index)] = entry;
+    else
+      m_block_cache.push_back(entry);
   }
 
   m_block_cache_height.store(height, std::memory_order_release);

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -802,12 +802,8 @@ void BlockchainLMDB::remove_block()
       throw1(DB_ERROR(lmdb_error("Failed to add removal of block info to db transaction: ", result).c_str()));
 
   // m_block_cache feeds the proof of work seed by height (get_cna_v2_data,
-  // get_cna_v6_data) and nothing else invalidated it. A popped block left in it
-  // makes later seeds draw on a chain that no longer exists, so the node hashes
-  // differently from the network and rejects every block as bad proof of work.
-  // Seeds read 256 blocks back so the cache normally trails the tip;
-  // ensure_batch_longhashes warms it to the tip during catch-up sync.
-  //
+  // get_cna_v6_data). A popped block left in it makes later seeds read a chain
+  // that no longer exists, and every block after that fails as bad PoW.
   // Lower the height, keep the vector: readers resolve a height before taking
   // the shared lock, so shrinking could walk one off the end.
   {
@@ -2411,8 +2407,8 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
 
   boost::unique_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
 
-  // Re-check under the lock: another thread may have filled the cache while we
-  // waited, and storing our own smaller height below would drop its entries.
+  // Re-check under the lock: another thread may have filled it while we waited,
+  // and storing our own smaller height below would discard its entries.
   const uint64_t have = m_block_cache_height.load(std::memory_order_relaxed);
   if (have >= height)
     return;
@@ -2433,7 +2429,7 @@ void BlockchainLMDB::build_block_cache(uint64_t height)
   RCURSOR(block_info);
 
   // Start from the cached height, not the vector size: remove_block lowers the
-  // height without shrinking, so these slots may hold popped blocks. Overwrite.
+  // height without shrinking, so these slots may hold popped blocks.
   for (uint64_t index = have; index < height; ++index)
   {
     MDB_val_set(query, index);
@@ -4087,6 +4083,18 @@ void BlockchainLMDB::batch_abort()
   m_write_batch_txn = nullptr;
   m_batch_active = false;
   memset(&m_wcursors, 0, sizeof(m_wcursors));
+
+  // build_block_cache reads through the batch write txn, so the cache can cover
+  // blocks this abort just discarded, and remove_block never ran for them. Same
+  // stale seed data a reorg would leave. height() after the abort reflects what
+  // actually committed.
+  {
+    const uint64_t committed = height();
+    boost::unique_lock<boost::shared_mutex> cache_lock(m_block_cache_lock);
+    if (m_block_cache_height.load(std::memory_order_relaxed) > committed)
+      m_block_cache_height.store(committed, std::memory_order_release);
+  }
+
   LOG_PRINT_L3("batch transaction: aborted");
 }
 


### PR DESCRIPTION
## Problem

`m_block_cache` is a height-indexed cache of block data that feeds the CryptoNight-Adaptive proof of work seed (`get_cna_v2_data`, `get_cna_v6_data`). Nothing invalidated it when blocks were removed: only `close()` and `reset()` cleared it, and `build_block_cache` only ever appended.

There are three ways the chain can lose blocks and two of them left the cache stale. `remove_block()` covers every pop and every reorg. `batch_abort()` is the less obvious one: `build_block_cache` reads through the batch write transaction by design, so the cache legitimately covers blocks that are still uncommitted, and an abort discards them without `remove_block()` ever running.

In both cases `m_block_cache_height` kept claiming heights whose contents had changed, so later seeds were drawn from a chain that no longer existed. The node then computed a different long hash than the network for every block and rejected each as bad proof of work, while still looking connected.

## When it bites

Live on v0.3.0.0 today, through the recovery path. After a `pop_blocks` deeper than the cache frontier, the entries above the new tip survive and `build_block_cache` short-circuits on `have >= height`, so the node keeps seeding from records the pop removed. **This is why popping alone has never recovered a forked node and a restart has always been needed.**

Observed on mainnet 2026-08-31: a node stalled at 4377750, was popped 500 blocks, resynced, stalled again at the same height with the identical computed hash, and only recovered once a restart rebuilt the cache from disk.

Separately, `warm_block_cache` inside `ensure_batch_longhashes` (added by #117) lifts the cache to the tip during catch-up sync. That widens the exposure from deep pops to ordinary reorgs once HF14 activates at 4,500,000.

Complementary to #136, which fixes a separate on-disk corruption. Recovering an already-forked node needs both: the pop writes correct difficulties back to disk, and this stops the cache from serving the stale ones.

## Fix

- `remove_block()` lowers `m_block_cache_height`. Single chokepoint for pops and reorgs.
- `batch_abort()` lowers it to what actually committed.
- `build_block_cache()` refills from that height and overwrites the stale slots, and re-checks the height under the lock so a concurrent filler's entries are not discarded.

The height is lowered but the vector is never shrunk. Readers resolve a height before taking the shared lock, so shrinking could drop the buffer under a live reader and walk it off the end (same class as #108). Leaving the entries in place and overwriting them on the way back up is equally correct and cannot fault.

Not a consensus change. The rule is unchanged, this only stops a stale cache from breaking it. No fork height, no reindex, and safe to deploy node by node, since the stale state was always node-local.

## Testing

Two tests that look right and prove nothing: a forward sync never calls `remove_block()`, and `pop_blocks` plus a resync re-downloads the same blocks, so the stale entries match and it passes on master too. It needs a real divergence, and the cache has to reach above the fork point.

Two isolated daemons at a common height `F`:

1. Miner mines 100 blocks. The test node syncs them in one batch, which is what runs `warm_block_cache` and lifts the cache to the tip. Confirm with a `Hashed N blocks on N threads` line (needs `--show-time-stats 1`); without it the cache never rises above `tip - 255` and the test is vacuous.
2. Isolate. The miner pops back to `F` and mines a longer chain reaching at least `F + 260`.
3. Reconnect and let the test node reorg. Do not restart it, since a restart rebuilds the cache from disk and hides the bug.

Keep the first chain under 256 blocks so the reorg can complete at all, and make the second exceed `F + 257`, which is where the first poisoned slot is read.

Expected: on master the test node reorgs and then stalls at `F + 257`. On this branch it follows to the tip. Run both arms, since the failure on master is what proves the test reaches the bug.
