### PR TITLE
chore: push HF14 mainnet activation height to 4500000

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -244,11 +244,12 @@ namespace config
         {11, 500000},
         {12, 930000},
         {13, 4320000},  // CryptoNight-Adaptive v6: 8 MB scratchpad + random VM program
-        {14, 4400000}   // CLSAG + Bulletproofs+ (type 7 only) and CryptoNight-Adaptive
+        {14, 4500000}   // CLSAG + Bulletproofs+ (type 7 only) and CryptoNight-Adaptive
                         // v7 (per-nonce mutable-buffer chase, one box ~ one vote).
-                        // Placeholder, about six weeks of blocks past the tip it was
-                        // picked against. It moves if the validation gates slip:
-                        // reference-pair run, testnet fork, GPU port test.
+                        // Placeholder height, held far enough out that builds from
+                        // master don't fork early. The real one is set once the
+                        // validation gates pass: reference-pair run, testnet fork,
+                        // GPU port test.
     };
 
     namespace testnet


### PR DESCRIPTION
Moves the mainnet HF14 activation height from 4400000 to 4500000 in `src/cryptonote_config.h`.

The height is still a placeholder pending the validation gates (reference-pair run, testnet fork, GPU port test), but 4400000 sits close enough to the tip that anyone running a build from master would fork off before the real height is picked. Holding it at 4500000 keeps that from happening while the gates are worked through.

Testnet and stagenet are unchanged (HF14 at 1000). No other reference to the old height exists in the tree.