### PR TITLE
fix(core): a stale reader poisoned the difficulty window cache

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -86,7 +86,7 @@ DISABLE_VS_WARNINGS(4267)
 
 //------------------------------------------------------------------
 Blockchain::Blockchain(tx_memory_pool& tx_pool) :
-  m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_hash_context(NULL), m_timestamps_and_difficulties_height(0), m_current_block_cumul_weight_limit(0), m_current_block_cumul_weight_median(0),
+  m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_hash_context(NULL), m_timestamps_and_difficulties_height(0), m_timestamps_and_difficulties_top_hash(crypto::null_hash), m_current_block_cumul_weight_limit(0), m_current_block_cumul_weight_median(0),
   m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_batch_longhash_base(0), m_prepare_blocks(NULL), m_prepare_nblocks(0), m_db_sync_on_blocks(true), m_db_sync_threshold(1), m_db_sync_mode(db_async), m_db_default_sync(false), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0), m_bytes_to_sync(0), m_cancel(false),
   m_long_term_block_weights_window(CRYPTONOTE_LONG_TERM_BLOCK_WEIGHT_WINDOW_SIZE),
   m_long_term_effective_median_block_weight(0),
@@ -872,6 +872,9 @@ uint64_t Blockchain::get_difficulty_for_next_block()
   }
 
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  // one snapshot for the tip and every block read below; without it each read
+  // renews its own txn and a batch committing mid-loop splices two chains
+  db_rtxn_guard rtxn_guard(m_db);
   std::vector<uint64_t> timestamps;
   std::vector<difficulty_type_128> difficulties;
   uint64_t height;
@@ -894,7 +897,12 @@ uint64_t Blockchain::get_difficulty_for_next_block()
   //    then when the next block difficulty is queried, push the latest height data and
   //    pop the oldest one from the list. This only requires 1x read per height instead
   //    of doing 735 (DIFFICULTY_BLOCKS_COUNT).
-  if (m_timestamps_and_difficulties_height != 0 && ((height - m_timestamps_and_difficulties_height) == 1) && m_timestamps.size() >= difficulty_blocks_count)
+  // The cached window is keyed by its newest block, not just by height. A
+  // caller that is not the batch writer reads the last committed state, which
+  // during a reorg is the orphaned chain, and would otherwise hand the writer a
+  // window it then extends as if it were current.
+  if (m_timestamps_and_difficulties_height != 0 && ((height - m_timestamps_and_difficulties_height) == 1) && m_timestamps.size() >= difficulty_blocks_count
+      && m_db->get_block_hash_from_height(height - 2) == m_timestamps_and_difficulties_top_hash)
   {
     uint64_t index = height - 1;
     m_timestamps.push_back(m_db->get_block_timestamp(index));
@@ -906,6 +914,7 @@ uint64_t Blockchain::get_difficulty_for_next_block()
       m_difficulties.erase(m_difficulties.begin());
 
     m_timestamps_and_difficulties_height = height;
+    m_timestamps_and_difficulties_top_hash = top_hash;
     timestamps = m_timestamps;
     difficulties = m_difficulties;
   }
@@ -929,6 +938,7 @@ uint64_t Blockchain::get_difficulty_for_next_block()
     }
 
     m_timestamps_and_difficulties_height = height;
+    m_timestamps_and_difficulties_top_hash = top_hash;
     m_timestamps = timestamps;
     m_difficulties = difficulties;
   }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1100,6 +1100,10 @@ namespace cryptonote
     std::vector<uint64_t> m_timestamps;
     std::vector<difficulty_type_128> m_difficulties;
     uint64_t m_timestamps_and_difficulties_height;
+    // hash of the newest block in m_timestamps/m_difficulties; the height alone
+    // does not identify the window, since a reorg keeps the height and changes
+    // the contents
+    crypto::hash m_timestamps_and_difficulties_top_hash;
     uint64_t m_long_term_block_weights_window;
     uint64_t m_long_term_effective_median_block_weight;
     mutable uint64_t m_long_term_block_weights_cache_tip_height;


### PR DESCRIPTION
Closes #135.

## Cause

`get_difficulty_for_next_block` is called from RPC threads with no blockchain
lock: `on_get_info` (`core_rpc_server.cpp:328`), `on_mining_status` (`:1367`)
and the zmq `get_info` (`daemon_handler.cpp:442`). The comment above the fast
path says that is fine because the answer may just be slightly out of date. It
is not fine, for a reason unrelated to staleness.

Those threads are not the batch writer. `block_rtxn_start` returns the write txn
only to `m_writer`; everyone else gets an `MDB_RDONLY` txn on the last committed
state. `prepare_handle_incoming_blocks` scopes the blockchain lock to itself and
releases it on return, while the batch it opened stays open across the whole
per-block loop. So an RPC thread can hold the blockchain lock, mid-batch, and
read a chain the writer has already reorged away.

It then rebuilds `m_timestamps`/`m_difficulties` from that view and publishes
them under `m_timestamps_and_difficulties_height`, which is keyed by height
alone. A reorg keeps the height and changes the contents. Every reorg path
already resets the height to 0 (`:1016`, `:602`, `:620`), which is why an audit
of those resets comes up clean; the reader sets it straight back afterwards,
from a chain that no longer exists.

The writer's next call then finds a cached height exactly one below its own,
takes the incremental path, and appends an accepted block to an orphaned window:

```
committed: ... 4377488, 4377489-A          (orphan tip, height 4377490)
in batch:  ... 4377488, 4377489-B, 4377490-B

writer  height 4377491, window ends 4377490-B      correct
rpc     height 4377490, rebuilds from chain A      m_t_a_d_height = 4377490
        batch commits
writer  height 4377491, delta == 1 -> incremental
        window = [4377430..4377490] with 4377489-A
```

That is the observed 2492059 in #135, to the digit.

## Fix

Key the window by the hash of its newest block, exactly as the difficulty value
cache at `:867` already is. Identical hash at identical height implies identical
ancestry, so validating the newest entry validates the whole window. A mismatch
costs one full 61-block rebuild.

Also take a single read transaction for the tip read and the window. Each lookup
otherwise renews its own, so a 61-block window is 122 independent snapshots and
a commit landing mid-loop can splice two chains. This is hardening rather than
part of the fix, and it removes 121 renew/reset pairs per `get_info`.

Not a consensus change. The rule is unchanged; this stops a stale cache from
breaking it. No fork height, no reindex, safe node by node.

## Testing

The cheap tests prove nothing here: a forward sync never diverges the two views,
and a single-threaded reorg never has a reader in the gap. The bug needs a reorg
inside an open batch and a concurrent RPC poll.

**Transcription test.** I transcribed the cache logic with both LMDB views and
ran the orderings. Sequencing matters: the difficulty for block `h` is computed
while the chain height is `h`, and using the post-add view instead hides the
bug entirely.

| case | master | this branch |
| --- | --- | --- |
| reorg, no RPC poll (control) | clean | clean |
| reorg + RPC poll inside the batch | corrupt @4377489 | clean |
| repeated polls | corrupt | clean |
| 3-block reorg + poll | corrupt @4377487-89 | clean |
| poll straddling the commit, both orderings | clean | clean |
| batch_abort then re-add | clean | clean |

Fast path unaffected: 1 full rebuild per 200 blocks, identical to master.

**Arithmetic.** Independently reproduced #135's numbers. The reported LWMA times
k=1830 is exactly 108777, so it is consistent with the real `next_difficulty_v6`.
Canonical gives 2492013; one interior timestamp at +2s gives 2492059.03 ->
2492059. The canonical result sits 0.21 from the integer boundary, relative
8.4e-8, so #120's class of problem is excluded.

**Live repro**, if someone wants it end to end: two isolated daemons at a common
height, poll `get_info` in a loop at 1 Hz against the test node, then feed it a
span that reorgs its tip and continues for at least 260 blocks. On master it
stores a difficulty that disagrees with the miner's for the block after the
reorg and stalls 259 blocks later; on this branch it follows. The poll is the
part that makes it reproduce.

## Relationship to #133

Independent bugs, no file overlap, rebases cleanly either way. #133 is an
in-memory cache that a restart clears. This one writes wrong consensus data to
disk that a restart does not clear.

They should ship in the same release, because recovering an already-forked node
needs both: popping blocks writes correct difficulties back to disk, but without
#133 `m_block_cache` keeps serving the stale `diff_lo`.
