### PR TITLE
fix(wallet): sweep rebuilt the transaction with a fee its destination…

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9476,7 +9476,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
         tx.ptx = test_ptx;
         tx.weight = get_transaction_weight(test_tx, txBlob.size());
         tx.outs = outs;
-        tx.needed_fee = needed_fee;
+        // the fee the tx was built with; the rebuild below sizes change against it
+        tx.needed_fee = test_ptx.fee;
         accumulated_fee += test_ptx.fee;
         accumulated_change += test_ptx.change_dts.amount;
         adding_fee = false;
@@ -9836,7 +9837,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
       tx.ptx = test_ptx;
       tx.weight = get_transaction_weight(test_tx, txBlob.size());
       tx.outs = outs;
-      tx.needed_fee = needed_fee;
+      // the fee the tx was built with; a sweep has no change to absorb a lower one
+      tx.needed_fee = test_ptx.fee;
       accumulated_fee += test_ptx.fee;
       accumulated_change += test_ptx.change_dts.amount;
       if (!unused_transfers_indices.empty() || !unused_dust_indices.empty())


### PR DESCRIPTION
…s were not sized for

The fee loop settles on a transaction built with fee F, then stores the fee recomputed from that transaction, F', which the loop condition keeps at or below F and which is usually below it. The signing pass then rebuilds from the stored fee while the destinations are still sized for F, so F - F' comes back as change nobody asked for. A sweep has no change to absorb it, so sanity_check refuses the wallet's own transaction and there is no way to sweep.

Store the fee the transaction was actually built with. That is what upstream does at both sites, and accumulated_fee on the next line was already using it, so the two stop disagreeing. create_transactions_2 carried the same divergence and is fixed with it; it just has change to hide the difference in.

The transaction now pays F rather than the marginally lower F', and it carries one output fewer, since the spurious change is gone.

The trigger is the per kB rounding in calculate_fee, kB = (bytes + 1023) / 1024. F and F' differ only when the estimate and the built transaction land in different kB buckets, so it turns on transaction size, not on the transaction format or the fork. It bites on HF13, the format mainnet runs today.

Fixes #127