### PR TITLE
fix(rpc): reject a coinbase sum range that runs past the tip

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2507,7 +2507,8 @@ namespace cryptonote
   {
     RPC_TRACKER(get_coinbase_tx_sum);
     const uint64_t bc_height = m_core.get_current_blockchain_height();
-    if (req.height >= bc_height || req.count > bc_height)
+    // The height check runs first, so bc_height - req.height cannot underflow.
+    if (req.height >= bc_height || req.count > bc_height - req.height)
     {
       res.status = "height or count is too large";
       return true;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -87,7 +87,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 4
-#define CORE_RPC_VERSION_MINOR 1
+#define CORE_RPC_VERSION_MINOR 2
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 


### PR DESCRIPTION
The guard on `get_coinbase_tx_sum` tested `req.height` and `req.count` against the chain height independently, so nothing constrained their sum:

```cpp
if (req.height >= bc_height || req.count > bc_height)
```

Each half can be satisfied while the range runs well past the tip. On a chain at height 4343869, `{"height": 4343868, "count": 4343869}` is accepted, one block is summed, and the result comes back as `CORE_RPC_STATUS_OK` for a 4343869-block range. The daemon prints `[4343868, 8687737)`.

Nothing downstream caught it. `BlockchainLMDB::for_blocks_range` breaks on `MDB_NOTFOUND` at the tip with `fret` still `true`, so a short walk is indistinguishable from a complete one, and `core::get_coinbase_tx_sum` discards that bool anyway. Neither the status nor the return value told a caller the range had been truncated.

Comparing `count` against `bc_height - req.height` bounds the far end. The height check runs first and `||` short circuits, so the subtraction cannot underflow.

### Verification

There is no test tree in this repo, so I verified the predicate directly instead. Exhaustively, for every `bc_height` in 1..40, `height` in 0..45 and `count` in 0..90 (167440 combinations), against ground truth "the range [h, h+c) lies inside [0, bc)":

    new guard mismatches : 0
    old guard mismatches : 10660

Boundary cases at a realistic height, old vs new:

| case | old | new | correct |
|---|---|---|---|
| tip start, full-chain count (#140 repro) | accept | reject | reject |
| mid-chain start, full-chain count (#140 repro) | accept | reject | reject |
| legitimate whole chain (`0, bc_height`) | accept | accept | accept |
| one past the whole chain | reject | reject | reject |
| last block only | accept | accept | accept |
| last block plus one past the tip | accept | reject | reject |
| empty range (`count = 0`) | accept | accept | accept |
| `count = UINT64_MAX` | reject | reject | reject |
| `height = UINT64_MAX` | reject | reject | reject |

The whole-chain call that #126 just made exact is still accepted, which was the main thing to not break. `core_rpc_server.cpp`, `rpc_command_executor.cpp` and `cryptonote_core.cpp` compile clean.

Both daemon CLI paths surface the rejection rather than swallowing it: the direct path checks `res.status` explicitly, and `rpc_client.h::json_rpc_request` checks it for the remote path.

### Notes

Requests that ran past the tip now fail with `height or count is too large` where they previously returned a plausible but short sum. That is the intent.

`CORE_RPC_VERSION_MINOR` goes to 2. No response field changed, so this is not the defs-header rule; the reason is the compatibility note below. A caller that chunks the range has no other way to tell a daemon that accepts an overshooting last chunk from one that rejects it, and it needs that to decide whether to clamp for itself. Minor rather than major, because a client sending a range inside the chain is unaffected and the wire format is identical. I originally reasoned by analogy to #122 and left the version alone; that analogy was weak, because #122 only tightened restricted-mode paths while this changes a call shape that succeeded on every daemon in the field.

**Compatibility, worth calling out.** A fixed-size chunked walk overshoots on its last chunk, and that is the pattern #126's description attributes to the supply tooling. At height 4343869 with a chunk of 100000, the final request is `{height: 4300000, count: 100000}`, reaching 4400000. Today that is accepted and returns the correct partial sum for 4300000..4343868. After this change it is rejected.

Any such caller has to clamp its last chunk. The migration is clean rather than painful, because #126 removed the reason to chunk in the first place: one call over the whole range is now exact, so the workaround this bound was propping up is obsolete. But it is a live break for anything not yet updated, and it is the strongest argument for clamping to the valid range instead of rejecting. I went with rejecting because that matches the issue, upstream, and the #122 precedent, and because silently answering a different question than the one asked is the defect being fixed.

Left alone deliberately: `core::get_coinbase_tx_sum` still discards the `for_blocks_range` return value. With the range now bounded it cannot truncate for that reason, and the residual is a reorg landing between the `bc_height` read and the read-only transaction opening - narrow, pre-existing, and shared with other handlers, so not worth widening this change for.

Closes #140.
