### PR TITLE
docs: regenerate openapi.yaml for the RPC changes that landed beside it

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -20,7 +20,7 @@ info:
 
     This document is generated from the daemon source by scripts/openapi/generate_openapi.py and is checked
     for drift in CI.'
-  version: 4.0.0
+  version: 4.1.0
   contact:
     name: Nerva Project
     url: https://nerva.one
@@ -1797,13 +1797,21 @@ components:
         emission_amount:
           type: integer
           format: int64
+        emission_amount_top64:
+          type: integer
+          format: int64
         fee_amount:
+          type: integer
+          format: int64
+        fee_amount_top64:
           type: integer
           format: int64
       required:
       - status
       - emission_amount
+      - emission_amount_top64
       - fee_amount
+      - fee_amount_top64
     GetConnectionsResponse:
       type: object
       properties:


### PR DESCRIPTION
## Problem

`ci/gh-actions/openapi` has failed on master since #130 landed, at the drift check:

```
docs/openapi.yaml is out of sync with the RPC sources.
Run python3 scripts/openapi/generate_openapi.py and commit the result.
```

This is a semantic merge conflict, not a bug in the generator. #130 generated and committed `docs/openapi.yaml` from a base that predated two PRs which merged ahead of it:

| Merged first | What it changed | Resulting drift |
| --- | --- | --- |
| #126 | Added `emission_amount_top64` / `fee_amount_top64` to `GET_COINBASE_TX_SUM` | 4 missing properties and 2 missing `required` entries in `GetCoinbaseTxSumResponse` |
| #124 | Bumped `CORE_RPC_VERSION_MINOR` 0 to 1 | `info.version` committed as `4.0.0`, generator derives `4.1.0` |

Git merged all three cleanly because they touch different files, but the generator reads the RPC headers, so the committed specification went stale as soon as #130 was applied on top.

## Fix

Output of `python3 scripts/openapi/generate_openapi.py` against current master. No source changes.

## Verification

The regenerated file matches the diff CI reports exactly, 9 insertions and 1 deletion, and passes the validator:

```
docs/openapi.yaml: OK
```

## Follow-up worth considering

This will recur whenever a PR adding an RPC field or bumping the RPC version merges beside another such PR, since the check runs on a `src/rpc/**` path filter and cannot see a conflicting merge landing next to it. Requiring branches to be current before merge, or having the workflow regenerate and commit rather than fail, would close that gap.
