### PR TITLE
docs: regenerate openapi.yaml for the rpc version bump in #141

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -20,7 +20,7 @@ info:
 
     This document is generated from the daemon source by scripts/openapi/generate_openapi.py and is checked
     for drift in CI.'
-  version: 4.1.0
+  version: 4.2.0
   contact:
     name: Nerva Project
     url: https://nerva.one


### PR DESCRIPTION
`master` is red on the openapi drift check as of fabd79e.

#141 bumped `CORE_RPC_VERSION_MINOR` to 2, and the generated spec carries that number in `info.version`. #141 was branched before #130 added the openapi workflow, so its own checks never included the drift job and the breakage only surfaced on the push to master.

Regenerated with `scripts/openapi/generate_openapi.py`:

```diff
-  version: 4.1.0
+  version: 4.2.0
```

That line is the only difference, which is the useful part: it confirms nothing else in the spec had silently drifted, and that #141 is the whole cause.

Checked the same way CI does - generator run is idempotent on a second pass, and `openapi-spec-validator docs/openapi.yaml` reports OK.
