### PR TITLE
fix(rpc): bound the heights the rpc layer feeds straight to the db

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1893,6 +1893,15 @@ namespace cryptonote
   bool core_rpc_server::fill_block_header_response(const block& blk, bool orphan_status, uint64_t height, const crypto::hash& hash, block_header_response& response)
   {
     PERF_TIMER(fill_block_header_response);
+    // An alt block carries its own height, so it can sit past the tip: the db
+    // reads below would throw for it and depth would underflow. Checked before
+    // anything is written, so a rejected header leaves response untouched.
+    const uint64_t bc_height = m_core.get_current_blockchain_height();
+    if (height >= bc_height)
+    {
+      MDEBUG("Block header requested for height " << height << ", chain height " << bc_height);
+      return false;
+    }
     response.major_version = blk.major_version;
     response.minor_version = blk.minor_version;
     response.timestamp = blk.timestamp;
@@ -1900,16 +1909,25 @@ namespace cryptonote
     response.nonce = blk.nonce;
     response.orphan_status = orphan_status;
     response.height = height;
-    response.depth = m_core.get_current_blockchain_height() - height - 1;
+    response.depth = bc_height - height - 1;
     response.hash = string_tools::pod_to_hex(hash);
     response.difficulty = m_core.get_blockchain_storage().block_difficulty(height);
-    store_128(m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(height),
-        response.cumulative_difficulty, response.cumulative_difficulty_top64);
     response.reward = get_block_reward(blk);
-    response.block_size = response.block_weight = m_core.get_blockchain_storage().get_db().get_block_weight(height);
     response.num_txes = blk.tx_hashes.size();
-    response.long_term_weight = m_core.get_blockchain_storage().get_db().get_block_long_term_weight(height);
     response.miner_tx_hash = string_tools::pod_to_hex(cryptonote::get_transaction_hash(blk.miner_tx));
+    // Bounded above, but a reorg between that read and these still throws.
+    try
+    {
+      store_128(m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(height),
+          response.cumulative_difficulty, response.cumulative_difficulty_top64);
+      response.block_size = response.block_weight = m_core.get_blockchain_storage().get_db().get_block_weight(height);
+      response.long_term_weight = m_core.get_blockchain_storage().get_db().get_block_long_term_weight(height);
+    }
+    catch (const std::exception &e)
+    {
+      MERROR("Failed to fill block header at height " << height << ": " << e.what());
+      return false;
+    }
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -2522,13 +2540,33 @@ namespace cryptonote
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_generated_coins(const COMMAND_RPC_GET_GENERATED_COINS::request& req, COMMAND_RPC_GET_GENERATED_COINS::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx)
   {
-    PERF_TIMER(on_get_generated_coins);
+    RPC_TRACKER(get_generated_coins);
     CHECK_CORE_READY();
+    const uint64_t bc_height = m_core.get_current_blockchain_height();
     uint64_t h = req.height;
     if (h == 0)
-      h = m_core.get_current_blockchain_height() - 1;
-    uint64_t c = m_core.get_blockchain_storage().get_db().get_block_already_generated_coins(h);
-    res.coins = c;
+      h = bc_height - 1;
+    else if (h >= bc_height)
+    {
+      error_resp.code = CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT;
+      error_resp.message = std::string("Requested block height: ") + std::to_string(req.height) + " greater than current top block height: " +  std::to_string(bc_height - 1);
+      return false;
+    }
+    // Bounded above, but a reorg between the height read and the lookup still throws.
+    try
+    {
+      res.coins = m_core.get_blockchain_storage().get_db().get_block_already_generated_coins(h);
+    }
+    catch (const std::exception &e)
+    {
+      // The reason goes to the log, not to a caller who may be unauthenticated.
+      MERROR("Failed to get generated coins at height " << h << ": " << e.what());
+      // The in-process daemon caller reads res.status and never sees error_resp.
+      res.status = "Failed to get generated coins";
+      error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+      error_resp.message = "Internal error: can't get generated coins. Height = " + std::to_string(req.height) + '.';
+      return false;
+    }
     res.status = CORE_RPC_STATUS_OK;
     return true;
   }


### PR DESCRIPTION
Two RPC paths handed a caller-supplied height straight to the db, which throws `BLOCK_DNE` when the block is not there. Both are reachable unauthenticated.

### `on_get_generated_coins`

`req.height` went straight to `get_block_already_generated_coins`. Only `h == 0` was remapped to the tip, so any height at or above the chain height reached the throw, and the method is registered with `MAP_JON_RPC_WE` rather than `MAP_JON_RPC_WE_IF(..., !m_restricted)`, so it is served on a restricted port too. One field was enough.

### `fill_block_header_response` - the more exposed of the two

**Correction to an earlier version of this description, which claimed `get_generated_coins` was the only handler of its kind. It was not.** `fill_block_header_response` takes the height from the block's own coinbase (`boost::get<txin_gen>(blk.miner_tx.vin.front()).height`), not from the chain, so an **alt block can carry a height at or past the tip**. It then makes three direct db reads with it - `get_block_cumulative_difficulty`, `get_block_weight`, `get_block_long_term_weight` - each of which throws for such a height, and `depth = get_current_blockchain_height() - height - 1` underflows to about 2^64 on the way. Reachable unauthenticated via `getblockheaderbyhash` and `getblock` with an alt block hash.

`block_difficulty` on the line above is safe only by accident: `Blockchain` catches `BLOCK_DNE` internally for that one.

### Severity, traced

The issue was filed with this unconfirmed, so I followed the unwind: these handlers call the db directly and so miss the `catch (const BLOCK_DNE&)` inside `Blockchain::get_block_id_by_height`; `simple_http_connection_handler::handle_request_and_send_response` calls `handle_request` with no catch; the exception lands in the `catch (const std::exception&)` around `io_context_.run()` in `boosted_tcp_server::worker_thread`, which logs and re-enters the loop.

So the daemon does not crash. The connection being handled is abandoned mid-request, and it is a cheap unauthenticated trigger for connection churn and error-log volume. Availability-flavoured rather than memory-unsafe - worth stating plainly rather than leaving it sounding worse than it is.

### The fix

`on_get_generated_coins` is bounded the way the other height-taking handlers in this file are, reusing `CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT` and the wording from `on_get_block_header_by_height`. The `h == 0` shorthand is preserved and the chain height is read once so the bound and the message cannot disagree. The db call is wrapped too, since the height is read before the lookup and a reorg in between would leave it stale; every exception that call can raise derives from `std::exception` (`BLOCK_DNE` -> `DB_EXCEPTION` -> `std::exception`). The reason goes to `MERROR`, not into `error_resp`, since the caller may be unauthenticated and `what()` can carry internal detail.

`fill_block_header_response` is guarded before any field is written, so a rejected header leaves the caller's response object untouched, and its three db reads are wrapped for the same reorg race. All five call sites already convert a `false` return into `CORE_RPC_ERROR_CODE_INTERNAL_ERROR`, and the guard can only fire where the code previously threw or underflowed.

The two log levels differ on purpose. The guard is at `MDEBUG`: an alt chain briefly ahead of the main one is a real state an honest query can hit, so it must not become a lever for filling the log - the same amplification this PR is fixing. The wrapped reads log at `MERROR`, because a throw *after* the bound means something genuinely unexpected, and a reorg is not attacker-controlled.

Two things that came out of review rather than the original report:

- The catch path sets `res.status` as well as `error_resp`. `t_rpc_command_executor::print_generated_coins` calls the handler in-process and prints `make_error(fail_message, res.status)`; it never reads `error_resp`, so without this the operator gets "Unsuccessful" with a blank reason. The too-big-height path deliberately does *not* set it: `t_command_parser_executor::print_generated_coins` discards its `args` and calls a no-argument executor, so that caller always sends height 0 and can never reach the branch - a `res.status` there would be dead code.
- The handler now uses `RPC_TRACKER` rather than bare `PERF_TIMER`, so it appears in RPC statistics like its neighbours. For a method this cheap to call unauthenticated, being invisible to the stats an operator would use to spot abuse was the wrong default.

### Verification

Modelled the old and new height resolution and ran both exhaustively over `bc_height` 1..200 x `req.height` 0..400:

    new guard ever reaches the db out of range : no
    old code reached a throwing db call        : 60100 times

Every height inside the chain resolves identically to before, so this is purely a rejection of inputs that previously threw.

| request height | old | new |
|---|---|---|
| `0` (documented "tip" shorthand) | queries 4343868 | queries 4343868 |
| tip | queries 4343868 | queries 4343868 |
| one past the tip | queries 4343869, **throws** | `TOO_BIG_HEIGHT` |
| `UINT64_MAX` (the repro) | queries 18446744073709551615, **throws** | `TOO_BIG_HEIGHT` |

Compiles with 68 warnings, the same count as the unmodified file, so the change introduces none. `scripts/openapi/generate_openapi.py` output is byte-identical, so the drift gate that #141 tripped stays green.

`bc_height - 1` cannot underflow: `Blockchain::init` generates and adds the genesis block when the db is empty and fails init if that does not stick, so the chain is never empty by the time rpc is served. Worth noting that `CHECK_CORE_READY` is *not* what makes this safe - it only tests p2p synchronisation. I checked the invariant rather than adding an unreachable guard for it.

### Deliberately not in this change

- **No `CORE_RPC_VERSION` bump**, which is the opposite of the call made in #141 and worth justifying. #141 changed requests that previously returned `OK` with a real, if short, answer, so a client needed a way to tell the two daemons apart. Here the previous behaviour was an unhandled exception and a dropped connection - not an API contract anyone could have depended on, and trivially distinguishable at runtime without a version. Fixing a crash is not an interface change.
- **Registration left as `MAP_JON_RPC_WE`.** The unrestricted exposure is half the diagnosis, but total emission at a height is public information of the same kind `get_info` already serves, and gating it would break public explorers for no security gain once the throw is closed. `get_coinbase_tx_sum` is restricted because it is O(chain) to compute, which is a cost argument rather than a secrecy one.
- **`on_getblockhash` at line 1670** sets `error_resp` for a too-big height and then falls through without `return false`, so the error is discarded and the caller gets an all-zeros hash with a success response. It cannot throw, since `get_block_id_by_height` catches internally - a wrong-answer bug rather than this class, so it belongs in its own change. Tracked as #147, fixed in #148.

  *Corrected after merge:* this bullet originally said the fall-through "is upstream Monero's code verbatim", which I asserted from memory without checking, and it was the load-bearing half of the reasoning. Monero v0.18.x does lack the `return false`, so it did arrive through the fork lineage - but upstream fixed it in [`be79b83b4`](https://github.com/monero-project/monero/commit/be79b83b4) (monero-project/monero#10109). It was not a quirk to preserve for parity; it was a bug upstream had already dropped and this tree was still carrying. The deferral itself still stands on its other ground, that it is a different class from the throw this PR closed.
- The `TOO_BIG_HEIGHT` message construction is now duplicated at four sites in this file, double space and all. A `check_height(uint64_t, epee::json_rpc::error&)` helper would collapse all four and would also give the other three the read-the-height-once property this change applies only to the new handler. Worth doing, but not while the surrounding change is a security fix.
- **An alt block *below* the tip still returns mixed data.** The guard stops the throw, not the deeper wart: for an orphan whose height is in range, `difficulty`, `cumulative_difficulty`, the weights and `depth` are read from the **main chain** at that height while `hash`, `nonce`, `timestamp` and `reward` come from the alt block, so the header mixes two blocks with no error. `BlockchainDB::get_alt_block` already returns an `alt_block_data_t` carrying `cumulative_weight` and `cumulative_difficulty_low/high`, so reading the alt record when `orphan_status` is true is the real fix. Pre-existing, unchanged by this PR, and its own piece of work - I am not claiming this change makes alt-block headers correct, only that it stops them throwing.
- **`INTERNAL_ERROR` is an imprecise label** for "you asked for an alt block past the tip", since all five call sites map `false` onto it. Fixing it properly means giving `fill_block_header_response` an error channel, which is a signature change across five sites; returning a mislabelled error still beats abandoning the connection.
- **No `use_bootstrap_daemon_if_necessary`.** Every neighbouring handler forwards to a bootstrap daemon first and this one does not, so an unsynced bootstrap node answers `BUSY`. It is a real gap, but it is a functional change unrelated to the height bug, and forwarding a Nerva-specific method to a daemon that may not implement it needs its own thought.
- **`bc_height == 0`** is unreachable, since `Blockchain::init` adds genesis or fails init, and `CHECK_CORE_READY` is *not* what makes that true - it only tests p2p sync. Both paths also degrade safely if it ever were: the `fill_block_header_response` guard rejects every height, and `get_generated_coins` turns the underflowed lookup into a caught `INTERNAL_ERROR` rather than a throw. I checked the invariant and the degradation rather than adding an unreachable branch.

Closes #142.

