### PR TITLE
ci: stop an unrelated apt repo from failing the ubuntu builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,11 @@ env:
         echo "Acquire::Retries \"3\";"         | sudo tee -a /etc/apt/apt.conf.d/80-custom
         echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
         echo "Acquire::ftp::Timeout \"120\";"  | sudo tee -a /etc/apt/apt.conf.d/80-custom
+    UPDATE_APT: |
+        # An unused third-party repo on the runner image serving a bad index would
+        # otherwise fail the job before anything is compiled. The install step is the
+        # real gate: a repo this build does need failing shows up there.
+        sudo apt-get update || echo "apt-get update reported errors, continuing"
     CCACHE_SETTINGS: |
         ccache --max-size=500M
         ccache --set-config=compression=true
@@ -76,9 +81,9 @@ jobs:
             -   name: Set APT configuration
                 run: ${{env.SET_APT_CONF}}
             -   name: Update APT
-                run: sudo apt update
+                run: ${{env.UPDATE_APT}}
             -   name: Install dependencies
-                run: sudo apt install -y build-essential cmake ccache pkg-config libboost-all-dev libssl-dev libzmq3-dev libpgm-dev libunbound-dev libsodium-dev git
+                run: sudo apt-get install -y build-essential cmake ccache pkg-config libboost-all-dev libssl-dev libzmq3-dev libpgm-dev libunbound-dev libsodium-dev git
             -   uses: ./.github/actions/set-make-job-count
             -   name: Build
                 run: |
@@ -163,9 +168,9 @@ jobs:
             -   name: Set APT configuration
                 run: ${{env.SET_APT_CONF}}
             -   name: Update APT
-                run: sudo apt update
+                run: ${{env.UPDATE_APT}}
             -   name: Install dependencies
-                run: sudo apt install -y build-essential cmake ccache pkg-config libboost-all-dev libssl-dev libzmq3-dev libpgm-dev libunbound-dev libsodium-dev git
+                run: sudo apt-get install -y build-essential cmake ccache pkg-config libboost-all-dev libssl-dev libzmq3-dev libpgm-dev libunbound-dev libsodium-dev git
             -   uses: ./.github/actions/set-make-job-count
             -   name: Build
                 run: |


### PR DESCRIPTION
`sudo apt update` fails if **any** configured repository has a bad index, and the step runs under `bash -e`, so the job dies before a line is compiled.

Not hypothetical: `build-ubuntu` and `libwallet-ubuntu` were red for a day on #145 with

```
Err  https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
E: Failed to fetch .../Packages.gz  Hash Sum mismatch
E: Some index files failed to download.
```

Google's Chrome repository is preinstalled on the GitHub runner image and nothing in this build uses it. Three reruns across twenty minutes hit the identical mismatch, so it was not flake; it cleared only when Google republished the index the following day. Meanwhile the change under test was fine - the other 18 jobs, including every cross-compile target, were green throughout.

The exposure is repo-wide: every ubuntu job, on every pull request and every push to master, can be red-lined by any third-party repository on the image having a bad hour. The `Acquire::Retries "3"` already configured does nothing against a hash mismatch, because the fetch succeeds and the checksum is what disagrees.

### What changed

The update step no longer decides the job. `apt-get install` directly below it is the real gate: if a repository this build *does* need failed to refresh, install fails there and names the package it could not find, which is a more useful error than the update step's anyway. A genuinely broken build still goes red, just at the step that can say why.

Also switched both steps to `apt-get`, the interface with a stable CLI for scripts, which drops the warning `apt` prints about exactly that on every run.

### The option I did not take

Deleting the unused third-party repositories is the obvious alternative and is not obviously safe. On noble the main archive can itself live in `sources.list.d` as `ubuntu.sources`, so a glob delete risks removing the repositories the build depends on - trading a transient outage for a permanent breakage. Naming the files individually avoids that but breaks silently whenever the runner image is rebuilt.

### Scope

`depends.yml` is deliberately untouched. It runs in a Debian container with no third-party repositories, and already separates update from install with `;`.

Verified the shell semantics under `bash -e`, which is the shell GitHub uses for `run:`: `cmd || echo` exits 0, so the step passes and execution reaches install. The multi-line `env` -> `run:` substitution follows the same pattern `SET_APT_CONF` already uses two lines above. This PR's own ubuntu jobs exercise the new path.
