### PR TITLE
fix(rpc): return the error getblockhash builds for a too-large height

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1669,6 +1669,7 @@ namespace cryptonote
     {
       error_resp.code = CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT;
       error_resp.message = std::string("Requested block height: ") + std::to_string(h) + " greater than current top block height: " +  std::to_string(m_core.get_current_blockchain_height() - 1);
+      return false;
     }
     res = string_tools::pod_to_hex(m_core.get_block_id_by_height(h));
     return true;


### PR DESCRIPTION
`on_getblockhash` built an error for a height past the tip and then discarded it, handing the caller an all-zeros hash inside a **successful** response.

```cpp
    if(m_core.get_current_blockchain_height() <= h)
    {
      error_resp.code = CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT;
      error_resp.message = ...;
    }                                    // <- no return
    res = string_tools::pod_to_hex(m_core.get_block_id_by_height(h));
    return true;
```

`get_block_id_by_height` catches `BLOCK_DNE` internally and yields the null hash, and `MAP_JON_RPC_WE` only serialises the error response when the callback returns `false`. Returning `true` therefore throws away the error that was just constructed:

    { "jsonrpc": "2.0", "id": "0",
      "result": "0000000000000000000000000000000000000000000000000000000000000000" }

no `error` member at all.

This is a wrong answer rather than the throw class fixed in #145 - no crash. It is reachable unauthenticated, and the method is registered twice, as `on_get_block_hash` and `on_getblockhash`, both with `MAP_JON_RPC_WE`, so a public daemon serves it. An explorer or indexer that checks the JSON-RPC `error` member, which is how most client libraries surface failure, records the null hash as a real block.

### This is upstream's fix

The behaviour matched Monero v0.18.x, so it arrived through the fork lineage rather than being introduced here. Upstream has since concluded it is a bug and fixed it in [`be79b83b4`](https://github.com/monero-project/monero/commit/be79b83b4), "Daemon RPC: fix on_getblockhash error return on too high height" (2025-09-25, monero-project/monero#10109). Applied verbatim:

```diff
       error_resp.message = std::string("Requested block height: ") + ...;
+      return false;
     }
```

I checked both ends rather than assuming: `v0.18.3.4` has no `return false` and matches us, `master` has it. The divergence now runs the other way round - we were carrying behaviour upstream had already dropped.

### Notes

No request or response field changes, and no behaviour change for a height inside the chain, so `CORE_RPC_VERSION` is untouched. Fixing a wrong answer is not an interface change, the same reasoning applied in #145, and upstream's own commit touches only this file with no version bump.

Compiles clean, and `scripts/openapi/generate_openapi.py` output is byte-identical so the drift gate stays green.

Closes #147.
