### PR TITLE
fix(rpc): give decode_outputs errors a message and scope its derivations

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -670,7 +670,8 @@ namespace cryptonote
     const bool restricted = m_restricted && ctx;
     if (restricted && req.tx_hashes.size() > RESTRICTED_TRANSACTIONS_COUNT)
     {
-      res.status = "Too many transactions requested in restricted mode";
+      error_resp.code = CORE_RPC_ERROR_CODE_RESTRICTED;
+      error_resp.message = "Too many transactions requested in restricted mode";
       return false;
     }
 
@@ -680,12 +681,14 @@ namespace cryptonote
       blobdata b;
       if(!string_tools::parse_hexstr_to_binbuff(tx_hex_str, b))
       {
-        res.status = "Failed to parse hex representation of transaction hash";
+        error_resp.code = CORE_RPC_ERROR_CODE_WRONG_PARAM;
+        error_resp.message = "Failed to parse hex representation of transaction hash";
         return false;
       }
       if(b.size() != sizeof(crypto::hash))
       {
-        res.status = "Failed, size of data mismatch";
+        error_resp.code = CORE_RPC_ERROR_CODE_WRONG_PARAM;
+        error_resp.message = "Failed, size of data mismatch";
         return false;
       }
       vh.push_back(*reinterpret_cast<const crypto::hash*>(b.data()));
@@ -698,7 +701,8 @@ namespace cryptonote
 
     if(!m_core.get_transactions(vh, txs, missed_txs))
     {
-      res.status = "Failed. Could not retrieve transactions";
+      error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+      error_resp.message = "Failed. Could not retrieve transactions";
       return false;
     }
 
@@ -722,9 +726,10 @@ namespace cryptonote
       }
     }
 
-    if (!get_account_address_from_str(ai, cryptonote::MAINNET, req.address))
+    if (!get_account_address_from_str(ai, nettype(), req.address))
     {
-      res.status = "Failed. Could not parse address";
+      error_resp.code = CORE_RPC_ERROR_CODE_WRONG_WALLET_ADDRESS;
+      error_resp.message = "Failed. Could not parse address";
       return false;
     }
 
@@ -736,15 +741,17 @@ namespace cryptonote
 
     if(!epee::string_tools::parse_hexstr_to_binbuff(req.sec_view_key, sec_vk_data) || sec_vk_data.size() != sizeof(crypto::secret_key))
     {
-      res.status = "Failed. Could not parse view key";
+      error_resp.code = CORE_RPC_ERROR_CODE_WRONG_PARAM;
+      error_resp.message = "Failed. Could not parse view key";
       return false;
     }
 
     view_seckey = *reinterpret_cast<const crypto::secret_key*>(sec_vk_data.data());
-    std::vector<crypto::key_derivation> tx_derivations;
-
     for(const auto& tx: txs)
     {
+      // Per transaction: an output can only be matched by its own tx's
+      // derivations, and sharing the vector made the scan quadratic.
+      std::vector<crypto::key_derivation> tx_derivations;
       crypto::public_key tx_pubkey = get_tx_pub_key_from_extra(tx.extra);
       crypto::key_derivation kd;
 
@@ -807,14 +814,16 @@ namespace cryptonote
                   break;
                 default:
                 {
-                  res.status = "Failed. Unknown RCT type";
+                  error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+                  error_resp.message = "Failed. Unknown RCT type";
                   return false;
                 }
               }
             }
             catch (const std::exception &e)
             {
-              res.status = "Failed. Failed to decode input";
+              error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+              error_resp.message = "Failed. Failed to decode input";
               return false;
             }
 


### PR DESCRIPTION
Two problems in `on_decode_outputs`, both self-contained.

### Errors carried no message

Every failure path did `res.status = "..."; return false;`. `decode_outputs` is registered `MAP_JON_RPC_WE`, and that macro serialises `fail_resp` only when the callback returns `false`, discarding `resp.result`. So `res` never reached the caller and `error_resp` was never populated - the client got an error with no code and no message, for all eight paths.

This is the mirror of #147, which I fixed in #148: there the error was built and the result returned; here the result was built and the error returned. Same outcome, caller cannot see what went wrong.

Each path now sets `error_resp` with a fitting code: `RESTRICTED` for the restricted-mode cap, `WRONG_PARAM` for the two hash parses and the view key, `WRONG_WALLET_ADDRESS` for the address, `INTERNAL_ERROR` for the transaction lookup, the unknown RCT type and the decode failure. The `res.status` writes are removed rather than kept alongside, since on this path they are provably dead.

### The output scan was quadratic

`tx_derivations` was declared above `for(const auto& tx: txs)` and never cleared, so each transaction appended to a vector still holding every earlier one's derivations, and had its outputs tested against all of them. Moving the declaration inside the loop matches each transaction's outputs against its own derivations, which is the only thing that can match them.

Wasted work rather than wrong answers - a false match would need a foreign derivation to reproduce the output key. Restricted mode caps the request at 100 transactions, so this only showed on an unrestricted daemon.

### Also fixed: the address was parsed against mainnet unconditionally

```diff
-    if (!get_account_address_from_str(ai, cryptonote::MAINNET, req.address))
+    if (!get_account_address_from_str(ai, nettype(), req.address))
```

Every valid address was rejected on a testnet or stagenet daemon, making the endpoint unusable there - and the first version of this PR made that rejection *legible* for the first time without fixing it. `nettype()` is available on `core_rpc_server` and the file's other two `get_account_address_from_str` call sites already use it; line 729 was the only holdout. Added at review request, since it would otherwise bite on the testnet run.

### Notes

I found the last two error paths (`Unknown RCT type`, `Failed to decode input`) only on a second pass; the first inventory used a fixed line window that stopped short of the end of the function. All eight are covered now, and the only `res.status` left in the handler is the success one.

Compiles clean at the same warning count as the unmodified file. No request or response field changes, so `CORE_RPC_VERSION` is untouched and `scripts/openapi/generate_openapi.py` output is byte-identical.

Closes #149.
