### PR TITLE
fix(pow): bound every seed read that a peer can drive to a low height

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -866,8 +866,18 @@ namespace cryptonote
       }
 
       b.nonce = nonce;
+      // 0xff and a checked return: h is only written when the hash succeeds,
+      // and an all-zero hash would pass check_hash at every difficulty.
       crypto::hash h;
-      get_block_longhash(hash_context, m_pbc, b, h, height);
+      memset(h.data, 0xff, sizeof(h.data));
+      if (!get_block_longhash(hash_context, m_pbc, b, h, height))
+      {
+        // Height-dependent, so retrying this template cannot help; wait for
+        // the next one rather than spinning.
+        LOG_PRINT_L2("No long hash available at height " << height);
+        epee::misc_utils::sleep_no_w(1000);
+        continue;
+      }
 
       // Report which pages the mining buffers landed on. The allocation used to
       // fall back to normal pages silently and mining just looked slow until

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -654,11 +654,22 @@ namespace cryptonote
     return get_block_longhash(context, db, b.major_version, blob, res, height);
   }
   //---------------------------------------------------------------
+  // get_cna_v2_data indexes the block cache by a XOR of two bytes below the
+  // height it is handed, so that height must be at least CN_SEED_BACKREACH for
+  // the subscript to stay in range. The hashers that read at a fixed depth take
+  // the sum; get_block_longhash_v7_8 takes its own offset instead.
+  //
+  // These are real checks rather than asserts because handle_alternative_block
+  // validates a block's fork version against the height its miner tx claims but
+  // hashes at the height derived from its parent, so a peer chooses the two
+  // independently and can drive any of these paths at any height.
+  static constexpr uint64_t CN_SEED_BACKREACH = 255;
+  static constexpr uint64_t CN_SEED_STABLE_DEPTH = 256;
+  static constexpr uint64_t CN_SEED_MIN_HEIGHT = CN_SEED_STABLE_DEPTH + CN_SEED_BACKREACH;
+  //---------------------------------------------------------------
   bool get_block_longhash_v13(crypto::cn_hash_context_t *context, BlockchainDB &db, const blobdata &blob, crypto::hash &res, uint64_t height)
   {
-    // same hard guard as the v14 path: the assert is compiled out in release
-    // and the subtraction below would wrap
-    if (height <= 257)
+    if (height < CN_SEED_MIN_HEIGHT)
       return false;
     const uint64_t stable_height = height - 256;
 
@@ -692,9 +703,7 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool get_block_longhash_v14(crypto::cn_hash_context_t *context, BlockchainDB &db, const blobdata &blob, crypto::hash &res, uint64_t height)
   {
-    // no fork table puts v14 this low; keep the guard hard because the
-    // assert is compiled out in release and the subtraction would wrap
-    if (height <= 257)
+    if (height < CN_SEED_MIN_HEIGHT)
       return false;
     const uint64_t stable_height = height - 256;
 
@@ -766,7 +775,10 @@ namespace cryptonote
   //---------------------------------------------------------------
   crypto::hash get_block_longhash(crypto::cn_hash_context_t *context, Blockchain *bc, const block& b, const uint64_t height)
   {
-    crypto::hash p = crypto::null_hash;
+    // 0xff rather than null: an all-zero hash passes check_hash at every
+    // difficulty, so a failure here must not read as a satisfied target.
+    crypto::hash p;
+    memset(p.data, 0xff, sizeof(p.data));
     get_block_longhash(context, bc, b, p, height);
     return p;
   }
@@ -774,8 +786,10 @@ namespace cryptonote
   bool get_block_longhash_v11(crypto::cn_hash_context_t *context, BlockchainDB &db, const blobdata &blob, crypto::hash &res, uint64_t height)
   {
     // Guard against chain splits by only taking data from blocks with at least
-    // 256 ancestors.
-    assert(height > 257);
+    // 256 ancestors. A real check, not an assert: handle_alternative_block
+    // hashes at a height derived from the parent, so this is reachable.
+    if (height < CN_SEED_MIN_HEIGHT)
+      return false;
     uint64_t stable_height = height - 256;
 
     if (context->cached_height != height)
@@ -813,6 +827,9 @@ namespace cryptonote
 
   bool get_block_longhash_v10(crypto::cn_hash_context_t *context, BlockchainDB &db, const blobdata &blob, crypto::hash& res, uint64_t height)
   {
+    if (height < CN_SEED_MIN_HEIGHT)
+      return false;
+
     const uint64_t ht = height - 256;
 
     if (context->cached_height != height)
@@ -854,6 +871,9 @@ namespace cryptonote
 
   bool get_block_longhash_v9(crypto::cn_hash_context_t *context, BlockchainDB &db, const blobdata &blob, crypto::hash& res, uint64_t height)
   {
+    if (height < CN_SEED_MIN_HEIGHT)
+      return false;
+
     const uint64_t ht = height - 256;
 
     if (context->cached_height != height)
@@ -877,6 +897,9 @@ namespace cryptonote
 
   bool get_block_longhash_v7_8(crypto::cn_hash_context_t *context, BlockchainDB &db, const blobdata &blob, crypto::hash& res, uint64_t height, uint64_t data_offset)
   {
+    if (height < data_offset + CN_SEED_BACKREACH)
+      return false;
+
     if (context->cached_height != height)
     {
       db.get_cna_v2_data(&context->random_values, height - data_offset, CN_SCRATCHPAD_MEMORY - 1);


### PR DESCRIPTION
> **Corrected after the first revision.** This originally described the bug as latent and "not reachable on mainnet, testnet or stagenet", and fixed only the v13/v14 guards on that basis. Both were wrong: it is remotely reachable on mainnet today, and the reasoning that made the other paths look safe does not hold. Scope and severity below are the corrected ones.

`handle_alternative_block` validates a block's fork version against the height its **miner tx claims**, but hashes at the height derived from its **parent**:

```cpp
  uint64_t block_height = get_block_height(b);            // from the miner tx
  ...
  if (!m_hardfork->check_for_height(b, block_height))     // version checked here
  ...
  bei.height = prev_height + 1;                           // real height
  ...
  get_block_longhash(m_hash_context, this, bei.bl, proof_of_work, bei.height);
```

`is_alternative_block_allowed` only requires the claimed height to sit above the last checkpoint (`checkpoint_height < block_height`) and never bounds it against the tip, so a peer chooses the two independently.

**A block claiming height 4,400,000 with `major_version` 13, whose `prev_id` is main-chain block 300, clears every gate and reaches `get_block_longhash_v13` at height 301.**

`get_cna_v2_data` indexes the block cache by a XOR of two bytes below the height it is handed, so that height must be at least 255. Hashers reading at `height - 256` therefore need **511**. The old guard was 258, which 301 passes: `stable_height` 45, subscript `45 - up_to_255`, wrapped, against a `std::vector` with an unchecked `operator[]`.

### Every seed read is guarded, not just the two that had guards

Activation heights bound the *claimed* height, never the height the hasher sees, so the "safe because they activate high" reasoning I used to leave the older paths alone was void:

| path | guard | was |
|---|---|---|
| v7 | `data_offset + 255` | none |
| v8 | same, offset 256 | none |
| v9 | 511 | none |
| v10 | 511 | none |
| v11 / v12 | 511 | `assert`, compiled out in release |
| v13 / v14 | 511 | `258` |

Constants replace the hand-copied number so the floor stays tied to the two values it is derived from.

### Nothing legitimate is refused

Checked every (network, version) activation pair against its guard: **zero rejections**. The lowest height that can legitimately reach a seed read is 550 (testnet v7) against a guard of 256. Below 511 every version is 6 or lower, and those hash without touching the database — including legitimate alt blocks, whose claimed height equals their real height.

### Fail-closed on refusal

Both `blockchain.cpp` call sites already `memset` the hash to `0xff` before calling, so a refusal fails closed there. Two places did not:

- **`miner.cpp`** declared `crypto::hash h;` uninitialised, discarded the bool, and passed `h` to `check_hash` — so a refusal compared whatever the stack held. It now starts at `0xff`, checks the result, and waits for the next template rather than spinning on a height that cannot hash.
- **The `crypto::hash` overload** of `get_block_longhash` returned `crypto::null_hash` on failure. `check_hash` multiplies each word by the difficulty and never carries for an all-zero hash, so **null passes at every difficulty** — a failed hash read as a satisfied target. It starts at `0xff` too.

### Not done here

The reviewer's stronger suggestion is to put the bound inside `get_cna_v2_data`, protecting all callers at once rather than replicating the derived constant. That is the better shape, but the only way to signal from there is a throw, and `handle_alternative_block` has no catch on this path — it would swap an out-of-bounds read for an uncaught exception. Worth doing alongside an error path that can carry it.

Closes #151.
