### PR TITLE
fix(wallet): say why the ring size is unknown instead of blaming the daemon

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10043,13 +10043,24 @@ bool wallet2::use_fork_rules(uint8_t version, int64_t early_blocks)
 // light wallet, which would build the larger ring before consensus takes it.
 // One size is valid per version, so the same helper consensus uses decides it
 // here and the two cannot drift apart.
+// Either guess builds a ring the network refuses: the old size after the fork,
+// the new one before it. Both callers must fail rather than pick one.
+uint8_t wallet2::get_hard_fork_for_ring_size()
+{
+  // A light wallet server speaks the light wallet api and has no hard_fork_info,
+  // so asking would surface as a connection error against a server that is
+  // answering fine. Say what is actually wrong.
+  THROW_WALLET_EXCEPTION_IF(m_light_wallet, error::wallet_internal_error,
+      "Cannot determine the ring size: the fork version is not available in light wallet mode");
+  const uint8_t hf_version = get_current_hard_fork();
+  // Offline there is no version to read.
+  THROW_WALLET_EXCEPTION_IF(hf_version == 0, error::no_connection_to_daemon, "hard_fork_info");
+  return hf_version;
+}
+//----------------------------------------------------------------------------------------------------
 uint64_t wallet2::adjust_mixin(uint64_t mixin)
 {
-  const uint8_t hf_version = get_current_hard_fork();
-  // Offline there is no version to read, and either guess builds a ring the
-  // network refuses: the old size after the fork, the new one before it. Say
-  // that rather than hand back a transaction the daemon drops without a reason.
-  THROW_WALLET_EXCEPTION_IF(hf_version == 0, error::no_connection_to_daemon, "hard_fork_info");
+  const uint8_t hf_version = get_hard_fork_for_ring_size();
   const uint64_t ring_size = cryptonote::get_ring_size(hf_version);
   if (mixin + 1 != ring_size)
   {
@@ -10175,8 +10186,11 @@ const wallet2::transfer_details &wallet2::get_transfer_details(size_t idx) const
 //----------------------------------------------------------------------------------------------------
 std::vector<size_t> wallet2::select_available_unmixable_outputs()
 {
-  // too few of the amount around to build a ring of the size this fork wants
-  return select_available_outputs_from_histogram(cryptonote::get_ring_size(get_current_hard_fork()), false, true, false);
+  // too few of the amount around to build a ring of the size this fork wants.
+  // Same helper as adjust_mixin: get_current_hard_fork answers 0 when offline,
+  // and get_ring_size(0) is the pre-fork size, which would quietly pick the
+  // wrong threshold instead of saying the version is unknown.
+  return select_available_outputs_from_histogram(cryptonote::get_ring_size(get_hard_fork_for_ring_size()), false, true, false);
 }
 //----------------------------------------------------------------------------------------------------
 std::vector<wallet2::pending_tx> wallet2::create_unmixable_sweep_transactions()

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1036,6 +1036,7 @@ private:
     const transfer_details &get_transfer_details(size_t idx) const;
 
     uint8_t get_current_hard_fork();
+    uint8_t get_hard_fork_for_ring_size();
     void get_hard_fork_info(uint8_t version, uint64_t &earliest_height);
     bool use_fork_rules(uint8_t version, int64_t early_blocks = 0);
     // ring size consensus will accept for a transaction built right now


### PR DESCRIPTION
`adjust_mixin` is the first statement of both `create_transactions_2` and `create_transactions_from`, and it reads the fork version with `get_current_hard_fork()`, which short-circuits only for `m_offline` before issuing a `hard_fork_info` JSON-RPC. A light wallet points the same http client at a light-wallet API server that has no such method, so the send fails with a connection error against a server that is answering fine.

Every other fork decision *in the body of* those functions goes through `use_fork_rules`, which returns `true` for a light wallet by design, and this one runs *before* the `if(m_light_wallet)` branch below it.

To be precise about the scope, since an earlier draft of this overstated it: `adjust_mixin` is not the only path that reaches `get_current_hard_fork()` on a send. `transfer_selected_rct` calls `get_current_tx_version()`, which does the same thing one layer deeper, and `sign_tx` / `sign_multisig_tx` follow it. Those have the same light-wallet failure and, offline, the worse one - `get_current_tx_version()` maps hard fork 0 to `TRANSACTION_VERSION_V1` silently. This PR fixes the ring-size pair only; the rest belongs with a light-wallet fork-version source rather than more throws.

Introduced in 3d1d3e2 (#124). The comment there shows `get_current_hard_fork` was picked over `use_fork_rules` deliberately - `use_fork_rules` answers `true` on any version for a light wallet and would build the post-fork ring before consensus takes it. That reasoning is right; the throw it introduces was not considered.

### The fix

Neither light-wallet nor offline mode can learn a ring size the network will accept, so both must refuse - the question is only whether they say why. `get_hard_fork_for_ring_size` distinguishes them: no fork version available in light wallet mode, nothing to ask when offline.

`select_available_unmixable_outputs` had no guard at all, so it threw for a light wallet too and, offline, fell through to `get_ring_size(0)` - the **pre-fork** size - quietly picking the wrong threshold instead of reporting an unknown version. It now goes through the same helper. That half was benign in effect, since the sweep reaches `create_transactions_from` and throws there before building anything.

### What I did not change, and why

The obvious smaller fix is to make `get_current_hard_fork()` return 0 for a light wallet, matching `m_offline`, and let the existing `hf_version == 0` check fire. Checking its other callers ruled that out:

- `get_current_tx_version()` does `hf >= V2_TX_FORK_HEIGHT ? V2 : V1`, so hard fork 0 silently yields the **v1** transaction version.
- `wallet2.cpp:9940` feeds `aux_data.hard_fork` to a hardware cold-signer.

Returning 0 would have traded a loud failure for a quiet wrong value in both. The accessor is untouched.

### Reach

Narrow, and worth stating plainly: `simplewallet` never enables light wallet mode. The only switch is the `lightWallet` argument to `WalletImpl::init` in libwallet, which a GUI or mobile consumer would pass against a light-wallet server. If no such deployment exists, nothing is broken today and this closes a tripwire rather than an incident.

`wallet2.cpp`, `simplewallet.cpp` and `wallet_rpc_server.cpp` compile at the same warning counts as before.

Closes #153.
